### PR TITLE
Target curated lists for sticky TOC JavaScript

### DIFF
--- a/patternlab/changelogs/DP-8177.txt
+++ b/patternlab/changelogs/DP-8177.txt
@@ -1,0 +1,5 @@
+___DESCRIPTION___
+Changed
+Patch
+- DP-8177: Adds a selector to the sticky TOC JavaScript to target curated lists
+

--- a/patternlab/styleguide/source/_patterns/03-organisms/by-template/sticky-toc.twig
+++ b/patternlab/styleguide/source/_patterns/03-organisms/by-template/sticky-toc.twig
@@ -1,5 +1,5 @@
 {% if stickyTOC %}
-  <section class="ma__sticky-toc">
+  <section class="ma__sticky-toc" {{ stickyTOC.min ? 'data-min-to-show="' ~ stickyTOC.min ~ '"' : ""}}>
     <a href="#ma-end-sticky-toc" class="ma__visually-hidden">skip table of contents</a>
     <div class="ma__sticky-toc__inner">
       <div class="ma__sticky-toc__container">

--- a/patternlab/styleguide/source/_patterns/03-organisms/by-template/sticky-toc.twig
+++ b/patternlab/styleguide/source/_patterns/03-organisms/by-template/sticky-toc.twig
@@ -1,5 +1,5 @@
 {% if stickyTOC %}
-  <section class="ma__sticky-toc" {{ stickyTOC.min ? 'data-min-to-show="' ~ stickyTOC.min ~ '"' : ""}}>
+  <section class="ma__sticky-toc" data-min-to-show="{{ stickyTOC.min ? stickyTOC.min : 2 }}">
     <a href="#ma-end-sticky-toc" class="ma__visually-hidden">skip table of contents</a>
     <div class="ma__sticky-toc__inner">
       <div class="ma__sticky-toc__container">

--- a/patternlab/styleguide/source/assets/js/modules/stickyTOC.js
+++ b/patternlab/styleguide/source/assets/js/modules/stickyTOC.js
@@ -3,7 +3,7 @@ export default function (window,document,$,undefined) {
   $('.pre-content .ma__sticky-toc').each(function() {
     const $toc = $('.ma__sticky-toc'),
           $tocContent = $('.ma__sticky-toc__links'),
-          $tocSections = $('.ma__information-details .page-content').find('h2'),
+          $tocSections = $('.ma__information-details .page-content, .ma__stacked-row-section__container .ma__stacked-row-section__title').find('h2'),
           lastHeading = $tocSections.last().text(),
           tocSectionCount = $tocSections.length,
           $tocColumn = $('.ma__sticky-toc__column'),

--- a/patternlab/styleguide/source/assets/js/modules/stickyTOC.js
+++ b/patternlab/styleguide/source/assets/js/modules/stickyTOC.js
@@ -10,10 +10,11 @@ export default function (window,document,$,undefined) {
           $mobileToggle = $('.ma__sticky-toc__toggle-link'),
           $tocToggle = $('.stickyTOC-open'),
           $tocFooter = $('.ma__sticky-toc__footer'),
-          $stickyToc = $('.ma__sticky-toc__current-section');
+          $stickyToc = $('.ma__sticky-toc__current-section'),
+          minSectionsToShow = $toc.data('min-to-show');
 
     // // Remove wrapper if not enough links.
-    if (tocSectionCount < 3 ) {
+    if (minSectionsToShow && tocSectionCount <= minSectionsToShow || !minSectionsToShow && tocSectionCount < 3 ) {
       $toc.remove();
     }
     else {

--- a/patternlab/styleguide/source/assets/js/modules/stickyTOC.js
+++ b/patternlab/styleguide/source/assets/js/modules/stickyTOC.js
@@ -14,7 +14,7 @@ export default function (window,document,$,undefined) {
           minSectionsToShow = $toc.data('min-to-show');
 
     // // Remove wrapper if not enough links.
-    if (minSectionsToShow && tocSectionCount <= minSectionsToShow || !minSectionsToShow && tocSectionCount < 3 ) {
+    if (minSectionsToShow && (tocSectionCount < minSectionsToShow) || !minSectionsToShow && tocSectionCount < 3 ) {
       $toc.remove();
     }
     else {


### PR DESCRIPTION
**Description:**
Update the selector for the sticky TOC so that it can be used on Curated Lists.

**Jira:**
https://jira.mass.gov/browse/DP-8177

**To Test:**
Build locally and confirm that the TOC still works on the [Information Details Table of Contents page](http://localhost:3000/?p=pages-information-details-table-of-contents).