### PR TITLE
Add Twig block around stack row title for overrides.

### DIFF
--- a/patternlab/changelogs/DP-9475.txt
+++ b/patternlab/changelogs/DP-9475.txt
@@ -1,0 +1,3 @@
+___DESCRIPTION___
+Added
+- DP-9475: Added Twig block around stack row title for overrides.

--- a/patternlab/styleguide/source/_patterns/03-organisms/by-author/stacked-row-section.twig
+++ b/patternlab/styleguide/source/_patterns/03-organisms/by-author/stacked-row-section.twig
@@ -2,20 +2,22 @@
 {% set stackRowBorderless = stackedRow.borderless ? ' ma__stacked-row__section--borderless' : ''  %}
 
 <section class="ma__stacked-row__section{{ stackRowBorderless }}{{ stackRowRestriction }}">
-  {% if stackedRowSection.title %}
-    <div class="ma__stacked-row-section__container">
-      <div class="ma__stacked-row-section__title">
-        {% set compHeading = {
-            "title": stackedRowSection.title,
-            "sub": "",
-            "color": "",
-            "id": stackedRowSection.id
-          }
-        %}
-        {% include "@atoms/04-headings/comp-heading.twig" %}
+  {% block stackRowTitle %}
+    {% if stackedRowSection.title %}
+      <div class="ma__stacked-row-section__container">
+        <div class="ma__stacked-row-section__title">
+          {% set compHeading = {
+              "title": stackedRowSection.title,
+              "sub": "",
+              "color": "",
+              "id": stackedRowSection.id
+            }
+          %}
+          {% include "@atoms/04-headings/comp-heading.twig" %}
+        </div>
       </div>
-    </div>
-  {% endif %}
+    {% endif %}
+  {% endblock %}
   <div class="main-content {{ stackedRowSection.sideBar|length ? 'main-content--two' : 'main-content--full' }}">
     <div class="page-content">
       {% block stackedRowContentOverride %}


### PR DESCRIPTION
### Description
Adds a twig block around the section title in the `stack-row-section.twig` template.

### Related Issue / Ticket
https://jira.mass.gov/browse/DP-9475

### Steps to Test
N/A
