### PR TITLE
DP-9435: alert mobile cutoff

### DIFF
--- a/patternlab/changelogs/DP-9435.txt
+++ b/patternlab/changelogs/DP-9435.txt
@@ -1,0 +1,3 @@
+___DESCRIPTION___
+Fixed
+- DP-9435: Adds text-wrapping on header alert messages to fix bug on mobile devices

--- a/patternlab/styleguide/source/assets/scss/03-organisms/_header-alert.scss
+++ b/patternlab/styleguide/source/assets/scss/03-organisms/_header-alert.scss
@@ -27,7 +27,6 @@
     overflow: hidden;
     max-width: 100%;
     vertical-align: baseline;
-    white-space: nowrap;
   }
 
   &__label {


### PR DESCRIPTION
### Description
Adds text-wrapping on header alert messages to fix bug on mobile devices

### JIRA Issue
https://jira.mass.gov/browse/DP-9435

### Testing Instructions
- [x] Navigate to a node showing an alert (e.g., `/orgs/department-of-transitional-assistance`)
- [x] Confirm that entire alert message is shown, and not cut off at all