### PR TITLE
React/dp 9797 orgfilter mobile

### DIFF
--- a/react/src/components/organisms/FilterBox/FilterBox.stories.js
+++ b/react/src/components/organisms/FilterBox/FilterBox.stories.js
@@ -19,8 +19,8 @@ storiesOf('organisms', module).addDecorator(withKnobs)
     withInfo()(() => {
       const hideTopic = boolean('filterBox.hideTopic', true);
       const hideOrganization = boolean('filterBox.hideOrganization', true);
-      const hideType = boolean('filterBox.hideType', true);
-      const hideDateRange = boolean('filterBox.hideDateRange', true);
+      const hideType = boolean('filterBox.hideType', false);
+      const hideDateRange = boolean('filterBox.hideDateRange', false);
       const pressTypeInput = select('filterBox.pressType.inputType', { '': 'Choose', selectbox: 'SelectBox', typeahead: 'TypeAhead' }, 'typeahead');
       const props = {
         active: boolean('filterBox.active', true),
@@ -74,7 +74,7 @@ storiesOf('organisms', module).addDecorator(withKnobs)
           options: object('filterBox.pressType.options', selectBoxOptions.options.pressTypes),
           required: boolean('filterBox.pressType.required', true)
         };
-      } else if (pressTypeInput === 'typeAhead') {
+      } else if (pressTypeInput === 'typeahead') {
         props.pressType.typeAhead = {
           label: text('filterBox.pressType.label', 'Filter by Type'),
           id: text('filterBox.pressType.id', 'press-type'),

--- a/react/src/components/organisms/FilterBox/FilterBox.stories.js
+++ b/react/src/components/organisms/FilterBox/FilterBox.stories.js
@@ -19,6 +19,8 @@ storiesOf('organisms', module).addDecorator(withKnobs)
     withInfo()(() => {
       const hideTopic = boolean('filterBox.hideTopic', true);
       const hideOrganization = boolean('filterBox.hideOrganization', true);
+      const hideType = boolean('filterBox.hideType', true);
+      const hideDateRange = boolean('filterBox.hideDateRange', true);
       const pressTypeInput = select('filterBox.pressType.inputType', { '': 'Choose', selectbox: 'SelectBox', typeahead: 'TypeAhead' }, 'typeahead');
       const props = {
         active: boolean('filterBox.active', true),
@@ -31,11 +33,11 @@ storiesOf('organisms', module).addDecorator(withKnobs)
           required: boolean('filterBox.topic.required', true)
         }),
         pressType: {},
-        dateRange: {
+        dateRange: (hideDateRange ? undefined : {
           label: text('filterBox.dateRange.label', 'Date range'),
           startDate: object('filterBox.dateRange.startDate', sharedProps.startDate),
           endDate: object('filterBox.dateRange.endDate', sharedProps.endDate)
-        },
+        }),
         submitButton: {
           text: text('filterBox.submitButton.text', 'Submit'),
           type: select('filterBox.submitButton.type', buttonOptions.type, 'submit'),
@@ -62,7 +64,9 @@ storiesOf('organisms', module).addDecorator(withKnobs)
           onChange: action('filterBox.organization typeahead onChange')
         })
       };
-      if (pressTypeInput === 'selectbox') {
+      if (hideType) {
+        props.pressType.typeAhead = null;
+      } else if (pressTypeInput === 'selectbox') {
         props.pressType.selectBox = {
           label: text('filterBox.pressType.label', 'Filter by Type'),
           stackLabel: boolean('filterBox.pressType.stackLabel', true),
@@ -70,7 +74,7 @@ storiesOf('organisms', module).addDecorator(withKnobs)
           options: object('filterBox.pressType.options', selectBoxOptions.options.pressTypes),
           required: boolean('filterBox.pressType.required', true)
         };
-      } else {
+      } else if (pressTypeInput === 'typeAhead') {
         props.pressType.typeAhead = {
           label: text('filterBox.pressType.label', 'Filter by Type'),
           id: text('filterBox.pressType.id', 'press-type'),

--- a/react/src/components/organisms/FilterBox/index.js
+++ b/react/src/components/organisms/FilterBox/index.js
@@ -17,9 +17,10 @@ const FilterBox = (props) => {
       props.clearButton.onClearCallback();
     }
   };
+  const filterDesktopHidden = props.filterDesktopHidden && ' ma__filter-box--desktop-hidden';
   const isActive = active ? 'ma__filter-box__form--active' : '';
   return(
-    <section className="ma__filter-box">
+    <section className={`ma__filter-box${filterDesktopHidden}`}>
       <div className="ma__filter-box__container">
         <form className={`ma__filter-box__form js-filter-box ${isActive}`} action={action}>
           <div className="main-content--two">
@@ -88,7 +89,9 @@ FilterBox.propTypes = {
     text: PropTypes.string,
     info: PropTypes.string,
     onClearCallback: PropTypes.func
-  })
+  }),
+  /** Controls if we allow filterbox to render only on mobile */
+  filterDesktopHidden: PropTypes.bool
 };
 
 FilterBox.defaultProps = {

--- a/react/src/components/organisms/FilterBox/index.js
+++ b/react/src/components/organisms/FilterBox/index.js
@@ -17,7 +17,7 @@ const FilterBox = (props) => {
       props.clearButton.onClearCallback();
     }
   };
-  const filterDesktopHidden = props.filterDesktopHidden && ' ma__filter-box--desktop-hidden';
+  const filterDesktopHidden = props.filterDesktopHidden ? ' ma__filter-box--desktop-hidden' : '';
   const isActive = active ? 'ma__filter-box__form--active' : '';
   return(
     <section className={`ma__filter-box${filterDesktopHidden}`}>

--- a/react/src/components/organisms/FilterBox/index.js
+++ b/react/src/components/organisms/FilterBox/index.js
@@ -35,14 +35,18 @@ const FilterBox = (props) => {
               <div className="ma__filter-box__topic">
                 <SelectBox {...topic} />
               </div>
-            )}
+              )}
+              {pressType && (
               <div className="ma__filter-box__type">
                 {selectBoxProps && <SelectBox {...selectBoxProps} />}
                 {typeAheadProps && <InputTextTypeAhead {...typeAheadProps} />}
               </div>
+              )}
+              {dateRange && (
               <div className="ma__filter-box__date">
                 <DateRange {...dateRange} />
               </div>
+              )}
             </div>
             <div className="ma__filter-box__controls">
               <div className="ma__filter-box__button">
@@ -78,7 +82,7 @@ FilterBox.propTypes = {
   /** @atoms/forms/InputTextTypeAhead */
   organization: PropTypes.shape(InputTextTypeAhead.propTypes),
   /** @molecules/DateRange */
-  dateRange: PropTypes.shape(DateRange.PropTypes).isRequired,
+  dateRange: PropTypes.shape(DateRange.PropTypes),
   /** @atoms/forms/Button */
   submitButton: PropTypes.shape(Button.PropTypes).isRequired,
   /** Clear all button at the bottom of the filter */

--- a/react/src/components/organisms/FilterBox/index.js
+++ b/react/src/components/organisms/FilterBox/index.js
@@ -17,8 +17,6 @@ const FilterBox = (props) => {
       props.clearButton.onClearCallback();
     }
   };
-  const selectBoxProps = pressType.selectBox;
-  const typeAheadProps = pressType.typeAhead;
   const isActive = active ? 'ma__filter-box__form--active' : '';
   return(
     <section className="ma__filter-box">
@@ -38,8 +36,8 @@ const FilterBox = (props) => {
               )}
               {pressType && (
               <div className="ma__filter-box__type">
-                {selectBoxProps && <SelectBox {...selectBoxProps} />}
-                {typeAheadProps && <InputTextTypeAhead {...typeAheadProps} />}
+                {pressType.selectBox && <SelectBox {...pressType.selectBox} />}
+                {pressType.typeAhead && <InputTextTypeAhead {...pressType.typeAhead} />}
               </div>
               )}
               {dateRange && (

--- a/react/src/components/organisms/SearchBanner/SearchBanner.stories.js
+++ b/react/src/components/organisms/SearchBanner/SearchBanner.stories.js
@@ -67,6 +67,7 @@ storiesOf('organisms', module).addDecorator(withKnobs)
     if (withFilterBox) {
       props.toggleButtonOnClick = action('SearchBanner toggleButtonOnClick');
       props.filterBoxExpanded = boolean('SearchBanner.filterBoxExpanded', true);
+      props.filterDesktopHidden = boolean('SearchBanner.filterDesktopHidden', true);
       props.filterBox = {
         active: boolean('filterBox.active', true),
         action: text('filterBox.action', '#'),
@@ -89,7 +90,7 @@ storiesOf('organisms', module).addDecorator(withKnobs)
           placeholder: text('filterBox.organization.placeholder', 'All Organizations'),
           onChange: action('filterBox.organization typeahead onChange')
         },
-        pressType: (hideType ? undefined :{
+        pressType: (hideType ? undefined : {
           typeAhead: {
             label: text('filterBox.pressType.label', 'Filter by Type'),
             id: text('filterBox.pressType.id', 'press-type'),
@@ -103,7 +104,7 @@ storiesOf('organisms', module).addDecorator(withKnobs)
             onChange: action('SearchBanner filterBox.pressType.typeAhead.onChange')
           }
         }),
-        dateRange: (hideDateRange ? undefined :{
+        dateRange: (hideDateRange ? undefined : {
           label: text('filterBox.dateRange.label', 'Date range'),
           startDate: object('filterBox.dateRange.startDate', filterBoxSharedProps.startDate),
           endDate: object('filterBox.dateRange.endDate', filterBoxSharedProps.endDate)

--- a/react/src/components/organisms/SearchBanner/SearchBanner.stories.js
+++ b/react/src/components/organisms/SearchBanner/SearchBanner.stories.js
@@ -22,6 +22,7 @@ storiesOf('organisms', module).addDecorator(withKnobs)
     const hideTopic = boolean('filterBox.hideTopic', true);
     const hideType = boolean('filterBox.hideType', false);
     const hideDateRange = boolean('filterBox.hideDateRange', false);
+    const DesktopHidden = boolean('SearchBanner.filterDesktopHidden', true);
     const withTabs = boolean('HeaderSearch.withTabs', true);
     const props = {
       searchBox: {
@@ -67,8 +68,9 @@ storiesOf('organisms', module).addDecorator(withKnobs)
     if (withFilterBox) {
       props.toggleButtonOnClick = action('SearchBanner toggleButtonOnClick');
       props.filterBoxExpanded = boolean('SearchBanner.filterBoxExpanded', true);
-      props.filterDesktopHidden = boolean('SearchBanner.filterDesktopHidden', true);
+      props.filterDesktopHidden = DesktopHidden;
       props.filterBox = {
+        filterDesktopHidden: DesktopHidden,
         active: boolean('filterBox.active', true),
         action: text('filterBox.action', '#'),
         topic: (hideTopic ? undefined : {

--- a/react/src/components/organisms/SearchBanner/SearchBanner.stories.js
+++ b/react/src/components/organisms/SearchBanner/SearchBanner.stories.js
@@ -120,8 +120,10 @@ storiesOf('organisms', module).addDecorator(withKnobs)
           onClearCallback: action('SearchBanner filterBox.clearButton.onClearCallback')
         }
       };
-      props.filterBox.dateRange.startDate.defaultDate = new Date(props.filterBox.dateRange.startDate.defaultDate);
-      props.filterBox.dateRange.endDate.defaultDate = new Date(props.filterBox.dateRange.endDate.defaultDate);
+      if (props.filterBox.dateRange) {
+        props.filterBox.dateRange.startDate.defaultDate = new Date(props.filterBox.dateRange.startDate.defaultDate);
+        props.filterBox.dateRange.endDate.defaultDate = new Date(props.filterBox.dateRange.endDate.defaultDate);
+      }
     }
     return(<SearchBanner {...props} />);
   }));

--- a/react/src/components/organisms/SearchBanner/SearchBanner.stories.js
+++ b/react/src/components/organisms/SearchBanner/SearchBanner.stories.js
@@ -20,6 +20,8 @@ storiesOf('organisms', module).addDecorator(withKnobs)
     const withOrgDropdown = boolean('HeaderSearch.withOrgDropdown', true);
     const withFilterBox = boolean('HeaderSearch.withFilterBox', true);
     const hideTopic = boolean('filterBox.hideTopic', true);
+    const hideType = boolean('filterBox.hideType', false);
+    const hideDateRange = boolean('filterBox.hideDateRange', false);
     const withTabs = boolean('HeaderSearch.withTabs', true);
     const props = {
       searchBox: {
@@ -87,7 +89,7 @@ storiesOf('organisms', module).addDecorator(withKnobs)
           placeholder: text('filterBox.organization.placeholder', 'All Organizations'),
           onChange: action('filterBox.organization typeahead onChange')
         },
-        pressType: {
+        pressType: (hideType ? undefined :{
           typeAhead: {
             label: text('filterBox.pressType.label', 'Filter by Type'),
             id: text('filterBox.pressType.id', 'press-type'),
@@ -100,12 +102,12 @@ storiesOf('organisms', module).addDecorator(withKnobs)
             placeholder: text('filterBox.pressType.placeholder', 'All Types'),
             onChange: action('SearchBanner filterBox.pressType.typeAhead.onChange')
           }
-        },
-        dateRange: {
+        }),
+        dateRange: (hideDateRange ? undefined :{
           label: text('filterBox.dateRange.label', 'Date range'),
           startDate: object('filterBox.dateRange.startDate', filterBoxSharedProps.startDate),
           endDate: object('filterBox.dateRange.endDate', filterBoxSharedProps.endDate)
-        },
+        }),
         submitButton: {
           text: text('filterBox.submitButton.text', 'Submit'),
           type: select('filterBox.submitButton.type', buttonOptions.type, 'submit'),

--- a/react/src/components/organisms/SearchBanner/SearchBanner.stories.js
+++ b/react/src/components/organisms/SearchBanner/SearchBanner.stories.js
@@ -22,7 +22,7 @@ storiesOf('organisms', module).addDecorator(withKnobs)
     const hideTopic = boolean('filterBox.hideTopic', true);
     const hideType = boolean('filterBox.hideType', false);
     const hideDateRange = boolean('filterBox.hideDateRange', false);
-    const DesktopHidden = boolean('SearchBanner.filterDesktopHidden', true);
+    const DesktopHidden = boolean('SearchBanner.filterDesktopHidden', false);
     const withTabs = boolean('HeaderSearch.withTabs', true);
     const props = {
       searchBox: {
@@ -69,6 +69,7 @@ storiesOf('organisms', module).addDecorator(withKnobs)
       props.toggleButtonOnClick = action('SearchBanner toggleButtonOnClick');
       props.filterBoxExpanded = boolean('SearchBanner.filterBoxExpanded', true);
       props.filterDesktopHidden = DesktopHidden;
+      props.filterToggleText = text('SearchBanner.filterBoxText', 'More Filters');
       props.filterBox = {
         filterDesktopHidden: DesktopHidden,
         active: boolean('filterBox.active', true),

--- a/react/src/components/organisms/SearchBanner/index.js
+++ b/react/src/components/organisms/SearchBanner/index.js
@@ -29,7 +29,9 @@ class SearchBanner extends Component {
     }
   }
   render() {
-    const { tabs, searchBox, filterBox } = this.props;
+    const {
+      tabs, searchBox, filterBox, filterToggleText
+    } = this.props;
     let submitButton;
 
     if (filterBox) {
@@ -55,7 +57,7 @@ class SearchBanner extends Component {
         {filterBox && (
           <div className="main-content--two ma__search-banner__filter-box-toggle-container">
             <button onClick={this.toggleFilterBox} type="button" className={toggleButtonClass}>
-              More Filters
+              {filterToggleText}
               <SvgChevron />
             </button>
           </div>
@@ -78,7 +80,14 @@ SearchBanner.propTypes = {
   /** Controls if filterBox is expanded */
   filterBoxExpanded: PropTypes.bool,
   /** Controls if we allow filterbox toggle to render only on mobile */
-  filterDesktopHidden: PropTypes.bool
+  filterDesktopHidden: PropTypes.bool,
+  /** Filter box toggle button text */
+  filterToggleText: PropTypes.string
+};
+
+SearchBanner.defaultProps = {
+  filterDesktopHidden: false,
+  filterToggleText: 'More Filters'
 };
 
 export default SearchBanner;

--- a/react/src/components/organisms/SearchBanner/index.js
+++ b/react/src/components/organisms/SearchBanner/index.js
@@ -42,8 +42,9 @@ class SearchBanner extends Component {
         }
       };
     }
-
-    const toggleButtonClass = `ma__search-banner__filter-box-toggle ${this.state.filterBoxExpanded && 'ma__search-banner__filter-box-toggle--expanded'}`;
+    const filterExpanded = this.state.filterBoxExpanded && ' ma__search-banner__filter-box-toggle--expanded';
+    const filterDesktopHidden = this.props.filterDesktopHidden && ' ma__search-banner__filter-box-toggle--desktop-hidden';
+    const toggleButtonClass = `ma__search-banner__filter-box-toggle${filterExpanded}${filterDesktopHidden}`;
     return(
       <div className={`ma__search-banner__top ${!tabs && 'ma__search-banner__top--noTabs'}`}>
         <div className="main-content--two">

--- a/react/src/components/organisms/SearchBanner/index.js
+++ b/react/src/components/organisms/SearchBanner/index.js
@@ -76,7 +76,9 @@ SearchBanner.propTypes = {
   /** filterbox toggle button custom function */
   toggleButtonOnClick: PropTypes.func,
   /** Controls if filterBox is expanded */
-  filterBoxExpanded: PropTypes.bool
+  filterBoxExpanded: PropTypes.bool,
+  /** Controls if we allow filterbox toggle to render only on mobile */
+  filterDesktopHidden: PropTypes.bool
 };
 
 export default SearchBanner;

--- a/react/src/components/organisms/SearchBanner/index.js
+++ b/react/src/components/organisms/SearchBanner/index.js
@@ -42,8 +42,8 @@ class SearchBanner extends Component {
         }
       };
     }
-    const filterExpanded = this.state.filterBoxExpanded && ' ma__search-banner__filter-box-toggle--expanded';
-    const filterDesktopHidden = this.props.filterDesktopHidden && ' ma__search-banner__filter-box-toggle--desktop-hidden';
+    const filterExpanded = this.state.filterBoxExpanded ? ' ma__search-banner__filter-box-toggle--expanded' : '';
+    const filterDesktopHidden = this.props.filterDesktopHidden ? ' ma__search-banner__filter-box-toggle--desktop-hidden' : '';
     const toggleButtonClass = `ma__search-banner__filter-box-toggle${filterExpanded}${filterDesktopHidden}`;
     return(
       <div className={`ma__search-banner__top ${!tabs && 'ma__search-banner__top--noTabs'}`}>

--- a/react/src/components/organisms/SearchBanner/style.scss
+++ b/react/src/components/organisms/SearchBanner/style.scss
@@ -71,7 +71,7 @@
     }
 
     &--desktop-hidden {
-      @media ($bp-large-min) {
+      @media ($bp-medium-min) {
         display: none;
       }
     }
@@ -110,7 +110,7 @@
     }
 
     &--desktop-hidden {
-      @media ($bp-large-min) {
+      @media ($bp-medium-min) {
         display: none;
       }
     }

--- a/react/src/components/organisms/SearchBanner/style.scss
+++ b/react/src/components/organisms/SearchBanner/style.scss
@@ -68,6 +68,7 @@
       & > svg {
         padding-left: 5px;
       }
+
     }
 
     &--desktop-hidden {
@@ -104,6 +105,7 @@
   }
 
   .ma__filter-box {
+    text-align: left;
     width: 100%;
     @media ($bp-large-min) {
       position: absolute;

--- a/react/src/components/organisms/SearchBanner/style.scss
+++ b/react/src/components/organisms/SearchBanner/style.scss
@@ -109,6 +109,12 @@
       position: absolute;
     }
 
+    &--desktop-hidden {
+      @media ($bp-large-min) {
+        display: none;
+      }
+    }
+
     &__organizations {
       @media ($bp-medium-min) {
         display: none;

--- a/react/src/components/organisms/SearchBanner/style.scss
+++ b/react/src/components/organisms/SearchBanner/style.scss
@@ -70,6 +70,12 @@
       }
     }
 
+    &--desktop-hidden {
+      @media ($bp-large-min) {
+        display: none;
+      }
+    }
+
     &:focus {
       outline: none;
     }


### PR DESCRIPTION
This pr allows filterbox toggle and filterbox be shown only on mobile.
Use case: 

To test: 
- `npm start`
- go to orgisms/SearchBanner and check the following knobs:
  - hideType
  - hideDateRange
  - filterDesktopHidden

In search: 
- test `https://github.com/massgov/massgov-search/pull/304` using `npm link`

![org-mobile](https://user-images.githubusercontent.com/5789411/43334013-2201a882-919a-11e8-8326-7d196408a075.gif)


- [JIRA issue DP-9797]()