### PR TITLE
DP-9750: Adds HelperText form atom component to Mayflower React library

### DIFF
--- a/changelogs/DP-9750.txt
+++ b/changelogs/DP-9750.txt
@@ -1,0 +1,3 @@
+___DESCRIPTION___
+Added
+- DP-9750: Added HelperText form atom component to Mayflower React library, including a new Story for the new component to be used with Storybook.

--- a/react/src/components/atoms/forms/HelperText/HelperText.knobs.options.js
+++ b/react/src/components/atoms/forms/HelperText/HelperText.knobs.options.js
@@ -1,0 +1,4 @@
+export default {
+  inputId: 'GUID2738572489',
+  message: 'Helper text for the input located above'
+};

--- a/react/src/components/atoms/forms/HelperText/HelperText.md
+++ b/react/src/components/atoms/forms/HelperText/HelperText.md
@@ -1,0 +1,13 @@
+### Description
+Helper text for a form input.
+
+### Usage Guidelines
+* The `inputId` value should match the id of the related input.
+
+### Variables
+~~~
+inputId:
+  type: string / required
+message:
+  type: string / required
+~~~

--- a/react/src/components/atoms/forms/HelperText/HelperText.stories.js
+++ b/react/src/components/atoms/forms/HelperText/HelperText.stories.js
@@ -1,0 +1,18 @@
+import React from 'react';
+
+import { storiesOf } from '@storybook/react';
+import { withInfo } from '@storybook/addon-info';
+import { withKnobs } from '@storybook/addon-knobs/react';
+
+import HelperText from './index';
+import HelperTextReadme from './HelperText.md';
+import HelperTextOptions from './HelperText.knobs.options';
+
+storiesOf('atoms/forms', module).addDecorator(withKnobs)
+  .add('HelperText', withInfo(`<div>${HelperTextReadme}</div>`)(() => {
+    const props = {
+      inputId: HelperTextOptions.inputId,
+      message: HelperTextOptions.message
+    };
+    return (<HelperText {...props} />);
+  }));

--- a/react/src/components/atoms/forms/HelperText/HelperText.stories.js
+++ b/react/src/components/atoms/forms/HelperText/HelperText.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
-import { withKnobs } from '@storybook/addon-knobs/react';
+import { withKnobs, text } from '@storybook/addon-knobs/react';
 
 import HelperText from './index';
 import HelperTextReadme from './HelperText.md';
@@ -11,8 +11,8 @@ import HelperTextOptions from './HelperText.knobs.options';
 storiesOf('atoms/forms', module).addDecorator(withKnobs)
   .add('HelperText', withInfo(`<div>${HelperTextReadme}</div>`)(() => {
     const props = {
-      inputId: HelperTextOptions.inputId,
-      message: HelperTextOptions.message
+      inputId: text('helperText.inputID', HelperTextOptions.inputId),
+      message: text('helperText.message', HelperTextOptions.message)
     };
-    return (<HelperText {...props} />);
+    return(<HelperText {...props} />);
   }));

--- a/react/src/components/atoms/forms/HelperText/index.js
+++ b/react/src/components/atoms/forms/HelperText/index.js
@@ -1,19 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const HelperText = (props) => {
-  return (
-    <React.Fragment>
-      <label
-        htmlFor={props.inputId}
-        aria-labelledby={props.inputId}
-        className="ma__helper-text"
-      >
-        {props.message}
-      </label>
-    </React.Fragment>
-  );
-};
+const HelperText = (props) => (
+  <React.Fragment>
+    <label
+      htmlFor={props.inputId}
+      aria-labelledby={props.inputId}
+      className="ma__helper-text"
+    >
+      {props.message}
+    </label>
+  </React.Fragment>
+);
 
 HelperText.propTypes = {
   /** The ID of the corresponding input field */

--- a/react/src/components/atoms/forms/HelperText/index.js
+++ b/react/src/components/atoms/forms/HelperText/index.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const HelperText = (props) => {
+  return (
+    <React.Fragment>
+      <label
+        htmlFor={props.inputId}
+        aria-labelledby={props.inputId}
+        className="ma__helper-text"
+      >
+        {props.message}
+      </label>
+    </React.Fragment>
+  );
+};
+
+HelperText.propTypes = {
+  /** The ID of the corresponding input field */
+  inputId: PropTypes.string.isRequired,
+  /** The help text for the corresponding input field */
+  message: PropTypes.string.isRequired
+};
+
+export default HelperText;

--- a/react/src/index.js
+++ b/react/src/index.js
@@ -15,6 +15,7 @@ export ButtonSort from './components/atoms/buttons/ButtonSort';
 export ButtonToggle from './components/atoms/buttons/ButtonToggle';
 export ButtonWithIcon from './components/atoms/buttons/ButtonWithIcon';
 // @atoms/@forms
+export HelperText from './components/atoms/forms/HelperText';
 export InputDate from './components/atoms/forms/InputDate';
 export InputText from './components/atoms/forms/InputText';
 export SelectBox from './components/atoms/forms/SelectBox';


### PR DESCRIPTION
## Description
Adds HelperText form atom component to Mayflower React library, including a new Story for the new component to be used with Storybook.

## Related Issue / Ticket
- https://jira.mass.gov/browse/DP-9750

## Steps to Test
1. Confirm that new HelperText atom is rendered as expected within Storybook
