### PR TITLE
DP-10032: Fix for binder overlay button click not triggering overlay

### DIFF
--- a/changelogs/DP-10032.txt
+++ b/changelogs/DP-10032.txt
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+Fixed
+Minor
+- (Patternlab) DP-10032: Fix for binder overlay button click not triggering overlay

--- a/patternlab/styleguide/source/assets/js/modules/inlineOverlay.js
+++ b/patternlab/styleguide/source/assets/js/modules/inlineOverlay.js
@@ -1,5 +1,5 @@
 
-export default function (window,document,$,undefined) {
+export default (function (window,document,$,undefined) {
   let tocContainerClass = '.js-toc-container';
   let containerClass = '.js-inline-overlay';
   let contentClass = '.js-inline-overlay-content';
@@ -36,4 +36,4 @@ export default function (window,document,$,undefined) {
   });
 
 
-}(window,document,jQuery);
+})(window,document,jQuery);


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/dev/docs/change-log-instructions.md)


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
Fixes binder overlay JS so that clicking the expand button opens the overlay.  This was broken during a recent dependency update of babelify. 

## Related Issue / Ticket

- [JIRA issue](https://jira.mass.gov/browse/DP-10032)

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Visit http://localhost:3000/?p=pages-binder-page-internal
2. Click the `+` button on the table of contents.
3. The overlay should open.

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* 

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
