### PR TITLE
Sync develop with master

### DIFF
--- a/changelogs/DP-10032.txt
+++ b/changelogs/DP-10032.txt
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+Fixed
+Minor
+- (Patternlab) DP-10032: Fix for binder overlay button click not triggering overlay

--- a/patternlab/styleguide/source/assets/js/modules/inlineOverlay.js
+++ b/patternlab/styleguide/source/assets/js/modules/inlineOverlay.js
@@ -1,5 +1,5 @@
 
-export default function (window,document,$,undefined) {
+export default (function (window,document,$,undefined) {
   let tocContainerClass = '.js-toc-container';
   let containerClass = '.js-inline-overlay';
   let contentClass = '.js-inline-overlay-content';
@@ -36,4 +36,4 @@ export default function (window,document,$,undefined) {
   });
 
 
-}(window,document,jQuery);
+})(window,document,jQuery);


### PR DESCRIPTION
This PR syncs master back to develop after the merge of #160.  We thought we were gonna need to hotfix, but there didn't end up being a need.  This work can be released at any point.