### PR TITLE
DP-10029 - Update styles to fix margin on image without requiring it to be linked.

### DIFF
--- a/assets/scss/03-organisms/_location-listing.scss
+++ b/assets/scss/03-organisms/_location-listing.scss
@@ -150,6 +150,10 @@ $location-listin--map-min-width: 315px;
 
       > a {
         display: block;
+      }
+
+      img {
+        border-radius: 5px;
 
         @media ($bp-medium-max) {
           flex: 0 0 100px;
@@ -161,10 +165,6 @@ $location-listin--map-min-width: 315px;
         @media ($bp-medium-min) {
           margin-bottom: 1rem;
         }
-      }
-
-      img {
-        border-radius: 5px;
       }
     }
 

--- a/changelogs/DP-10029.txt
+++ b/changelogs/DP-10029.txt
@@ -1,0 +1,3 @@
+___DESCRIPTION___
+Fixed
+- (Patternlab) DP-10029: Updated styles to fix spacing on non-hyperlinked images on location listing row.


### PR DESCRIPTION

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
Updated styles to fix spacing on non-hyperlinked images on location listing row.

## Related Issue / Ticket

- [JIRA issue](https://jira.mass.gov/browse/DP-10029)

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. 

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* 

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
