### PR TITLE
Hotfix/fixed feedback button zindex update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ jobs:
             cd patternlab/styleguide/dist
             git clone --bare git@github.com:massgov/mayflower-artifacts.git .git
             git config core.bare false
-            git branch --force "$CIRCLE_BRANCH" $(git show-ref -s "$CIRCLE_BRANCH" || git show-ref -s master)
+            git rev-parse --verify -q "$CIRCLE_BRANCH" || git branch "$CIRCLE_BRANCH" $(git show-ref -s master)
             git symbolic-ref HEAD "refs/heads/$CIRCLE_BRANCH"
             git add .
             if git diff-index --quiet HEAD; then
@@ -122,20 +122,25 @@ jobs:
             else
               git commit -m "Automated commit based on $CIRCLE_SHA1"
             fi
-            git tag "$CIRCLE_TAG"
+            git rev-parse --verify -q "$CIRCLE_TAG" || git tag "$CIRCLE_TAG"
             git push origin "$CIRCLE_TAG"
       - run:
           name: 'Deploy NPM Tag'
           command: |
             cd patternlab/styleguide/dist
             npm version --no-git-tag-version "$CIRCLE_TAG"
-            npm publish
+            if [ test -z "$(npm show @massds/mayflower@$CIRCLE_TAG)" ]; then
+              npm publish
+            else
+              echo "Skipping NPM publish - $CIRCLE_TAG already exists"
+            fi
       - run:
           name: 'Deploy S3 Tag'
           command: |
             aws s3 sync patternlab/styleguide/public "s3://mayflower.digital.mass.gov/v/$CIRCLE_TAG"
             if [[ "$CIRCLE_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              aws s3 sync patternlab/styleguide/public "s3://mayflower.digital.mass.gov"
+              # Use cp instead of sync for root copy.  sync lists all keys and is too slow.
+              aws s3 cp patternlab/styleguide/public "s3://mayflower.digital.mass.gov"
             fi
 
   react_build_storybook:
@@ -193,7 +198,11 @@ jobs:
           command: |
             cd react
             npm version --no-git-tag-version "$CIRCLE_TAG"
-            npm publish
+            if [ test -z "$(npm show @massds/mayflower-react@$CIRCLE_TAG)" ]; then
+              npm publish
+            else
+              echo "Skipping NPM publish - $CIRCLE_TAG already exists"
+            fi
       - run: |
           # Only sync to S3 for stable tags.
           if [[ "$CIRCLE_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - DP-1234: The short description text on a [service detail](http://mayflower.digital.mass.gov/?p=pages-detail-for-service-howto-location) page banner ([@organisms/by-template/page-banner](http://mayflower.digital.mass.gov/?p=organisms-page-banner)) should now render ([PR #493](https://github.com/massgov/mayflower/pull/493))
 
 
+## 7.0.1 (8/30/2018)
+
+### Fixed
+- (PatternLab) z-index fix for feedback button to always ensure it appears on top. #209
+- (PatternLab) Allow deploy tag jobs to be rerun #206
+
 ## 7.0.0 (8/29/2018)
 
 ### Changed
@@ -52,7 +58,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - (React) DP-9919: Directly consume global level SCSS variables from shared assets.
 - (React) DP-9981: Changes heading atom in Mayflower React, adding the option to pass a classname to a heading component.
 - (React) DP-10098: Consume scss and images directly from shared assets.
-- (Patternlab, React) DP-10107: 
+- (Patternlab, React) DP-10107:
   - Make current button "small" the default button size and add "large" and "small" variations.
   - Update the button size for location listing CTA to align with default size.
 

--- a/assets/scss/01-atoms/_fixed-feedback-button.scss
+++ b/assets/scss/01-atoms/_fixed-feedback-button.scss
@@ -5,6 +5,8 @@
   right: 0;
   height: 300px;
   pointer-events: none;
+  // set without variable to ensure coverage
+  z-index: 9999;
   
   a {
     display: block;


### PR DESCRIPTION
## 7.0.1 (8/30/2018)

### Fixed
- (PatternLab) z-index fix for feedback button to always ensure it appears on top. #209
- (PatternLab) Allow deploy tag jobs to be rerun #206