### PR TITLE
DP-9176 [a11y] Focus on accordion open/close button

### DIFF
--- a/changelogs/DP-9176.txt
+++ b/changelogs/DP-9176.txt
@@ -1,4 +1,4 @@
 ___DESCRIPTION___
 Changed
 Minor
-- Patternlab DP-9176: Add title attribute to the table of content accordion button in binder page to override the symbols for screen readers, remove the visually hidden text which title attribute replaces with. #PR#
+- Patternlab DP-9176: Add aria-label attribute to the table of content accordion button in binder page to override the symbols for screen readers, remove the visually hidden text which aria-label attribute replaces with. #PR#

--- a/changelogs/DP-9176.txt
+++ b/changelogs/DP-9176.txt
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+Changed
+Minor
+- Patternlab DP-9176: Add title attribute to the table of content accordion button in binder page to override the symbols for screen readers, remove the visually hidden text which title attribute replaces with. #PR#

--- a/changelogs/DP-9176.txt
+++ b/changelogs/DP-9176.txt
@@ -1,4 +1,4 @@
 ___DESCRIPTION___
 Changed
 Minor
-- Patternlab DP-9176: Add aria-label attribute to the table of content accordion button in binder page to override the symbols for screen readers, remove the visually hidden text which aria-label attribute replaces with. #PR#
+- Patternlab DP-9176: Add aria-label attribute to the table of content accordion button in binder page to override the symbols for screen readers, remove the visually hidden text which aria-label attribute replaces with. #215#

--- a/patternlab/styleguide/source/_patterns/03-organisms/by-template/table-of-contents-overlay.twig
+++ b/patternlab/styleguide/source/_patterns/03-organisms/by-template/table-of-contents-overlay.twig
@@ -4,10 +4,7 @@
     {% set decorativeLink = tableOfContentsOverlay.title %}
     {% include "@atoms/decorative-link.twig" %}
     <button type="button" class="ma__toc__toc__toggle js-inline-overlay-toggle" aria-expanded="false" aria-controls="toc-overlay">
-      <span class="show">
-        +
-        <span class="ma__visually-hidden">Show table of contents</span>
-      </span>
+      <span class="show" aria-label="click to show table of contents">+</span>
     </button>
   </div>
   <div class="ma__toc--overlay__container js-inline-overlay" id="toc-overlay">
@@ -16,9 +13,8 @@
       {% set decorativeLink = tableOfContentsOverlay.title %}
       {% include "@atoms/decorative-link.twig" %}
       <button type="button" class="ma__toc__toc__toggle js-inline-overlay-toggle" aria-expanded="true" aria-controls="toc-overlay">
-        <span class="hide">
+        <span class="hide" aria-label="Hide table of contents">
           &times;
-          <span class="ma__visually-hidden">Hide table of contents</span>
         </span>
       </button>
     </div>

--- a/patternlab/styleguide/source/_patterns/03-organisms/by-template/table-of-contents-overlay.twig
+++ b/patternlab/styleguide/source/_patterns/03-organisms/by-template/table-of-contents-overlay.twig
@@ -13,7 +13,7 @@
       {% set decorativeLink = tableOfContentsOverlay.title %}
       {% include "@atoms/decorative-link.twig" %}
       <button type="button" class="ma__toc__toc__toggle js-inline-overlay-toggle" aria-expanded="true" aria-controls="toc-overlay">
-        <span class="hide" aria-label="Hide table of contents">
+        <span class="hide" aria-label="click to hide table of contents">
           &times;
         </span>
       </button>


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/dev/docs/change-log-instructions.md)


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
Add the same treatment for the contact list accordion button (@molecules/contact-us.twig) to the binder page table of content accordion button for screen readers to avoid reading the symbol in the button and give screen reader users more useful text information for the button function.

Add **aria-label** attribute  to `span.show` and `span.hide` in `<button`> to override the symbols.
Remove `span.ma__visually-hidden` which is replaced with the `aria-label`.

No visual change. 
No Drupal change involved.

## Related Issue / Ticket

- [JIRA issue](https://jira.mass.gov/browse/DP-9176)

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Go to http://localhost:3000/?p=pages-binder-page-internal.
2. Check the markup for the table of content button.
3. Find the aria-label values as (screenshots are available below):
     - "click to show table of contents" with "+"
     - "click to hide table of contents" with "x" 

## Screenshots
Show
<img width="741" alt="show" src="https://user-images.githubusercontent.com/9633303/45038154-af402180-b02e-11e8-9ec5-3abbf549e6ff.png">

Hide
<img width="780" alt="hide" src="https://user-images.githubusercontent.com/9633303/45038168-b6672f80-b02e-11e8-91d4-fac098f4ba65.png">

## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* 

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
