### PR TITLE
DP-9255 [a11y]  Empty aria-labelledby and title in how-to page

### DIFF
--- a/changelogs/DP-9255.txt
+++ b/changelogs/DP-9255.txt
@@ -1,0 +1,30 @@
+___DESCRIPTION___
+Changed
+Minor
+- Patternlab DP-9255: Add conditions to place 'title' and 'aria-labelledby' only when their values are available. #218#
+
+___POST DEPLOY STEPS___
+1. Do this
+2. Then do this
+
+___CHANGE TYPES___
+- Added for new features.
+- Changed for changes in existing functionality.
+- Deprecated for soon-to-be removed features.
+- Removed for now removed features.
+- Fixed for any bug fixes.
+- Security in case of vulnerabilities.
+
+Note: See http://keepachangelog.com/ for more info about changelogs.
+
+___CHANGE IMPACT___
+- Minor
+- Major
+- Patch
+
+Note: Refer to `/docs/for-developers/versioning.md` for more info about change impact according to semantic versioning.
+
+___PROJECTS PREFIX___
+- Patternlab
+- React
+- Docs

--- a/patternlab/styleguide/source/_patterns/02-molecules/callout-link.twig
+++ b/patternlab/styleguide/source/_patterns/02-molecules/callout-link.twig
@@ -1,6 +1,6 @@
 {% set calloutLinkTheme = calloutLink.theme ? "ma__callout-link--" ~ calloutLink.theme : "" %}
 
-<div class="ma__callout-link {{calloutLinkTheme}}" title={{ calloutLink.info }}>
+<div class="ma__callout-link {{calloutLinkTheme}}"{% if alloutLink.info %} title={{ calloutLink.info }}{% endif %}>
   <a href="{{ calloutLink.href }}">
     {% if calloutLink.eyebrow or calloutLink.time %}
     <div class="ma__callout-link__header">

--- a/patternlab/styleguide/source/_patterns/03-organisms/by-author/key-actions.twig
+++ b/patternlab/styleguide/source/_patterns/03-organisms/by-author/key-actions.twig
@@ -9,7 +9,7 @@
       {% set compHeading = keyActions.compHeading %}
       {% include "@atoms/04-headings/comp-heading.twig" %}
     {% endif %}
-    <div class="ma__key-actions__items" aria-labelledby="{{ keyActions.compHeading.id }}">
+    <div class="ma__key-actions__items"{% if keyActions.compHeading.id %} aria-labelledby="{{ keyActions.compHeading.id }}"{% endif %}>
       {% for link in keyActions.links %}
         {% if link.image %}
           {% set illustratedLink = link %}


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/dev/docs/change-log-instructions.md)


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
Add conditions to place `title` and `aria-labelledby` only when their values are available.  So, AT users wouldn't get confused by those empty attributes.

No visual change.

No Drupal side change involved.

## Related Issue / Ticket

- [JIRA issue](https://jira.mass.gov/browse/DP-9255)

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Go to How-to page.
2. Check the source code for the key action items below the page title.
3. Find the `aria-labelledby` in `.ma__key-actions__items` and the `title` in `.ma__callout-link` are not there since their values are empty.  See the screenshots below.

## Screenshots
Before
<img width="598" alt="before" src="https://user-images.githubusercontent.com/9633303/45098937-170c7000-b0f4-11e8-891b-20f103411acc.png">

After
<img width="579" alt="after" src="https://user-images.githubusercontent.com/9633303/45098936-14117f80-b0f4-11e8-81a3-9e230c494437.png">



## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* 

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
