### PR TITLE
DP-10287: Adds block to page-overview twig file for responsive images.

### DIFF
--- a/changelogs/DP-10287.txt
+++ b/changelogs/DP-10287.txt
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+Changed
+Minor
+- (Patternlab) DP-10287: Adds block to page-overview twig file for responsive images.

--- a/patternlab/styleguide/source/_patterns/03-organisms/by-author/page-overview.twig
+++ b/patternlab/styleguide/source/_patterns/03-organisms/by-author/page-overview.twig
@@ -6,8 +6,10 @@
     {% endif %}
     {% if pageOverview.image %}
       <div class="ma__page-overview__event-image">
+      {% block overviewImage %}
         {% set image = pageOverview.image %}
         {% include "@atoms/09-media/image.twig" %}
+      {% endblock %}
       </div>
     {% endif %}
     {% if pageOverview.labelledList %}


### PR DESCRIPTION
## Description
DP-10287: Adds block to page-overview twig file for responsive images.

## Related Issue / Ticket
- [JIRA issue](https://jira.mass.gov/browse/DP-10287)
- [JIRA issue](https://jira.mass.gov/browse/DP-9513)

## Steps to Test
1. Navigate to http://localhost:3000/?p=organisms-page-overview
1. Inspect Image
1. In new tab, navigate to https://mayflower.digital.mass.gov/?p=organisms-page-overview
1. Inspect Image
1. Observe HTML is identical

## Screenshots
![image](https://user-images.githubusercontent.com/7987464/45306682-814d5800-b4da-11e8-8c10-98db4e379fff.png)

