### PR TITLE
DP-10368 Fixed SearchBanner molecule filters position when no tabs

### DIFF
--- a/changelogs/DP-10368.txt
+++ b/changelogs/DP-10368.txt
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+Fixed
+Patch
+- (React) DP-10368: Fixed SearchBanner molecule filters position when no tabs are rendered.

--- a/react/src/components/organisms/SearchBanner/index.js
+++ b/react/src/components/organisms/SearchBanner/index.js
@@ -54,7 +54,7 @@ class SearchBanner extends Component {
           <HeaderSearch {...searchBox} />
         </div>
         {tabs && <Tabs {...tabs} />}
-        <div className="ma_serach-banner__filter-box-container">
+        <div className="ma_search-banner__filter-box-container">
           {filterBox && (
             <div className="main-content--two ma__search-banner__filter-box-toggle-container">
               <button onClick={this.toggleFilterBox} type="button" className={toggleButtonClass}>

--- a/react/src/components/organisms/SearchBanner/index.js
+++ b/react/src/components/organisms/SearchBanner/index.js
@@ -54,15 +54,17 @@ class SearchBanner extends Component {
           <HeaderSearch {...searchBox} />
         </div>
         {tabs && <Tabs {...tabs} />}
-        {filterBox && (
-          <div className="main-content--two ma__search-banner__filter-box-toggle-container">
-            <button onClick={this.toggleFilterBox} type="button" className={toggleButtonClass}>
-              {filterToggleText}
-              <Icon name="chevron" svgWidth={20} svgHeight={20} />
-            </button>
-          </div>
-        )}
-        { filterBox && this.state.filterBoxExpanded && <FilterBox {...filterBox} submitButton={submitButton} /> }
+        <div className="ma_serach-banner__filter-box-container">
+          {filterBox && (
+            <div className="main-content--two ma__search-banner__filter-box-toggle-container">
+              <button onClick={this.toggleFilterBox} type="button" className={toggleButtonClass}>
+                {filterToggleText}
+                <Icon name="chevron" svgWidth={20} svgHeight={20} />
+              </button>
+            </div>
+          )}
+          { filterBox && this.state.filterBoxExpanded && <FilterBox {...filterBox} submitButton={submitButton} /> }
+        </div>
       </div>
     );
   }

--- a/react/src/components/organisms/SearchBanner/style.scss
+++ b/react/src/components/organisms/SearchBanner/style.scss
@@ -17,7 +17,7 @@
     padding-bottom: 30px;
     text-align: center;
 
-    .ma_serach-banner__filter-box-container {
+    .ma_search-banner__filter-box-container {
       margin-top: 20px;
       @media ($bp-medium-min) {
         margin-top: 60px;

--- a/react/src/components/organisms/SearchBanner/style.scss
+++ b/react/src/components/organisms/SearchBanner/style.scss
@@ -16,6 +16,13 @@
   &--noTabs {
     padding-bottom: 30px;
     text-align: center;
+
+    .ma_serach-banner__filter-box-container {
+      margin-top: 20px;
+      @media ($bp-medium-min) {
+        margin-top: 60px;
+      }
+    }
   }
 
   .main-content--two {
@@ -134,5 +141,4 @@
       }
     }
   }
-
 }


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/dev/docs/change-log-instructions.md)

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
Fixed SearchBanner molecule filters position when no tabs are rendered.

## Related Issue / Ticket
https://jira.mass.gov/browse/DP-10368

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. cd react; npm start
1. open 
1. browse to organisms/SearchBanner
1. change HeaderSearch.withTabs knob to off

## Screenshots
![screen shot 2018-09-14 at 13 46 39](https://user-images.githubusercontent.com/38226003/45575096-85a5a800-b82f-11e8-80f3-19d606aa53e7.png)

## Additional Notes:
N/A

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* organisms/SearchBanner

#### @TODO
N/A

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
