### PR TITLE
Switches the Link component arrow icon props to numbers from strings.

### DIFF
--- a/react/src/components/molecules/Link/index.js
+++ b/react/src/components/molecules/Link/index.js
@@ -8,7 +8,7 @@ const Link = (props) => (
     href={props.href}
     className="js-clickable-link"
     title={props.info}
-  >{props.text}&nbsp;<Icon name="arrow" svgWidth="13.2" svgHeight="13.2" />
+  >{props.text}&nbsp;<Icon name="arrow" svgWidth={13.2} svgHeight={13.2} />
   </a>
 );
 


### PR DESCRIPTION
## Description
The Link component was causing warnings to be displayed about the wrong type of props being passed for its arrow icon (svgWidth and svgHeight). They are currently strings and should be numbers. This PR does that.
