### PR TITLE
Loosen the child validation in AccordionWrapper so we can import in EEC

### DIFF
--- a/changelogs/eec-AccordionWrapper-child-validation.txt
+++ b/changelogs/eec-AccordionWrapper-child-validation.txt
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+Changed
+Minor
+- (React) EEC support: removes the component name check in AccordionWrapper child validation

--- a/react/src/components/molecules/AccordionItem/index.js
+++ b/react/src/components/molecules/AccordionItem/index.js
@@ -84,7 +84,7 @@ AccordionItem.propTypes = {
   emphasize: PropTypes.bool,
   /** Content rendered in the collapsed section. Only Paragraph, Table, Heading, OrderedList
       and UnorderList are valid children components to pass to AccordionItem */
-  children: PropTypes.node.isRequired,
+  children: PropTypes.element.isRequired,
   /** Whether to style the accordion as secondary or not. */
   secondary: PropTypes.bool,
   /** Heading level for accordion title */

--- a/react/src/components/organisms/AccordionWrapper/index.js
+++ b/react/src/components/organisms/AccordionWrapper/index.js
@@ -7,7 +7,7 @@ const AccordionWrapper = (props) => {
   return(
     <div className="ma__accordion-wrapper">
       { React.Children.map(children, (child) => {
-        if (React.isValidElement(child) && child.type.name === 'AccordionItem') {
+        if (React.isValidElement(child)) {
           const clone = React.cloneElement(child, {
             secondary: props.secondary,
             emphasize: props.emphasize,
@@ -17,8 +17,8 @@ const AccordionWrapper = (props) => {
           return clone;
         }
         return(
-          /* eslint-disable no-console */
-          console.log(`Warning! You cannot pass a ${child.type.name} child to AccordionWrapper`)
+          /* eslint-disable-next-line no-console */
+          console.warn('Warning! You can only pass an AccordionItem child to AccordionWrapper.')
         );
       })}
     </div>

--- a/react/src/components/organisms/AccordionWrapper/index.js
+++ b/react/src/components/organisms/AccordionWrapper/index.js
@@ -27,7 +27,7 @@ const AccordionWrapper = (props) => {
 
 AccordionWrapper.propTypes = {
   /** Only AccordionItem can be passed as a Child to the AccordionWrapper */
-  children: PropTypes.node.isRequired,
+  children: PropTypes.element.isRequired,
   /** Whether accordion children are emphasized or not. */
   emphasize: PropTypes.bool,
   /** Whether accordion children are with border or not. */


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/dev/docs/change-log-instructions.md)


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
Removes the element name check from AccordionWrapper child validation.

During the gatsby build for EEC, the component names are mangled and not checkable.

## Related Issue / Ticket
N/A

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. npm run build
1. in EEC npm link ../mayflower/react
1. npm run build && npm run serve
** the build should not fail due to AccordionWrapper prop validation.

## Screenshots
N/A

## Additional Notes:
N/A

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* EEC AccordionWrapper build

#### @TODO
N/A

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
