### PR TITLE
componentize results heading scss

### DIFF
--- a/react/src/components/molecules/ResultsHeading/style.scss
+++ b/react/src/components/molecules/ResultsHeading/style.scss
@@ -1,4 +1,5 @@
 @import 'global';
+@import "01-atoms/label";
 @import "01-atoms/select-box";
 @import "02-molecules/results-heading";
 

--- a/react/src/components/molecules/ResultsHeading/style.scss
+++ b/react/src/components/molecules/ResultsHeading/style.scss
@@ -1,4 +1,6 @@
 @import 'global';
+@import "01-atoms/select-box";
+@import "02-molecules/results-heading";
 
 @media ($bp-small-min){
   .ma__results-heading__tags+.ma__results-heading__sort.ma__results-heading__sort-selecBox {

--- a/react/src/components/styles/_global.scss
+++ b/react/src/components/styles/_global.scss
@@ -1,3 +1,4 @@
+@import "bourbon/core/bourbon";
 @import '00-base/variables';
 @import '00-base/breakpoints';
 @import '00-base/colors';

--- a/react/src/index.scss
+++ b/react/src/index.scss
@@ -114,7 +114,6 @@ $assets-path: './assets';
 @import "02-molecules/press-teaser";
 @import "02-molecules/related-action";
 @import "02-molecules/relationship-indicators";
-@import "02-molecules/results-heading";
 @import "02-molecules/section-links";
 @import "02-molecules/sort-results";
 @import "02-molecules/social-links";


### PR DESCRIPTION
Componentize resultsHeading styles to import into EEC
<img width="1345" alt="screen shot 2018-09-26 at 3 40 22 pm" src="https://user-images.githubusercontent.com/5789411/46104882-88df5300-c1a2-11e8-8520-6a86376a89d4.png">

To test:
`npm link` EEC branch `wiring-resultsHeading-sort`
