### PR TITLE
React/accordion wrapper child validation

### DIFF
--- a/changelogs/AccordionWrapper-PropType.txt
+++ b/changelogs/AccordionWrapper-PropType.txt
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+Fixed
+Minor
+- (React) Fixed AccordionWrapper child PropType

--- a/react/src/components/organisms/AccordionWrapper/index.js
+++ b/react/src/components/organisms/AccordionWrapper/index.js
@@ -27,7 +27,10 @@ const AccordionWrapper = (props) => {
 
 AccordionWrapper.propTypes = {
   /** Only AccordionItem can be passed as a Child to the AccordionWrapper */
-  children: PropTypes.element.isRequired,
+  children: PropTypes.oneOfType([
+    PropTypes.element,
+    PropTypes.arrayOf(PropTypes.element)
+  ]),
   /** Whether accordion children are emphasized or not. */
   emphasize: PropTypes.bool,
   /** Whether accordion children are with border or not. */


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->

## Description
Fix the react/AccordionWrapper child PropType to allow a single element, or array of elements.
This should remove the need for the Fragment in EEC.

## Related Issue / Ticket
N/A

## Steps to Test
1.  npm run start
1. load http://localhost:6006/
1. Navigate to organisms/AccordionWrapper
1. You should not see PropType warnings about the `children` prop

## Screenshots
N/A

## Additional Notes:
N/A

#### Impacted Areas in Application
* mf/react, Search, EEC

#### @TODO
N/A

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
