### PR TITLE
refactor results heading to passable string

### DIFF
--- a/changelogs/ResultsHeadingMolecule-MessageRefactor.txt
+++ b/changelogs/ResultsHeadingMolecule-MessageRefactor.txt
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+Refactor
+Minor
+React: Refactor the results heading message to a passable string.

--- a/react/src/components/molecules/ResultsHeading/ResultsHeading.stories.js
+++ b/react/src/components/molecules/ResultsHeading/ResultsHeading.stories.js
@@ -14,8 +14,7 @@ storiesOf('molecules', module).addDecorator(withKnobs)
   .add('ResultsHeading', withInfo(`<div>${ResultsHeadingDocs}</div>`)(() => {
     const inputType = select('sortResults.inputType', { '': 'None', buttonToggle: 'buttonToggle', selectBox: 'selectBox' }, 'selectBox');
     const props = {
-      numResults: text('resultsHeading.numResults', '1-12'),
-      totalResults: text('resultsHeading.totalResults', '108'),
+      resultsMessage: text('resultsHeading.resultsMessage', 'Showing 1-10 of 100 for:'),
       tags: {
         tags: object('resultsHeading.tags', TagsData.tags),
         onClearCallback: action('resultsHeading tags on clearAll'),

--- a/react/src/components/molecules/ResultsHeading/ResultsHeading.stories.js
+++ b/react/src/components/molecules/ResultsHeading/ResultsHeading.stories.js
@@ -14,7 +14,7 @@ storiesOf('molecules', module).addDecorator(withKnobs)
   .add('ResultsHeading', withInfo(`<div>${ResultsHeadingDocs}</div>`)(() => {
     const inputType = select('sortResults.inputType', { '': 'None', buttonToggle: 'buttonToggle', selectBox: 'selectBox' }, 'selectBox');
     const props = {
-      resultsMessage: text('resultsHeading.resultsMessage', 'Showing 1-10 of 100 for:'),
+      resultsMessage: text('resultsHeading.resultsMessage', 'Showing results 1-11 of 100 for:'),
       tags: {
         tags: object('resultsHeading.tags', TagsData.tags),
         onClearCallback: action('resultsHeading tags on clearAll'),

--- a/react/src/components/molecules/ResultsHeading/index.js
+++ b/react/src/components/molecules/ResultsHeading/index.js
@@ -51,16 +51,14 @@ class Tags extends Component {
 }
 
 const ResultsHeading = (resultsHeading) => {
-  const resultsHeadingTotal = resultsHeading.totalResults ? ` of ${resultsHeading.totalResults} for: ` : '';
-  const resultsHeadingTitle = `Showing results ${resultsHeading.numResults}${resultsHeadingTotal}`;
-  const { tags } = resultsHeading;
+  const { tags, resultsMessage } = resultsHeading;
   const selectBoxProps = resultsHeading.selectBox;
   const buttonToggleProps = resultsHeading.buttonToggle;
   return(
     <div className="ma__results-heading js-results-heading">
       <div className="ma__results-heading__container">
         <div className="ma__results-heading__title">
-          {resultsHeadingTitle}
+          {resultsMessage}
         </div>
         {tags && (
           <Tags {...tags} />
@@ -83,10 +81,8 @@ const ResultsHeading = (resultsHeading) => {
 };
 
 ResultsHeading.propTypes = {
-  /** The range of results being displayed, e.g. 1-10 */
-  numResults: PropTypes.string,
-  /** The total count of results */
-  totalResults: PropTypes.string,
+  /** The message to be displayed for the results listing */
+  resultsMessage: PropTypes.string,
   /** The sort input type as ButtonToggle */
   buttonToggle: PropTypes.shape(ButtonToggle.props),
   /** The sort input type as SelectBox */


### PR DESCRIPTION
This PR updates the results heading in mayflower-react so that the top message is a passable string instead of a set string.