### PR TITLE
React: Add suggestions as passable prop to header search

### DIFF
--- a/react/src/components/molecules/HeaderSearch/HeaderSearch.scss
+++ b/react/src/components/molecules/HeaderSearch/HeaderSearch.scss
@@ -13,7 +13,7 @@
 
     &--responsive {
       @media ($bp-medium-max) {
-        > div:first-child, input + section {
+        .ma__header-search__pre-filter, .ma__header-search__post-filter {
           display: none;
         }
       }

--- a/react/src/components/molecules/HeaderSearch/index.js
+++ b/react/src/components/molecules/HeaderSearch/index.js
@@ -31,7 +31,11 @@ class HeaderSearch extends React.Component {
     const shouldShowTypeAhead = (orgDropdown && orgDropdown.dropdownButton && orgDropdown.inputText);
     return(
       <div className="ma__header-search__wrapper ma__header-search__wrapper--responsive">
-        {shouldShowTypeAhead && <TypeAheadDropdown {...orgDropdown} /> }
+        {shouldShowTypeAhead && 
+          <div className="ma__header-search__pre-filter">
+            <TypeAheadDropdown {...orgDropdown} />
+          </div>
+        }
         <section className="ma__header-search">
           <form action="#" className="ma__form" onSubmit={headerSearch.onSubmit}>
             <label
@@ -48,7 +52,9 @@ class HeaderSearch extends React.Component {
               value={this.state.value}
             />
             {this.props.suggestions && this.props.suggestions}
-            {this.props.postInputFilter}
+            <div className="ma__header-search__post-filter">
+              {this.props.postInputFilter}
+            </div>
             <ButtonWithIcon {...headerSearch.buttonSearch} />
           </form>
         </section>

--- a/react/src/components/molecules/HeaderSearch/index.js
+++ b/react/src/components/molecules/HeaderSearch/index.js
@@ -47,6 +47,7 @@ class HeaderSearch extends React.Component {
               type="search"
               value={this.state.value}
             />
+            {this.props.suggestions && this.props.suggestions}
             {this.props.postInputFilter}
             <ButtonWithIcon {...headerSearch.buttonSearch} />
           </form>
@@ -71,6 +72,8 @@ HeaderSearch.propTypes = {
   onChange: PropTypes.func,
   /** Default input text value */
   defaultText: PropTypes.string,
+  /** Render suggestions as passable element */
+  suggestions: PropTypes.element,
   /** @molecules/TypeAheadDropdown */
   orgDropdown: PropTypes.shape(PropTypes.TypeAheadDropdown),
   /** postInputFilter passable component */


### PR DESCRIPTION
Enables consumers to pass a suggestion component to header search if the want to render suggestions.