### PR TITLE
DP-10662 [a11y] header site logo alt value

### DIFF
--- a/changelogs/DP-10662.txt
+++ b/changelogs/DP-10662.txt
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+Changed
+Minor
+- React DP-1234: Remove deprecate alt value from site logo image. #PR#

--- a/react/src/components/atoms/media/SiteLogo/SiteLogo.stories.js
+++ b/react/src/components/atoms/media/SiteLogo/SiteLogo.stories.js
@@ -16,7 +16,7 @@ storiesOf('atoms/media', module).addDecorator(withKnobs)
       },
       image: {
         src: text('siteLogo.image.src', logo),
-        alt: text('siteLogo.image.alt', 'Massachusetts state seal'),
+        alt: text('siteLogo.image.alt', ''),
         width: number('siteLogo.image.width', 45),
         height: number('siteLogo.image.height', 45)
       },

--- a/react/src/components/atoms/media/SiteLogo/index.js
+++ b/react/src/components/atoms/media/SiteLogo/index.js
@@ -32,7 +32,7 @@ SiteLogo.defaultProps = {
   },
   image: {
     src: logo,
-    alt: 'Massachusetts state seal',
+    alt: '',
     width: 45,
     height: 45
   },


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/dev/docs/change-log-instructions.md)


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
The state seal image in the header has the same data for its `alt` value as the site name followed `<span>` content.  The duplicate data doesn't provide useful information to AT users.

Remove the `alt` value since it's not necessary with its parent's link `title` attribute.  No change to the site logo function and its visual.

## Related Issue / Ticket

- [DP-10662 \[a11y: search.mass.gov\] Redundant alternative text](https://jira.mass.gov/browse/DP-10662)

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1.  `npm install && npm start`
2.  Check the state seal in the header and find its `alt` value is empty.

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* 

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
