### PR TITLE
DP-10667 Remove aria-label from search button.

### DIFF
--- a/changelogs/DP-10667.txt
+++ b/changelogs/DP-10667.txt
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+Changed
+Minor
+- React DP-10667: Remove aria-label from search button. Button with icon has aria-label only when it has value. #PR#

--- a/changelogs/DP-10667.txt
+++ b/changelogs/DP-10667.txt
@@ -1,4 +1,4 @@
 ___DESCRIPTION___
 Changed
 Minor
-- React DP-10667: Remove aria-label from search button. Button with icon has aria-label only when it has value. #PR#
+- React DP-10667: Remove aria-label from search button. Button with icon has aria-label only when it has value. #318#

--- a/react/src/components/atoms/buttons/ButtonWithIcon/ButtonWithIcon.stories.js
+++ b/react/src/components/atoms/buttons/ButtonWithIcon/ButtonWithIcon.stories.js
@@ -31,7 +31,8 @@ storiesOf('atoms/buttons', module)
         iconColor: select('ButtonWithIcon.iconColor', buttonWithIconOptions.color),
         canExpand: boolean('ButtonWithIcon.canExpand', true),
         expanded: boolean('ButtonWithIcon.expanded', true),
-        capitalized: boolean('ButtonWithIcon.capitalized', true)
+        capitalized: boolean('ButtonWithIcon.capitalized', true),
+        ariaLabel: text('ButtonWithIcon.arialLabel', '')
       };
 
       // Set the icon prop to the actual element based on knob selection.

--- a/react/src/components/atoms/buttons/ButtonWithIcon/index.js
+++ b/react/src/components/atoms/buttons/ButtonWithIcon/index.js
@@ -101,7 +101,7 @@ ButtonWithIcon.defaultProps = {
   capitalized: false,
   iconSize: '',
   iconColor: '',
-  ariaLabel: 'search',
+  ariaLabel: '',
   usage: ''
 };
 

--- a/react/src/components/atoms/buttons/ButtonWithIcon/index.js
+++ b/react/src/components/atoms/buttons/ButtonWithIcon/index.js
@@ -11,7 +11,6 @@ class ButtonWithIcon extends React.Component {
     this.handleClick = this.handleClick.bind(this);
   }
   setButtonRef(node) {
-    console.log(node)
     if (typeof this.props.setButtonRef === 'function') {
       this.props.setButtonRef(node);
     }

--- a/react/src/components/atoms/buttons/ButtonWithIcon/index.js
+++ b/react/src/components/atoms/buttons/ButtonWithIcon/index.js
@@ -11,6 +11,7 @@ class ButtonWithIcon extends React.Component {
     this.handleClick = this.handleClick.bind(this);
   }
   setButtonRef(node) {
+    console.log(node)
     if (typeof this.props.setButtonRef === 'function') {
       this.props.setButtonRef(node);
     }
@@ -23,7 +24,7 @@ class ButtonWithIcon extends React.Component {
   }
   render() {
     const {
-      classes, canExpand, expanded, capitalized, iconSize, iconColor, icon, type, usage
+      classes, canExpand, expanded, capitalized, iconSize, iconColor, icon, type, usage, ariaLabel
     } = this.props;
     // concat a space at the end of custom classes
     let buttonClasses = classes ? `${classes.join(' ')} ` : '';
@@ -43,21 +44,13 @@ class ButtonWithIcon extends React.Component {
       onClick: this.handleClick,
       tabIndex: 0
     };
-    if (this.props.ariaLabel !== '') {
-        return(
-          <button {...buttonProps} aria-label={this.props.ariaLabel} ref={this.setButtonRef}>
-            <span>{this.props.text}</span>
-            {this.props.icon}
-          </button>
-        );
-    } else {
-      return(
-        <button {...buttonProps} ref={this.setButtonRef}>
-          <span>{this.props.text}</span>
-          {this.props.icon}
-        </button>
-      );
-    }
+    if ( ariaLabel && ariaLabel !== '' ) { buttonProps['aria-label'] = ariaLabel };
+    return(
+      <button {...buttonProps} ref={this.setButtonRef} >
+        <span>{this.props.text}</span>
+        {this.props.icon}
+      </button>
+    );
   }
 }
 

--- a/react/src/components/atoms/buttons/ButtonWithIcon/index.js
+++ b/react/src/components/atoms/buttons/ButtonWithIcon/index.js
@@ -43,12 +43,21 @@ class ButtonWithIcon extends React.Component {
       onClick: this.handleClick,
       tabIndex: 0
     };
-    return(
-      <button {...buttonProps} aria-label={this.props.ariaLabel} ref={this.setButtonRef}>
-        <span>{this.props.text}</span>
-        {this.props.icon}
-      </button>
-    );
+    if (this.props.ariaLabel !== '') {
+        return(
+          <button {...buttonProps} aria-label={this.props.ariaLabel} ref={this.setButtonRef}>
+            <span>{this.props.text}</span>
+            {this.props.icon}
+          </button>
+        );
+    } else {
+      return(
+        <button {...buttonProps} ref={this.setButtonRef}>
+          <span>{this.props.text}</span>
+          {this.props.icon}
+        </button>
+      );
+    }
   }
 }
 

--- a/react/src/components/molecules/HeaderSearch/HeaderSearch.stories.js
+++ b/react/src/components/molecules/HeaderSearch/HeaderSearch.stories.js
@@ -20,7 +20,7 @@ storiesOf('molecules/HeaderSearch', module).addDecorator(withKnobs)
       placeholder: text('HeaderSearch.placeholder', 'Search Mass.gov'),
       buttonSearch: {
         onClick: action('Button clicked'),
-        ariaLabel: text('HeaderSearch.buttonSearch.ariaLabel', 'Search'),
+        ariaLabel: text('HeaderSearch.buttonSearch.ariaLabel', ''),
         text: text('HeaderSearch.buttonSearch.text', 'Search'),
         usage: select('HeaderSearch.buttonSearch.usage', {
           '': 'primary (default)',
@@ -68,7 +68,7 @@ storiesOf('molecules/HeaderSearch', module).addDecorator(withKnobs)
       placeholder: text('HeaderSearch.placeholder', 'Search Mass.gov'),
       buttonSearch: {
         onClick: action('Button clicked'),
-        ariaLabel: text('HeaderSearch.buttonSearch.ariaLabel', 'Search'),
+        ariaLabel: text('HeaderSearch.buttonSearch.ariaLabel', ''),
         text: text('HeaderSearch.buttonSearch.text', 'Search'),
         usage: select('HeaderSearch.buttonSearch.usage', {
           '': 'primary (default)',

--- a/react/src/components/molecules/HeaderSearch/index.js
+++ b/react/src/components/molecules/HeaderSearch/index.js
@@ -31,7 +31,7 @@ class HeaderSearch extends React.Component {
     const shouldShowTypeAhead = (orgDropdown && orgDropdown.dropdownButton && orgDropdown.inputText);
     return(
       <div className="ma__header-search__wrapper ma__header-search__wrapper--responsive">
-        {shouldShowTypeAhead && 
+        {shouldShowTypeAhead &&
           <div className="ma__header-search__pre-filter">
             <TypeAheadDropdown {...orgDropdown} />
           </div>
@@ -91,7 +91,7 @@ HeaderSearch.defaultProps = {
   label: 'Search terms',
   placeholder: 'Search Mass.gov',
   buttonSearch: {
-    ariaLabel: 'search',
+    ariaLabel: '',
     usage: 'secondary'
   }
 };


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/dev/docs/change-log-instructions.md)


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
The `aria-label` value for the search button was same as the button label. It's not providing any helpful information to AT users.

The `aria-label` value for the search button is removed.  In `props`, its default value is set to empty.
Button with icon has a condition to render `aria-label` only when it has value.  When no value, `aria-label` attribute wouldn't be rendered.

No visual change.

## Related Issue / Ticket

- [DP-10667 \[a11y: search.mass.gov\] Redundant aria-label for the search button.](https://jira.mass.gov/browse/DP-10667)

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. In mayflower/react, `npm install && npm start`.
2. Check the search buttons for its `aria-label` in source.  It's not supposed to be rendered at all.
      - atoms/ButtonSearch
      - molecules/HeaderSearch
      - organisms/SearchBanner

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* 

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
