### PR TITLE
DP-10666 aria-label for utility nav

### DIFF
--- a/changelogs/DP-10666.txt
+++ b/changelogs/DP-10666.txt
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+Changed
+Minor
+- Mayflower DP-10666: Add a condition for aria-label to render only when its value is available. #PR#

--- a/changelogs/DP-10666.txt
+++ b/changelogs/DP-10666.txt
@@ -1,4 +1,4 @@
 ___DESCRIPTION___
 Changed
 Minor
-- Mayflower DP-10666: Add a condition for aria-label to render only when its value is available. #PR#
+- Mayflower DP-10666: Add a condition for aria-label to render only when its value is available. #319#

--- a/patternlab/styleguide/source/_patterns/03-organisms/by-template/utility-nav.twig
+++ b/patternlab/styleguide/source/_patterns/03-organisms/by-template/utility-nav.twig
@@ -14,7 +14,7 @@
       <li class="ma__utility-nav__item js-util-nav-toggle">
         <a class="ma__utility-nav__link"
           href="#"
-          aria-label="{% if item.ariaLabelText %}{{ item.ariaLabelText }}{% else %}{{ item.text }}{% endif %}">
+          {% if item.ariaLabelText %} aria-label="{{ item.ariaLabelText }}"{% endif %}>
           {{ icon(item.icon) }}
           <span>
             {{ item.text }}


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/dev/docs/change-log-instructions.md)


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
Originally the issue was found through the search.mass.gov accessibility audit.  Since the utility nav data is pulled from the Mass.gov site, the fix is done in Patternlab.

The State Organizations link in the utility nav has unnecessary aria-label, which shares the same value with its link label.

A condition is added to add `aria-label` only when its unique value is available to the template.

No visual change.

## Related Issue / Ticket

- [DP-10666 \[a11y: search.mass.gov\] Redundant aria-label in State Organization link at the page top.](https://jira.mass.gov/browse/DP-10666)

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Go to any page with the utility nav.
2. Check `aria-label` in its two links:
       - State Organizations:  find no `aria-label`.
       - Log in to...: find `aria-label` with its unique value "Log in to the most requested services".

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* 

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
