### PR TITLE
(React) DP-10895: Fix for pageflipper bug

### DIFF
--- a/changelogs/DP-10895.txt
+++ b/changelogs/DP-10895.txt
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+Fixed
+Minor
+- (React) DP-10895: Fix bug in page flipper if intro props are not passed. #

--- a/react/src/components/organisms/PageFlipper/index.js
+++ b/react/src/components/organisms/PageFlipper/index.js
@@ -4,20 +4,18 @@ import componentPropTypeCheck from '../../utilities/componentPropTypeCheck';
 import './style.css';
 
 const PageFlipper = (props) => {
-  const introLabel = (props.intro.label) ? (<span className="ma__page-flipper__context-label">{props.intro.label}</span>) : '';
-  const introDecorativeLink = (props.intro.introDecorativeLink.props.text) ? props.intro.introDecorativeLink : '';
-  const introLink = (introLabel || introDecorativeLink) ? (
-    <div className="ma__page-flipper__context">
-      {introLabel}
-      {introDecorativeLink}
-    </div>
-  ) : '';
   const blank = (<div className="ma__page-flipper__blank">&nbsp;</div>);
   const prev = props.previousLink || blank;
   const next = props.nextLink || blank;
   return(
     <React.Fragment>
-      {introLink}
+      { props.intro && (
+        <div className="ma__page-flipper__context">
+          { props.intro.label && <span className="ma__page-flipper__context-label">{props.intro.label}</span> }
+          { props.intro.introDecorativeLink && props.intro.introDecorativeLink }
+        </div>
+        )
+      }
       <div className="ma__page-flipper">
         <div className="ma__page-flipper__container">
           {prev}

--- a/react/src/components/organisms/PageFlipper/index.js
+++ b/react/src/components/organisms/PageFlipper/index.js
@@ -12,7 +12,7 @@ const PageFlipper = (props) => {
       { props.intro && (
         <div className="ma__page-flipper__context">
           { props.intro.label && <span className="ma__page-flipper__context-label">{props.intro.label}</span> }
-          { props.intro.introDecorativeLink && props.intro.introDecorativeLink }
+          { (props.intro.introDecorativeLink && props.intro.introDecorativeLink.props.text) && props.intro.introDecorativeLink }
         </div>
         )
       }


### PR DESCRIPTION
React: This pr addresses a bug in the pageflipper organism that occurs if the intro props (label and dec link) are not passed to pageflipper.