### PR TITLE
fix/texta-font-antialias

### DIFF
--- a/assets/scss/01-atoms/global/_elements.scss
+++ b/assets/scss/01-atoms/global/_elements.scss
@@ -11,6 +11,10 @@
 
 // WARNING: avoid nesting of elements,
 // because it makes them harder to override
+* {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
 
 html {
   @media ($bp-small-max){
@@ -29,9 +33,9 @@ body {
   color: $c-font-base;
   font-family: "Texta", "Helvetica", "Arial", "sans-serif";
   font-weight: 400;
-  // for IE weirdness 
+  // for IE weirdness
   -ms-overflow-style: none;
-  
+
 
   // .translated-rtl & {
   //   direction: rtl;

--- a/changelogs/DP-10986.txt
+++ b/changelogs/DP-10986.txt
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+Fixed
+Minor
+- (Patternlab, React) DP-10986: Add font smoothing for Texta font weight accuracy. #336


### PR DESCRIPTION
[Jira ticket DP-10986](https://jira.mass.gov/secure/RapidBoard.jspa?rapidView=3530&view=detail&selectedIssue=DP-10986)
Before:
<img width="636" alt="screen shot 2018-10-17 at 1 49 22 pm" src="https://user-images.githubusercontent.com/5789411/47457389-f633d300-d7a4-11e8-84f1-c35c2f912f72.png">

After:
<img width="957" alt="screen shot 2018-10-24 at 3 48 13 pm" src="https://user-images.githubusercontent.com/5789411/47457374-eb793e00-d7a4-11e8-874e-b4b7ee3651b8.png">

To test:
````
<span style="font-weight:300">// Light => 300</span> </br>
<span style="font-weight:400">// Book => 400</span> </br>
<span style="font-weight:500">// Medium => 500</span> </br>
<span style="font-weight:700">// Bold => 700</span> </br>
<span style="font-weight:800">// Black => 800</span> </br>
````