### PR TITLE
Patternlab/DP-11135  create mayflower for new feedback form option 2a  contact link

### DIFF
--- a/assets/scss/03-organisms/_mass-feedback-form.scss
+++ b/assets/scss/03-organisms/_mass-feedback-form.scss
@@ -203,3 +203,11 @@
     }
   }
 }
+
+.ma__mass-feedback-form--success {
+
+  .ma__decorative-link {
+    padding-right: 0;
+    margin: 25px 0;
+  }
+}

--- a/changelogs/DP-11135.txt
+++ b/changelogs/DP-11135.txt
@@ -1,0 +1,30 @@
+___DESCRIPTION___
+Minor
+Added
+- pattern;ab / DP-11135: Create Mayflower for new feedback form - Option 2a (contact link)
+
+___POST DEPLOY STEPS___
+1. Do this
+2. Then do this
+
+___CHANGE TYPES___
+- Added for new features.
+- Changed for changes in existing functionality.
+- Deprecated for soon-to-be removed features.
+- Removed for now removed features.
+- Fixed for any bug fixes.
+- Security in case of vulnerabilities.
+
+Note: See http://keepachangelog.com/ for more info about changelogs.
+
+___CHANGE IMPACT___
+- Minor
+- Major
+- Patch
+
+Note: Refer to `/docs/for-developers/versioning.md` for more info about change impact according to semantic versioning.
+
+___PROJECTS PREFIX___
+- Patternlab
+- React
+- Docs

--- a/patternlab/styleguide/source/_patterns/03-organisms/feedback/mass-feedback-success.twig
+++ b/patternlab/styleguide/source/_patterns/03-organisms/feedback/mass-feedback-success.twig
@@ -1,6 +1,11 @@
-<div class="ma__mass-feedback-form" id="feedback" data-mass-feedback-form>
+<div class="ma__mass-feedback-form ma__mass-feedback-form--success" id="feedback" data-mass-feedback-form>
 <form class="ma__mass-feedback-form__form" method="post" novalidate="" action="{{action}}" class="" id="">
   <legend>{{ title }} {{org}}!</legend>
+  {% if contactLink %}
+    <span class="ma__decorative-link">
+      <a href="{{ contactLink }}">If you need to contact the {{org}}, please click here&nbsp;{{ icon('arrow') }}</a>
+    </span>
+  {% endif %}
   <p class="">{{ description }}</p>
 
   <fieldset class="ma__mass-feedback-form__form--submit-wrapper">

--- a/patternlab/styleguide/source/_patterns/03-organisms/feedback/mass-feedback-success~with-contact-link.json
+++ b/patternlab/styleguide/source/_patterns/03-organisms/feedback/mass-feedback-success~with-contact-link.json
@@ -1,0 +1,7 @@
+{
+  "title": "Thanks, your feedback has been sent to",
+  "action": "#",
+  "org": "the Registry of Motor Vehicles",
+  "contactLink": "#",
+  "description": "Would you like to provide additional feedback to help improve Mass.gov?"
+}


### PR DESCRIPTION
## Description
Adds optional contact link block to success panel

## Related Issue / Ticket

- [https://jira.mass.gov/browse/DP-11135](DP-11135)


## Steps to Test

1. visit https://mayflower.digital.mass.gov/b/patternlab/DP-11135--create-mayflower-for-new-feedback-form-option-2a--contact-link/patterns/03-organisms-feedback-mass-feedback-success-with-contact-link/03-organisms-feedback-mass-feedback-success-with-contact-link.html

## Screenshots
<img width="830" alt="screen shot 2018-11-07 at 12 55 23 pm" src="https://user-images.githubusercontent.com/18662734/48153962-1b3c4180-e28d-11e8-800c-9a5894de8a08.png">

There are no backstop updates associated with this PR