### PR TITLE
DP-11205: Fix footnote bug

### DIFF
--- a/changelogs/DP-11205.txt
+++ b/changelogs/DP-11205.txt
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+Minor
+Patch
+- (React) DP-11205: Fix FootNote atom bug.

--- a/react/src/components/atoms/links/FootNote/index.js
+++ b/react/src/components/atoms/links/FootNote/index.js
@@ -15,7 +15,7 @@ class FootNote extends React.Component {
           id={`footnotemsg${index}`}
           onClick={() => this.handleScroll()}
         >
-          <span classNames="ma__footnote-item-content">{`${index}. ${children}`}</span>
+          <span className="ma__footnote-item-content">{`${index}. ${children}`}</span>
         </button>
       </div>
     );


### PR DESCRIPTION
## Description
Fixes typo in FootNote component `classNames` --> `className`

## Related Issue / Ticket

- [DP-11205](https://jira.mass.gov/browse/DP-11205)
