### PR TITLE
Patternlab/DP-10231  location listing pagination bug

### DIFF
--- a/changelogs/DP-10231.txt
+++ b/changelogs/DP-10231.txt
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+Fixed
+Patch
+- patternlab / DP-10231: bug fix for location pagination

--- a/patternlab/styleguide/source/assets/js/modules/pagination.js
+++ b/patternlab/styleguide/source/assets/js/modules/pagination.js
@@ -22,13 +22,13 @@ export default (function (window, document, $, undefined) {
 
     // Listen for previous page button click and trigger pagination event.
     $el.on('click', prevButton, function () {
-      targetPageNumber = targetPageNumber - 1;
+      targetPageNumber = parseInt(targetPageNumber) - 1;
       pushPaginationState(targetPageNumber);
       $el.trigger('ma:Pagination:Pagination', [history.state.page]);
     });
     // Listen for next button click and trigger pagination event.
     $el.on('click', nextButton, function () {
-      targetPageNumber = targetPageNumber + 1;
+      targetPageNumber = parseInt(targetPageNumber) + 1;
       pushPaginationState(targetPageNumber);
       $el.trigger('ma:Pagination:Pagination', [history.state.page]);
     });
@@ -39,7 +39,7 @@ export default (function (window, document, $, undefined) {
       $el.trigger('ma:Pagination:Pagination', [history.state.page]);
     });
 
-    window.onpopstate = function(e) {
+    window.onpopstate = function (e) {
       if (e.state) {
         if (e.state.page) {
           $el.trigger("ma:Pagination:Pagination", [e.state.page]);
@@ -98,9 +98,9 @@ export default (function (window, document, $, undefined) {
     }
 
     let truncatedPagination = data,
-        current = data.currentPage,
-        last = data.totalPages,
-        delta = 1;
+      current = data.currentPage,
+      last = data.totalPages,
+      delta = 1;
 
     // For the first and last pages, set the delta to 2 so 2 page numbers
     // within the current page can be shown.
@@ -109,10 +109,10 @@ export default (function (window, document, $, undefined) {
     }
 
     let left = current - delta,
-        right = current + delta + 1,
-        range = [],
-        rangeWithEllipsis = [],
-        l;
+      right = current + delta + 1,
+      range = [],
+      rangeWithEllipsis = [],
+      l;
 
     for (let i = 1; i <= last; i++) {
       if (i == 1 || i == last || i >= left && i < right) {
@@ -161,4 +161,4 @@ export default (function (window, document, $, undefined) {
     }
   }
 
-}) (window, document, jQuery);
+})(window, document, jQuery);


### PR DESCRIPTION

## Description
updates pagination 'next' button 

## Related Issue / Ticket

- [DP-10231](https://jira.mass.gov/browse/DP-10231)

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. In mobile, click the next button. The pages should advance correctly and the next page should be placed at the top of the list

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* 

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
