### PR TITLE
React/DP-11402: InputTextFuzzy bug.

### DIFF
--- a/changelogs/DP-11402.txt
+++ b/changelogs/DP-11402.txt
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+Fixed
+Minor
+- (React) DP-11402: Fixes a bug in InputTextFuzzy where hitting enter on a suggestion did not pass a suggestion object to the onSuggestionClick prop function.

--- a/react/src/components/atoms/forms/InputTextFuzzy/index.js
+++ b/react/src/components/atoms/forms/InputTextFuzzy/index.js
@@ -91,14 +91,13 @@ class InputTextFuzzy extends React.Component {
                   suggestions: [],
                   highlightedItemIndex: null
                 };
-              }, () => {
-                if (typeof this.props.onSuggestionClick === 'function') {
-                  const suggestion = this.state.suggestions[this.state.highlightedItemIndex];
-
-                  // Suggestion is an object that can contain info on score, matches, etc.
-                  this.props.onSuggestionClick(event, {suggestion});
-                }
               });
+              if (typeof this.props.onSuggestionClick === 'function') {
+                const suggestion = this.state.suggestions[this.state.highlightedItemIndex];
+
+                // Suggestion is an object that can contain info on score, matches, etc.
+                this.props.onSuggestionClick(event, {suggestion});
+              }
               break;
             case 'Escape':
               this.setState({


### PR DESCRIPTION
## Description
This fixes a bug in InputTextFuzzy where hitting enter on a suggestion did not pass a suggestion object to the onSuggestionClick prop function.

## Related Issue / Ticket

- [JIRA issue](https://jira.mass.gov/browse/DP-11402)
## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Pull the branch, browse to http://localhost:6006/.
2. Click on atoms -> forms -> InputTextFuzzy
3. Verify that after partially typing an organization name, then using the down/up arrows to choose an organization and hitting enter to select it, there are no errors and the organization selected is shown in full in the input text box.
