### PR TITLE
Patternlab/DP-5859  checkboxes replace bullets for what you need

### DIFF
--- a/assets/scss/08-print/_print.scss
+++ b/assets/scss/08-print/_print.scss
@@ -429,20 +429,20 @@
   .ma__link-list__toggle {
     display: none;
   }
-}
 
-// Page level custom print styles
-.ma__details__content .ma__rich-text {
-  ul li {
-    list-style-type: none;
-    padding-left: 2em;
-    text-indent: -2em;
+  // Page level custom print styles
+  .ma__details__content .ma__rich-text {
+    ul li {
+      list-style-type: none;
+      padding-left: 2em;
+      text-indent: -2em;
 
-    &::before {
-      // checkbox
-      content: "\2610";
-      margin-right:5px;
-      font-size: 2.5rem;
+      &::before {
+        // checkbox
+        content: "\2610";
+        margin-right:5px;
+        font-size: 2.5rem;
+      }
     }
   }
 }

--- a/assets/scss/08-print/_print.scss
+++ b/assets/scss/08-print/_print.scss
@@ -430,3 +430,19 @@
     display: none;
   }
 }
+
+// Page level custom print styles
+.ma__details__content .ma__rich-text {
+  ul li {
+    list-style-type: none;
+    padding-left: 2em;
+    text-indent: -2em;
+
+    &::before {
+      // checkbox
+      content: "\2610";
+      margin-right:5px;
+      font-size: 2.5rem;
+    }
+  }
+}

--- a/changelogs/DP--5859.txt
+++ b/changelogs/DP--5859.txt
@@ -1,0 +1,5 @@
+___DESCRIPTION___
+Changed
+Patch
+- patternlab / DP-5859: Checkboxes missing from What You Need section on print style for How To Pages
+


### PR DESCRIPTION

## Description
In the What You Need section, bullets should transform into checkboxes when the page is printed.

## Related Issue / Ticket

- [DP-5859](https://jira.mass.gov/browse/DP-5859)


## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Visit the Mayflower How-to page at https://mayflower.digital.mass.gov/b/patternlab/DP-5859--checkboxes-replace-bullets-for-what-you-need/patterns/05-pages-howto/05-pages-howto.html
and open print preview

## Screenshots
<img width="1320" alt="screen shot 2018-12-03 at 2 10 21 pm" src="https://user-images.githubusercontent.com/18662734/49399654-7b48cb00-f707-11e8-937d-c293b72a1069.png">

