### PR TITLE
Patternlab/DP-10265 Added a static map block

### DIFF
--- a/changelogs/DP-10265.txt
+++ b/changelogs/DP-10265.txt
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+Added
+Minor
+- (Patternlab) DP-10265: Added a block for the map to the location-banner.twig.

--- a/patternlab/styleguide/source/_patterns/03-organisms/by-author/location-banner.twig
+++ b/patternlab/styleguide/source/_patterns/03-organisms/by-author/location-banner.twig
@@ -7,11 +7,13 @@
     }
   </style>
   <div class="ma__location-banner__map">
-    {% set googleMap = locationBanner.actionMap ? locationBanner.actionMap : locationBanner.googleMap %}
-    {% include "@molecules/google-map.twig" %}
+    {% block map %}
+      {% set googleMap = locationBanner.actionMap ? locationBanner.actionMap : locationBanner.googleMap %}
+      {% include "@molecules/google-map.twig" %}
+    {% endblock %}
   </div>
-  <div 
-    class="ma__location-banner__image" 
+  <div
+    class="ma__location-banner__image"
     id="{{ locationBannerId }}"
     role="image"
     title="{{ locationBanner.bgTitle }}">


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/dev/docs/change-log-instructions.md)


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
To have the map display within the location page added a block to the location banner twig. To prevent any cache issues from contact information and location pages information.

## Related Issue / Ticket

- [DP-10265](https://jira.mass.gov/browse/DP-10265)
- [Github issue]()

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. View the location-banner.twig to see a block map has been added to the twig. The block does not change anything visually in the location-banner.twig.

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* 

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
