### PR TITLE
Fix variable $column to be interpolated.

### DIFF
--- a/assets/scss/03-organisms/_page-banner.scss
+++ b/assets/scss/03-organisms/_page-banner.scss
@@ -331,7 +331,7 @@ $page-banner-height: 330px;
   &--small &__icon + &__title {
 
     @media ($bp-medium-min) {
-      width: calc(100% - $column);
+      width: calc(100% - #{$column});
     }
   }
 


### PR DESCRIPTION
Fix variable $column in /assets/scss/03-organisms/_page-banner.scss so that it is interpolated.

## Description
The literal string $content appears in the index-generated.css file.  This fixes the syntax error so the variable $column is interpolated, resulting in the $content variable value in the index-generated.css file.

## Related Issue / Ticket
/cc @alarrimore for clarification about this ticket.

## Steps to Test
1. Run gulp task patternlab:build
2. Search built index-generated.css  file for "$column"

## Screenshots

## Additional Notes:

#### Impacted Areas in Application
* /assets/scss/03-organisms/_page-banner.scss
