### PR TITLE
React DP-11634: MainNav a11y

### DIFF
--- a/assets/scss/02-molecules/_main-nav.scss
+++ b/assets/scss/02-molecules/_main-nav.scss
@@ -54,6 +54,9 @@
       &.is-open:after {
         display: none;
       }
+      &.is-open-react:after {
+        display: none;
+      }
     }
   }
 
@@ -108,7 +111,7 @@
       }
     }
 
-    .is-open & {
+    .is-open, is-open-react & {
 
       &:after {
         @media ($bp-header-toggle-min) {
@@ -180,7 +183,7 @@
         right: 0;
       }
 
-      &.is-closed {
+      &.is-closed, &.is-closed-react {
         right: -300px;
       }
     }
@@ -194,6 +197,10 @@
 
       &.is-closed {
         @include ma-visually-hidden;
+      }
+
+      &.is-closed-react {
+       display: none;
       }
 
       .ma__main-nav__item:last-child & {

--- a/changelogs/DP-11634.txt
+++ b/changelogs/DP-11634.txt
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+
+### Changed/Fixed Minor
+- (React) DP-11634: Update the MainNav molecule for better a11y, enabling users to tab through the navigation menu. Also updated the svg-sprite-loader package to permit Icon component #385

--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -2808,8 +2808,7 @@
     "boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
-      "dev": true
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
     "boom": {
       "version": "2.10.1",
@@ -3312,7 +3311,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
       "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
-      "dev": true,
       "requires": {
         "no-case": "^2.2.0",
         "upper-case": "^1.1.1"
@@ -3525,7 +3523,6 @@
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.11.tgz",
       "integrity": "sha1-Ls3xRaujj1R0DybO/Q/z4D4SXWo=",
-      "dev": true,
       "requires": {
         "source-map": "0.5.x"
       },
@@ -3533,8 +3530,7 @@
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
@@ -3711,8 +3707,7 @@
     "commander": {
       "version": "2.15.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
-      "dev": true
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
     },
     "common-tags": {
       "version": "1.7.2",
@@ -4219,7 +4214,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
-      "dev": true,
       "requires": {
         "boolbase": "~1.0.0",
         "css-what": "2.1",
@@ -4241,8 +4235,7 @@
     "css-what": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
-      "integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0=",
-      "dev": true
+      "integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0="
     },
     "cssesc": {
       "version": "0.1.0",
@@ -4777,7 +4770,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.1.4.tgz",
       "integrity": "sha1-pF71cnuJDJv/5tfIduexnLDhfzs=",
-      "dev": true,
       "requires": {
         "utila": "~0.3"
       },
@@ -4785,8 +4777,7 @@
         "utila": {
           "version": "0.3.3",
           "resolved": "https://registry.npmjs.org/utila/-/utila-0.3.3.tgz",
-          "integrity": "sha1-1+jn1+MJEHCSsF+NloiCTWM6QiY=",
-          "dev": true
+          "integrity": "sha1-1+jn1+MJEHCSsF+NloiCTWM6QiY="
         }
       }
     },
@@ -4844,7 +4835,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
       "integrity": "sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=",
-      "dev": true,
       "requires": {
         "domelementtype": "1"
       }
@@ -7711,7 +7701,6 @@
       "version": "3.5.16",
       "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.16.tgz",
       "integrity": "sha512-zP5EfLSpiLRp0aAgud4CQXPQZm9kXwWjR/cF0PfdOj+jjWnOaCgeZcll4kYXSvIBPeUMmyaSc7mM4IDtA+kboA==",
-      "dev": true,
       "requires": {
         "camel-case": "3.0.x",
         "clean-css": "4.1.x",
@@ -7726,7 +7715,6 @@
           "version": "3.3.26",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.26.tgz",
           "integrity": "sha512-XHxutZNxbx0UnqNUrjL/wvABLxirEYpbAnjCWGakPfQRJbbAGF2dI+YYw300F5mYKm7zBtgYiw3kOiQFobzglQ==",
-          "dev": true,
           "requires": {
             "commander": "~2.15.0",
             "source-map": "~0.6.1"
@@ -7778,7 +7766,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.3.0.tgz",
       "integrity": "sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=",
-      "dev": true,
       "requires": {
         "domelementtype": "1",
         "domhandler": "2.1",
@@ -7790,7 +7777,6 @@
           "version": "1.1.6",
           "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz",
           "integrity": "sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=",
-          "dev": true,
           "requires": {
             "domelementtype": "1"
           }
@@ -7798,14 +7784,12 @@
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
         "readable-stream": {
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.1",
@@ -7816,8 +7800,7 @@
         "string_decoder": {
           "version": "0.10.31",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
     },
@@ -9470,8 +9453,7 @@
     "lodash": {
       "version": "4.17.10",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-      "dev": true
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
     "lodash-es": {
       "version": "4.17.10",
@@ -9817,8 +9799,7 @@
     "lower-case": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
-      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
-      "dev": true
+      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
     },
     "lru-cache": {
       "version": "4.1.3",
@@ -10147,11 +10128,11 @@
       "dev": true
     },
     "merge-options": {
-      "version": "0.0.64",
-      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-0.0.64.tgz",
-      "integrity": "sha1-y+BPWUppheryf3+PCyo6z2+dVi0=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-1.0.1.tgz",
+      "integrity": "sha512-iuPV41VWKWBIOpBsjoxjDZw8/GbSfZ2mk7N1453bwMrfzdrIk7EzBd+8UVR6rkw67th7xnk9Dytl3J+lHPdxvg==",
       "requires": {
-        "is-plain-obj": "^1.1.0"
+        "is-plain-obj": "^1.1"
       }
     },
     "methods": {
@@ -10558,7 +10539,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
       "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
-      "dev": true,
       "requires": {
         "lower-case": "^1.1.1"
       }
@@ -11125,7 +11105,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
       "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
-      "dev": true,
       "requires": {
         "boolbase": "~1.0.0"
       }
@@ -11892,7 +11871,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
       "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "es-abstract": "^1.5.1"
@@ -12226,7 +12204,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
       "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
-      "dev": true,
       "requires": {
         "no-case": "^2.2.0"
       }
@@ -14073,7 +14050,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -14601,16 +14578,16 @@
           }
         },
         "htmlparser2": {
-          "version": "3.9.2",
-          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
-          "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.0.tgz",
+          "integrity": "sha512-J1nEUGv+MkXS0weHNWVKJJ+UrLfePxRWpN3C9bEi9fLxL2+ggW94DQvgYVXsaT30PGwYRIZKNZXuyMhp3Di4bQ==",
           "requires": {
             "domelementtype": "^1.3.0",
             "domhandler": "^2.3.0",
             "domutils": "^1.5.1",
             "entities": "^1.1.1",
             "inherits": "^2.0.1",
-            "readable-stream": "^2.0.2"
+            "readable-stream": "^3.0.6"
           }
         },
         "isobject": {
@@ -14620,13 +14597,23 @@
           "requires": {
             "isarray": "1.0.0"
           }
+        },
+        "readable-stream": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.0.tgz",
+          "integrity": "sha512-vpydAvIJvPODZNagCPuHG87O9JNPtvFEtjHHRVwNVsVVRBqemvPJkc2SYbxJsiZXawJdtZNmkmnsPuE3IgsG0A==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
         }
       }
     },
     "posthtml-rename-id": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/posthtml-rename-id/-/posthtml-rename-id-1.0.8.tgz",
-      "integrity": "sha512-xloDnCx/PFUCxEnXbUC79p3I5/ik3x2ffsx3ihX9HBhsbffXWIVl9O8+tplGk9d13IVhp202VvH++Hht7dGJTQ==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/posthtml-rename-id/-/posthtml-rename-id-1.0.11.tgz",
+      "integrity": "sha512-8doF8+w+WJT4AZuLVC0feA8Yy7g00IUmZw3YDKn8CKx0uC8FLbCH7JaGMbDOE1ArjyZsJMt1vmyP+IZ8SnNmXw==",
       "requires": {
         "escape-string-regexp": "1.0.5"
       }
@@ -14637,11 +14624,11 @@
       "integrity": "sha512-jL6eFIzoN3xUEvbo33OAkSDE2VIKU4JQ1wENOows1DpfnrdapR/K3Q1/fB43Mq7wQlcSgRm23nFrvoioufM7eA=="
     },
     "posthtml-svg-mode": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/posthtml-svg-mode/-/posthtml-svg-mode-1.0.2.tgz",
-      "integrity": "sha512-yH4w0CULTg6v3YW5hVUY2z14R+11XWvtxMRqk30FDgxg0JWv+BhS9FLtKNIu858/1mrO1NcIC4heb6IezLAfHw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/posthtml-svg-mode/-/posthtml-svg-mode-1.0.3.tgz",
+      "integrity": "sha512-hEqw9NHZ9YgJ2/0G7CECOeuLQKZi8HjWLkBaSVtOWjygQ9ZD8P7tqeowYs7WrFdKsWEKG7o+IlsPY8jrr0CJpQ==",
       "requires": {
-        "merge-options": "0.0.64",
+        "merge-options": "1.0.1",
         "posthtml": "^0.9.2",
         "posthtml-parser": "^0.2.1",
         "posthtml-render": "^1.0.6"
@@ -14686,7 +14673,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.1.tgz",
       "integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
-      "dev": true,
       "requires": {
         "renderkid": "^2.0.1",
         "utila": "~0.4"
@@ -14707,7 +14693,8 @@
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "dev": true
     },
     "progress": {
       "version": "2.0.0",
@@ -15442,6 +15429,7 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -15673,8 +15661,7 @@
     "relateurl": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
-      "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
-      "dev": true
+      "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk="
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
@@ -15686,7 +15673,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.1.tgz",
       "integrity": "sha1-iYyr/Ivt5Le5ETWj/9Mj5YwNsxk=",
-      "dev": true,
       "requires": {
         "css-select": "^1.1.0",
         "dom-converter": "~0.1",
@@ -15698,8 +15684,7 @@
         "utila": {
           "version": "0.3.3",
           "resolved": "https://registry.npmjs.org/utila/-/utila-0.3.3.tgz",
-          "integrity": "sha1-1+jn1+MJEHCSsF+NloiCTWM6QiY=",
-          "dev": true
+          "integrity": "sha1-1+jn1+MJEHCSsF+NloiCTWM6QiY="
         }
       }
     },
@@ -16718,8 +16703,7 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-resolve": {
       "version": "0.5.2",
@@ -17130,21 +17114,21 @@
       }
     },
     "svg-baker": {
-      "version": "1.2.17",
-      "resolved": "https://registry.npmjs.org/svg-baker/-/svg-baker-1.2.17.tgz",
-      "integrity": "sha512-Tjx9jgFoNpWQPLFgxEXKvCOjbo+8xoAxR9beUcdeR4k+5RFISfteWu6Y6OR7FPEXVBBrQzoZQM5/gSYTVfKxiA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/svg-baker/-/svg-baker-1.4.0.tgz",
+      "integrity": "sha512-VDI530erEOb1E8kbl2fMOCWBMnk9kz7RyjE0JtcvcAyhofSyqd0Oj7mL9MGvECexyZJn+rX6Isk6Hk21ApRcJg==",
       "requires": {
         "bluebird": "^3.5.0",
         "clone": "^2.1.1",
         "he": "^1.1.1",
         "image-size": "^0.5.1",
         "loader-utils": "^1.1.0",
-        "merge-options": "0.0.64",
+        "merge-options": "1.0.1",
         "micromatch": "3.1.0",
         "postcss": "^5.2.17",
         "postcss-prefix-selector": "^1.6.0",
         "posthtml-rename-id": "^1.0",
-        "posthtml-svg-mode": "^1.0",
+        "posthtml-svg-mode": "^1.0.3",
         "query-string": "^4.3.2",
         "traverse": "^0.6.6"
       },
@@ -17156,7 +17140,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -17298,28 +17282,63 @@
       }
     },
     "svg-baker-runtime": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/svg-baker-runtime/-/svg-baker-runtime-1.3.5.tgz",
-      "integrity": "sha512-BKxJT/Zz9M+K043zXbZf7CA3c10NKWByxobAukO30VLv71OvmpagjG32Z0UIay6ctMaOUmywOKHuceiSDqwUOA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/svg-baker-runtime/-/svg-baker-runtime-1.4.0.tgz",
+      "integrity": "sha512-wrv8ivS2MlkKKl9CLULEevxOSLXtCkQuwZaF9stFnvSQRp/Xexh2R5MOWpMQr+px0JMOy4I1dAXm50hq75Asrg==",
       "requires": {
         "deepmerge": "1.3.2",
         "mitt": "1.1.2",
-        "svg-baker": "^1.2.0"
+        "svg-baker": "^1.4.0"
       }
     },
     "svg-sprite-loader": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/svg-sprite-loader/-/svg-sprite-loader-3.8.0.tgz",
-      "integrity": "sha512-7HkMH0//OLVwqY9T1ho3R5l9GR8/70GBB0KKFULcgvNs+tkln8TcdsuC1UA5536mjM6GBcEuK7CCUR7+xIV9vg==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/svg-sprite-loader/-/svg-sprite-loader-4.1.3.tgz",
+      "integrity": "sha512-lOLDSJoyriYnOeGYc7nhxTDYj2vfdBVKpxIS/XK70//kA3VB55H89T1lct2OEClY4w5kQLZJAvDGQ41g3YTogQ==",
       "requires": {
         "bluebird": "^3.5.0",
         "deepmerge": "1.3.2",
         "domready": "1.0.8",
         "escape-string-regexp": "1.0.5",
+        "html-webpack-plugin": "^3.2.0",
         "loader-utils": "^1.1.0",
-        "svg-baker": "^1.2.17",
-        "svg-baker-runtime": "^1.3.3",
+        "svg-baker": "^1.4.0",
+        "svg-baker-runtime": "^1.4.0",
         "url-slug": "2.0.0"
+      },
+      "dependencies": {
+        "html-webpack-plugin": {
+          "version": "3.2.0",
+          "resolved": "http://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
+          "integrity": "sha1-sBq71yOsqqeze2r0SS69oD2d03s=",
+          "requires": {
+            "html-minifier": "^3.2.3",
+            "loader-utils": "^0.2.16",
+            "lodash": "^4.17.3",
+            "pretty-error": "^2.0.2",
+            "tapable": "^1.0.0",
+            "toposort": "^1.0.0",
+            "util.promisify": "1.0.0"
+          },
+          "dependencies": {
+            "loader-utils": {
+              "version": "0.2.17",
+              "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+              "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+              "requires": {
+                "big.js": "^3.1.3",
+                "emojis-list": "^2.0.0",
+                "json5": "^0.5.0",
+                "object-assign": "^4.0.1"
+              }
+            }
+          }
+        },
+        "tapable": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.1.tgz",
+          "integrity": "sha512-9I2ydhj8Z9veORCw5PRm4u9uebCn0mcCa6scWoNcbZ6dAtoo2618u9UUzxgmsCOreJpqDDuv61LvwofW7hLcBA=="
+        }
       }
     },
     "svg-tag-names": {
@@ -17667,8 +17686,7 @@
     "toposort": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.7.tgz",
-      "integrity": "sha1-LmhELZ9k7HILjMieZEOsbKqVACk=",
-      "dev": true
+      "integrity": "sha1-LmhELZ9k7HILjMieZEOsbKqVACk="
     },
     "tough-cookie": {
       "version": "2.3.4",
@@ -17991,8 +18009,7 @@
     "upper-case": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
-      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
-      "dev": true
+      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
     },
     "uri-js": {
       "version": "4.2.1",
@@ -18137,11 +18154,19 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
+    "util.promisify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+      "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+      "requires": {
+        "define-properties": "^1.1.2",
+        "object.getownpropertydescriptors": "^2.0.3"
+      }
+    },
     "utila": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
-      "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=",
-      "dev": true
+      "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw="
     },
     "utils-merge": {
       "version": "1.0.1",

--- a/react/package.json
+++ b/react/package.json
@@ -49,7 +49,7 @@
     "react-table": "^6.8.6",
     "react-transition-group": "^2.4.0",
     "shortid": "^2.2.8",
-    "svg-sprite-loader": "^3.8.0"
+    "svg-sprite-loader": "^4.1.3"
   },
   "devDependencies": {
     "@storybook/addon-actions": "^3.3.10",

--- a/react/src/components/atoms/icons/Icon/index.js
+++ b/react/src/components/atoms/icons/Icon/index.js
@@ -34,16 +34,17 @@ class Icon extends React.Component {
       svgHeight,
       title,
       name,
-      classes
+      classes,
+      ...rest
     } = this.props;
     if (svgFile) {
       const attr = {
         width: svgWidth || null,
         height: svgHeight || null,
-        className: classes ? classes.join(' ') : null
+        className: (classes && classes.length > 0) ? classes.join(' ') : null
       };
       return(
-        <svg {...attr}>
+        <svg {...attr} {...rest}>
           {title && <title>{ title }</title> }
           <use xlinkHref={`#${name}`} />
         </svg>

--- a/react/src/components/molecules/MainNav/index.js
+++ b/react/src/components/molecules/MainNav/index.js
@@ -1,7 +1,8 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import Icon from '../../atoms/icons/Icon';
-import './styles.css';
+import './style.css';
 
 class MainNav extends Component {
   constructor(props) {
@@ -14,7 +15,6 @@ class MainNav extends Component {
   mouseOver(e) {
     const bodyClass = document.querySelector('body').classList;
     bodyClass.toggle('show-submenu');
-
     this.setState({
       navSelected: e.currentTarget.id
     });
@@ -22,28 +22,39 @@ class MainNav extends Component {
   mouseOut() {
     const bodyClass = document.querySelector('body').classList;
     bodyClass.toggle('show-submenu');
-
     this.setState({
       navSelected: -1
     });
+  }
+  onKeyDown(e) {
+    if (e.keyCode === 13) {
+      this.setState({
+        navSelected: e.currentTarget.id
+      });
+    }
+    if (e.keyCode === 27) {
+      this.setState({
+        navSelected: -1
+      });
+    }
   }
   render() {
     return(
       <section className="ma__main-nav">
         <ul className="ma__main-nav__items js-main-nav" role="menubar">
           {this.props.mainNav.map((item, index) => {
+            const topItemClasses = classNames({
+              'ma__main-nav__item': true,
+              'is-active': item.active,
+              'has-subnav js-main-nav-toggle': item.subNav,
+              'js-main-nav-top-link': !item.subNav
+            });
             const buttonId = `button${index}`;
             const liId = `li${index}`;
-            const topItemClasses = ['ma__main-nav__item'];
             const { navSelected } = this.state;
             const isExpanded = navSelected === liId;
-            const isOpen = isExpanded ? 'is-open' : 'is-closed';
-            if (item.active) {
-              topItemClasses.push('is-active');
-            }
             const itemBody = [];
             if (item.subNav) {
-              topItemClasses.push('has-subnav js-main-nav-toggle');
               const buttonProps = {
                 id: buttonId,
                 index,
@@ -55,30 +66,23 @@ class MainNav extends Component {
                 key: buttonId
               };
               itemBody.push(<button {...buttonProps}>{item.text}</button>);
-              const navItemClasses = {
-                className: `ma__main-nav__subitems js-main-nav-content ${isOpen}`,
-                key: `navItem${index}`,
-                'aria-hidden': !isExpanded,
-                tabIndex: !isExpanded ? -1 : null
-              };
+              const navItemClasses = classNames({
+                'ma__main-nav__subitems': true,
+                'js-main-nav-content': true,
+                'is-open-react': isExpanded,
+                'is-closed-react': !isExpanded
+              });
               itemBody.push((
-                <div {...navItemClasses}>
+                <div className={navItemClasses} key={`navItem${index}`} aria-hidden={!isExpanded}>
                   <ul role="menu" aria-labelledby={buttonId} className="ma__main-nav__container" tabIndex={!isExpanded ? -1 : null}>
                     <li role="presentation" className="ma__main-nav__subitem">
                       <a href={item.href} role="menuitem" className="ma__main-nav__link" tabIndex={!isExpanded ? -1 : null}>{item.text}</a>
                     </li>
-                    {item.subNav.map((subItem, subItemIndex) => {
-                      const liProps = {
-                        role: 'menuitem',
-                        className: 'ma__main-nav__subitem',
-                        key: `liProps.${index}.${subItemIndex}`
-                      };
-                      return(
-                        <li {...liProps}>
-                          <a href={subItem.href} role="menuitem" className="ma__main-nav__link">{subItem.text}</a>
-                        </li>);
-                      })
-                    }
+                    {item.subNav.map((subItem, subItemIndex) => (
+                      <li role="menuitem" className="ma__main-nav__subitem" key={`liProps.${index}.${subItemIndex}`}>
+                        <a href={subItem.href} role="menuitem" className="ma__main-nav__link">{subItem.text}</a>
+                      </li>
+                    ))}
                     <li role="presentation" className="ma__main-nav__subitem">
                       <a href={item.href} role="menuitem" className="ma__main-nav__link">
                         <Icon name="arrowbent" aria-hidden />
@@ -88,7 +92,6 @@ class MainNav extends Component {
                   </ul>
                 </div>));
             } else {
-              topItemClasses.push('js-main-nav-top-link');
               const buttonProps = {
                 id: buttonId,
                 className: 'ma__main-nav__top-link',
@@ -99,13 +102,16 @@ class MainNav extends Component {
               };
               itemBody.push(<button {...buttonProps}>{item.text}</button>);
             }
-            const liClasses = {
-              className: topItemClasses.join(' '),
-              key: `liClasses${index}`,
-              id: liId
-            };
             return(
-              <li {...liClasses} role="presentation" onMouseEnter={(e) => this.mouseOver(e)} onMouseLeave={(e) => this.mouseOut(e)}>
+              <li
+                className={topItemClasses}
+                key={`liClasses${index}`}
+                id={liId}
+                role="presentation"
+                onKeyDown={(e) => this.onKeyDown(e)}
+                onMouseEnter={(e) => this.mouseOver(e)}
+                onMouseLeave={(e) => this.mouseOut(e)}
+              >
                 {itemBody}
               </li>);
             })

--- a/react/src/components/molecules/MainNav/index.js
+++ b/react/src/components/molecules/MainNav/index.js
@@ -30,10 +30,9 @@ class MainNav extends Component {
   render() {
     return(
       <section className="ma__main-nav">
-        <ul className="ma__main-nav__items js-main-nav">
+        <ul className="ma__main-nav__items js-main-nav" role="menubar">
           {this.props.mainNav.map((item, index) => {
             const buttonId = `button${index}`;
-            const menuId = `menu${index}`;
             const liId = `li${index}`;
             const topItemClasses = ['ma__main-nav__item'];
             const { navSelected } = this.state;
@@ -49,22 +48,24 @@ class MainNav extends Component {
                 id: buttonId,
                 index,
                 className: 'ma__main-nav__top-link',
-                tabIndex: index === 0 ? 0 : -1,
                 'aria-expanded': `${isExpanded}`,
                 'aria-haspopup': 'true',
-                'aria-controls': menuId,
+                role: 'menuitem',
+                'aria-label': (isExpanded) ? `Hide submenu for ${item.text}` : `Show submenu for ${item.text}`,
                 key: buttonId
               };
               itemBody.push(<button {...buttonProps}>{item.text}</button>);
               const navItemClasses = {
                 className: `ma__main-nav__subitems js-main-nav-content ${isOpen}`,
-                key: `navItem${index}`
+                key: `navItem${index}`,
+                'aria-hidden': !isExpanded,
+                tabIndex: !isExpanded ? -1 : null
               };
               itemBody.push((
                 <div {...navItemClasses}>
-                  <ul id={menuId} role="menu" aria-labelledby={buttonId} className="ma__main-nav__container">
-                    <li role="menuitem" className="ma__main-nav__subitem">
-                      <a href={item.href} className="ma__main-nav__link" tabIndex="-1">{item.text}</a>
+                  <ul role="menu" aria-labelledby={buttonId} className="ma__main-nav__container" tabIndex={!isExpanded ? -1 : null}>
+                    <li role="presentation" className="ma__main-nav__subitem">
+                      <a href={item.href} role="menuitem" className="ma__main-nav__link" tabIndex={!isExpanded ? -1 : null}>{item.text}</a>
                     </li>
                     {item.subNav.map((subItem, subItemIndex) => {
                       const liProps = {
@@ -74,13 +75,13 @@ class MainNav extends Component {
                       };
                       return(
                         <li {...liProps}>
-                          <a href={subItem.href} className="ma__main-nav__link" tabIndex="-1">{subItem.text}</a>
+                          <a href={subItem.href} role="menuitem" className="ma__main-nav__link">{subItem.text}</a>
                         </li>);
                       })
                     }
-                    <li role="menuitem" className="ma__main-nav__subitem">
-                      <a href={item.href} className="ma__main-nav__link" tabIndex="-1">
-                        <Icon name="arrowbent" />
+                    <li role="presentation" className="ma__main-nav__subitem">
+                      <a href={item.href} role="menuitem" className="ma__main-nav__link">
+                        <Icon name="arrowbent" aria-hidden />
                         <span>{item.text}</span>
                       </a>
                     </li>
@@ -92,9 +93,9 @@ class MainNav extends Component {
                 id: buttonId,
                 className: 'ma__main-nav__top-link',
                 'aria-haspopup': 'true',
-                'aria-controls': menuId,
-                tabIndex: index === 0 ? 0 : -1,
-                key: buttonId
+                key: buttonId,
+                role: 'menuitem',
+                'aria-label': (isExpanded) ? `Hide submenu for ${item.text}` : `Show submenu for ${item.text}`
               };
               itemBody.push(<button {...buttonProps}>{item.text}</button>);
             }
@@ -104,7 +105,7 @@ class MainNav extends Component {
               id: liId
             };
             return(
-              <li {...liClasses} onMouseEnter={(e) => this.mouseOver(e)} onMouseLeave={(e) => this.mouseOut(e)}>
+              <li {...liClasses} role="presentation" onMouseEnter={(e) => this.mouseOver(e)} onMouseLeave={(e) => this.mouseOut(e)}>
                 {itemBody}
               </li>);
             })

--- a/react/src/components/molecules/MainNav/index.js
+++ b/react/src/components/molecules/MainNav/index.js
@@ -41,13 +41,12 @@ class MainNav extends Component {
   render() {
     return(
       <section className="ma__main-nav">
-        <ul className="ma__main-nav__items js-main-nav" role="menubar">
+        <ul className="ma__main-nav__items" role="menubar">
           {this.props.mainNav.map((item, index) => {
             const topItemClasses = classNames({
               'ma__main-nav__item': true,
               'is-active': item.active,
-              'has-subnav js-main-nav-toggle': item.subNav,
-              'js-main-nav-top-link': !item.subNav
+              'has-subnav': item.subNav
             });
             const buttonId = `button${index}`;
             const liId = `li${index}`;
@@ -68,7 +67,6 @@ class MainNav extends Component {
               itemBody.push(<button {...buttonProps}>{item.text}</button>);
               const navItemClasses = classNames({
                 'ma__main-nav__subitems': true,
-                'js-main-nav-content': true,
                 'is-open-react': isExpanded,
                 'is-closed-react': !isExpanded
               });

--- a/react/src/components/molecules/MainNav/styles.scss
+++ b/react/src/components/molecules/MainNav/styles.scss
@@ -1,2 +1,0 @@
-@import 'global';
-@import "02-molecules/main-nav";

--- a/react/src/components/organisms/PageHeader/index.js
+++ b/react/src/components/organisms/PageHeader/index.js
@@ -6,8 +6,6 @@ import Paragraph from '../../atoms/text/Paragraph';
 import PublishState from '../../atoms/text/PublishState';
 import './style.css';
 
-import './style.css';
-
 const PageHeader = (pageHeader) => {
   const {
     category, title, subTitle, optionalContents, publishState

--- a/react/src/components/organisms/TeaserListing/TeaserListing.knob.options.js
+++ b/react/src/components/organisms/TeaserListing/TeaserListing.knob.options.js
@@ -1,200 +1,200 @@
 export default {
-  "teaserListing": {
-    "stacked": true,
-    "compHeading": {
-      "title": "Teaser Listing",
-      "sub": false,
-      "color": "",
-      "id": "",
-      "centered": true
+  teaserListing: {
+    stacked: true,
+    compHeading: {
+      title: 'Teaser Listing',
+      sub: false,
+      color: '',
+      id: '',
+      centered: true
     },
-    "sidebarHeading": {
-      "title": "Sidebar Heading",
-      "sub": false,
-      "color": "",
-      "id": "",
-      "centered": false
+    sidebarHeading: {
+      title: 'Sidebar Heading',
+      sub: false,
+      color: '',
+      id: '',
+      centered: false
     },
-    "description" : {
-      "text": "This is an optional descriptive paragraph field, explaining the listings below. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean euismod bibendum laoreet. Proin gravida dolor sit amet lacus accumsan et viverra justo commodo. Proin sodales pulvinar tempor. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Nam fermentum, nulla luctus pharetra vulputate, felis tellus mollis orci, sed rhoncus sapien nunc eget."
+    description: {
+      text: 'This is an optional descriptive paragraph field, explaining the listings below. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean euismod bibendum laoreet. Proin gravida dolor sit amet lacus accumsan et viverra justo commodo. Proin sodales pulvinar tempor. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Nam fermentum, nulla luctus pharetra vulputate, felis tellus mollis orci, sed rhoncus sapien nunc eget.'
     },
-    "featuredItems": [
+    featuredItems: [
       {
-        "image": {
-          "src":"https://mayflower.digital.mass.gov/assets/images/placeholder/172x228.png",
-          "alt": "placeholder image",
-          "width": "172",
-          "height": "228"
+        image: {
+          src: 'https://mayflower.digital.mass.gov/assets/images/placeholder/172x228.png',
+          alt: 'placeholder image',
+          width: '172',
+          height: '228'
         },
-        "eyebrow": "Eyebrow",
-        "title" : {
-          "href":"#",
-          "text":"Massachusetts Health Officials Release Quarterly Report on Opioid OD Deaths",
-          "info": "",
-          "property": ""
+        eyebrow: 'Eyebrow',
+        title: {
+          href: '#',
+          text: 'Massachusetts Health Officials Release Quarterly Report on Opioid OD Deaths',
+          info: '',
+          property: ''
         },
-        "org": "Health & Human Services, Public Safety",
-        "date": "4/4/2017",
-        "description": {
-          "text": "Optional descriptive text. Vel impetus tamquam equidem cu, ei possit possim constituam eos, mea ut rebum iudico. Soluta bonorum partiendo est ne, nominati postulant argumentum ius no, quo ne quaeque sanctus."
+        org: 'Health & Human Services, Public Safety',
+        date: '4/4/2017',
+        description: {
+          text: 'Optional descriptive text. Vel impetus tamquam equidem cu, ei possit possim constituam eos, mea ut rebum iudico. Soluta bonorum partiendo est ne, nominati postulant argumentum ius no, quo ne quaeque sanctus.'
         }
       },
       {
-        "image": {
-          "src":"https://mayflower.digital.mass.gov/assets/images/placeholder/172x228.png",
-          "alt": "placeholder image",
-          "width": "172",
-          "height": "228"
+        image: {
+          src: 'https://mayflower.digital.mass.gov/assets/images/placeholder/172x228.png',
+          alt: 'placeholder image',
+          width: '172',
+          height: '228'
         },
-        "eyebrow": "Eyebrow",
-        "title" : {
-          "href": "#",
-          "text":"Feature 2",
-          "info": "",
-          "property": ""
+        eyebrow: 'Eyebrow',
+        title: {
+          href: '#',
+          text: 'Feature 2',
+          info: '',
+          property: ''
         },
-        "org": "Org Name",
-        "date": "4/3/2017",
-        "description": {
-          "text": "Optional descriptive text. Vel impetus tamquam equidem cu, ei possit possim constituam eos, mea ut rebum iudico. Soluta bonorum partiendo est ne, nominati postulant argumentum ius no, quo ne quaeque sanctus."
+        org: 'Org Name',
+        date: '4/3/2017',
+        description: {
+          text: 'Optional descriptive text. Vel impetus tamquam equidem cu, ei possit possim constituam eos, mea ut rebum iudico. Soluta bonorum partiendo est ne, nominati postulant argumentum ius no, quo ne quaeque sanctus.'
         }
       }
     ],
-    "items": [
+    items: [
       {
-        "layout": "contents-stacked",
-        "image": {
-          "src": "https://mayflower.digital.mass.gov/assets/images/placeholder/72x96.png",
-          "alt": "placeholder image",
-          "width": "72",
-          "height": "96"
+        layout: 'contents-stacked',
+        image: {
+          src: 'https://mayflower.digital.mass.gov/assets/images/placeholder/72x96.png',
+          alt: 'placeholder image',
+          width: '72',
+          height: '96'
         },
-        "eyebrow": "Board member",
-        "title": {
-          "href": "#",
-          "text": "Sally Testperson",
-          "info": "",
-          "property": ""
+        eyebrow: 'Board member',
+        title: {
+          href: '#',
+          text: 'Sally Testperson',
+          info: '',
+          property: ''
         },
-        "emphasizedText": [
-          "Awesome board member"
+        emphasizedText: [
+          'Awesome board member'
         ],
-        "description": {
-          "text": "Optional descriptive text. Vel impetus tamquam equidem cu, ei possit possim constituam eos, mea ut rebum iudico. Soluta bonorum partiendo est ne, nominati postulant argumentum ius no, quo ne quaeque sanctus."
+        description: {
+          text: 'Optional descriptive text. Vel impetus tamquam equidem cu, ei possit possim constituam eos, mea ut rebum iudico. Soluta bonorum partiendo est ne, nominati postulant argumentum ius no, quo ne quaeque sanctus.'
         }
       },
       {
-        "layout": "contents-stacked",
-        "image": {
-          "src": "https://mayflower.digital.mass.gov/assets/images/placeholder/72x96.png",
-          "alt": "placeholder image",
-          "width": "72",
-          "height": "96"
+        layout: 'contents-stacked',
+        image: {
+          src: 'https://mayflower.digital.mass.gov/assets/images/placeholder/72x96.png',
+          alt: 'placeholder image',
+          width: '72',
+          height: '96'
         },
-        "eyebrow": "Board Member",
-        "title": {
-          "text": "Board Member's Name",
-          "info": "",
-          "property": ""
+        eyebrow: 'Board Member',
+        title: {
+          text: "Board Member's Name",
+          info: '',
+          property: ''
         },
-        "emphasizedText": [
+        emphasizedText: [
           "Member's title"
         ],
-        "description": {
-          "text": "Optional descriptive text. Vel impetus tamquam equidem cu, ei possit possim constituam eos, mea ut rebum iudico. Soluta bonorum partiendo est ne, nominati postulant argumentum ius no, quo ne quaeque sanctus."
+        description: {
+          text: 'Optional descriptive text. Vel impetus tamquam equidem cu, ei possit possim constituam eos, mea ut rebum iudico. Soluta bonorum partiendo est ne, nominati postulant argumentum ius no, quo ne quaeque sanctus.'
         }
       },
       {
-        "layout": "contents-stacked",
-        "image": {
-          "src": "https://mayflower.digital.mass.gov/assets/images/placeholder/72x96.png",
-          "alt": "placeholder image",
-          "width": "72",
-          "height": "96"
+        layout: 'contents-stacked',
+        image: {
+          src: 'https://mayflower.digital.mass.gov/assets/images/placeholder/72x96.png',
+          alt: 'placeholder image',
+          width: '72',
+          height: '96'
         },
-        "eyebrow": "Board Member",
-        "title": {
-          "text": "Board Member's Name",
-          "info": "",
-          "property": ""
+        eyebrow: 'Board Member',
+        title: {
+          text: "Board Member's Name",
+          info: '',
+          property: ''
         },
-        "emphasizedText": [
+        emphasizedText: [
           "Board Member's Title"
         ],
-        "description": {
-          "text": "Optional descriptive text. Vel impetus tamquam equidem cu, ei possit possim constituam eos, mea ut rebum iudico. Soluta bonorum partiendo est ne, nominati postulant argumentum ius no, quo ne quaeque sanctus."
+        description: {
+          text: 'Optional descriptive text. Vel impetus tamquam equidem cu, ei possit possim constituam eos, mea ut rebum iudico. Soluta bonorum partiendo est ne, nominati postulant argumentum ius no, quo ne quaeque sanctus.'
         }
       },
       {
-        "layout": "contents-stacked",
-        "image": {
-          "src": "https://mayflower.digital.mass.gov/assets/images/placeholder/72x96.png",
-          "alt": "placeholder image",
-          "width": "72",
-          "height": "96"
+        layout: 'contents-stacked',
+        image: {
+          src: 'https://mayflower.digital.mass.gov/assets/images/placeholder/72x96.png',
+          alt: 'placeholder image',
+          width: '72',
+          height: '96'
         },
-        "eyebrow": "Board Member",
-        "title": {
-          "text": "Board Member's Name",
-          "info": "",
-          "property": ""
+        eyebrow: 'Board Member',
+        title: {
+          text: "Board Member's Name",
+          info: '',
+          property: ''
         },
-        "emphasizedText": [
+        emphasizedText: [
           "Board Member's Title"
         ],
-        "description": {
-          "text": "Optional descriptive text. Vel impetus tamquam equidem cu, ei possit possim constituam eos, mea ut rebum iudico. Soluta bonorum partiendo est ne, nominati postulant argumentum ius no, quo ne quaeque sanctus."
+        description: {
+          text: 'Optional descriptive text. Vel impetus tamquam equidem cu, ei possit possim constituam eos, mea ut rebum iudico. Soluta bonorum partiendo est ne, nominati postulant argumentum ius no, quo ne quaeque sanctus.'
         }
       },
       {
-        "layout": "contents-stacked",
-        "image": {
-          "src": "https://mayflower.digital.mass.gov/assets/images/placeholder/72x96.png",
-          "alt": "placeholder image",
-          "width": "72",
-          "height": "96"
+        layout: 'contents-stacked',
+        image: {
+          src: 'https://mayflower.digital.mass.gov/assets/images/placeholder/72x96.png',
+          alt: 'placeholder image',
+          width: '72',
+          height: '96'
         },
-        "eyebrow": "Board Member",
-        "title": {
-          "text": "Board Member's Name",
-          "info": "",
-          "property": ""
+        eyebrow: 'Board Member',
+        title: {
+          text: "Board Member's Name",
+          info: '',
+          property: ''
         },
-        "emphasizedText": [
+        emphasizedText: [
           "Board Member's Title"
         ],
-        "description": {
-          "text": "Optional descriptive text. Vel impetus tamquam equidem cu, ei possit possim constituam eos, mea ut rebum iudico. Soluta bonorum partiendo est ne, nominati postulant argumentum ius no, quo ne quaeque sanctus."
+        description: {
+          text: 'Optional descriptive text. Vel impetus tamquam equidem cu, ei possit possim constituam eos, mea ut rebum iudico. Soluta bonorum partiendo est ne, nominati postulant argumentum ius no, quo ne quaeque sanctus.'
         }
       },
       {
-        "layout": "contents-stacked",
-        "image": {
-          "src": "https://mayflower.digital.mass.gov/assets/images/placeholder/72x96.png",
-          "alt": "placeholder image",
-          "width": "72",
-          "height": "96"
+        layout: 'contents-stacked',
+        image: {
+          src: 'https://mayflower.digital.mass.gov/assets/images/placeholder/72x96.png',
+          alt: 'placeholder image',
+          width: '72',
+          height: '96'
         },
-        "eyebrow": "Board Member",
-        "title": {
-          "text": "Board Member's Name",
-          "info": "",
-          "property": ""
+        eyebrow: 'Board Member',
+        title: {
+          text: "Board Member's Name",
+          info: '',
+          property: ''
         },
-        "emphasizedText": [
+        emphasizedText: [
           "Board Member's Title"
         ],
-        "description": {
-          "text": "Optional descriptive text. Vel impetus tamquam equidem cu, ei possit possim constituam eos, mea ut rebum iudico. Soluta bonorum partiendo est ne, nominati postulant argumentum ius no, quo ne quaeque sanctus."
+        description: {
+          text: 'Optional descriptive text. Vel impetus tamquam equidem cu, ei possit possim constituam eos, mea ut rebum iudico. Soluta bonorum partiendo est ne, nominati postulant argumentum ius no, quo ne quaeque sanctus.'
         }
       }
     ],
-    "more":{
-      "href": "#",
-      "text": "See all news and announcements",
-      "chevron": true,
-      "label": "See all news and announcements for the blah blah location"
+    more: {
+      href: '#',
+      text: 'See all news and announcements',
+      chevron: true,
+      label: 'See all news and announcements for the blah blah location'
     }
   }
-}
+};
 


### PR DESCRIPTION
## Description
Update the MainNav molecule for better a11y, enabling users to tab through the navigation menu. Also updated the svg-sprite-loader package to permit Icon component

## Related Issue / Ticket

- [JIRA issue](https://jira.mass.gov/browse/DP-11634)

## Steps to Test
1. `cd react`
2. `npm install`
3. `npm start`
4. go to http://localhost:6006/iframe.html?selectedKind=organisms&selectedStory=Header and confirm that you can tab through and on enter expand main nav like video below.

## Screenshots
![main-nav](https://user-images.githubusercontent.com/9359261/50616215-808b6800-0eb5-11e9-99ad-8e681303b555.gif)
