### PR TITLE
DP-6374: Add better aria tagging to content cards more link on topic pages

### DIFF
--- a/changelogs/DP-6374.txt
+++ b/changelogs/DP-6374.txt
@@ -1,0 +1,5 @@
+___DESCRIPTION___
+Fixed
+Patch
+- patternlab / DP-6374: A11y - Add better aria tagging to content cards more link on topic pages
+

--- a/patternlab/styleguide/source/_patterns/01-atoms/decorative-link.json
+++ b/patternlab/styleguide/source/_patterns/01-atoms/decorative-link.json
@@ -2,6 +2,7 @@
   "decorativeLink": {
     "href": "#",
     "text": "Lorem ipsum dolor sit amet.",
+    "label": "",
     "context": "",
     "button": false,
     "info": ""

--- a/patternlab/styleguide/source/_patterns/01-atoms/decorative-link.twig
+++ b/patternlab/styleguide/source/_patterns/01-atoms/decorative-link.twig
@@ -2,5 +2,8 @@
   <a
     href="{{decorativeLink.href}}"
     class="js-clickable-link"
-    title="{% if decorativeLink.info %}{{ decorativeLink.info }}{% else %}{{decorativeLink.text}}{% endif %}"{% if decorativeLink.context %} aria-describedby="{{ decorativeLink.context }}"{% endif %}>{{decorativeLink.text}}&nbsp;{{ icon('arrow') }}</a>
+    title="{% if decorativeLink.info %}{{ decorativeLink.info }}{% else %}{{decorativeLink.text}}{% endif %}"
+    {% if decorativeLink.context %} aria-describedby="{{ decorativeLink.context }}"{% endif %}
+    {% if decorativeLink.label %} aria-labelledby="{{ decorativeLink.label }}" {% else %} aria-labelledby="{{ decorativeLink.info }}"{% endif %}
+    >{{decorativeLink.text}}&nbsp;{{ icon('arrow') }}</a>
 </span>


### PR DESCRIPTION
## Description
Adds optional labelled by field to decorative links and fills it with the link info if nothing is provided
## Related Issue / Ticket

- [https://jira.mass.gov/browse/DP-6374](DP-6374)

## Steps to Test

1. Visit the topic page and inspect one of the more links in the topic cards. There should be a "labelledby" attribute that contains either a custom link label or the custom info text.

## Screenshots
<img width="994" alt="screen_shot_2018-12-26_at_2_31_54_pm" src="https://user-images.githubusercontent.com/18662734/50457058-63d3bb00-091e-11e9-9f6f-1b2c542c7630.png">
 
