### PR TITLE
Patternlab/DP-9183  MF [a11y] Expand button on alert

### DIFF
--- a/changelogs/DP-9183.txt
+++ b/changelogs/DP-9183.txt
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+changed
+patch
+- patternlab / DP-9183: Expand button on alert

--- a/patternlab/styleguide/source/_patterns/03-organisms/by-template/header-alert.twig
+++ b/patternlab/styleguide/source/_patterns/03-organisms/by-template/header-alert.twig
@@ -23,5 +23,6 @@
   </div>
   <button
     class="ma__header-alert__hide js-header-alert-link"
-    title="hide alert">+</button>
+    title="hide alert"
+    aria-label="hide alert">+</button>
 </section>


### PR DESCRIPTION
## Description
Adds aria label to header alert hide button

## Related Issue / Ticket

- [DP-9183](https://jira.mass.gov/browse/DP-9183)
- [Github issue]()

## Steps to Test

1. Using a screenreader, visit a page with a header alert. The close button should now read as "hide alert" 

