### PR TITLE
DP-9185: replace section tag with blockquote tag

### DIFF
--- a/assets/scss/03-organisms/_pullquote.scss
+++ b/assets/scss/03-organisms/_pullquote.scss
@@ -1,9 +1,8 @@
 //theme
 .ma__pullquote {
   position: relative;
-  margin-top: 30px;
-  margin-bottom: 30px;
-  
+  margin: 30px 0;
+
   @media ($bp-small-min) {
     margin-left: 6%;
   }

--- a/changelogs/DP-9185.txt
+++ b/changelogs/DP-9185.txt
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+change
+patch
+- patternlab /  DP-9185: MF [a11y] Use proper html element for semantics

--- a/patternlab/styleguide/source/_patterns/03-organisms/by-author/pullquote.twig
+++ b/patternlab/styleguide/source/_patterns/03-organisms/by-author/pullquote.twig
@@ -1,3 +1,3 @@
-<section class="ma__pullquote">
+<blockquote class="ma__pullquote">
   <span class="ma__pullquote__content">{{pullquoteCallout.content}}</span>
-</section>
+</blockquote>


### PR DESCRIPTION
## Description
Use <blockquote> instead of <section> tags for better semantic markup

## Related Issue / Ticket

- [DP-9185](https://jira.mass.gov/browse/DP-9185)
- [Github issue]()

## Steps to Test

1.  Visit an information details page with a blockquote, inspect the blockquote to see it now uses the proper tag.

## Screenshots
<img width="1312" alt="screen shot 2018-12-27 at 12 02 22 pm" src="https://user-images.githubusercontent.com/18662734/50489794-51658a00-09cf-11e9-983d-03c0caaa65b0.png">

