### PR TITLE
Patternlab/DP 5232  Fix print styles: remove feedback button

### DIFF
--- a/assets/scss/08-print/_print.scss
+++ b/assets/scss/08-print/_print.scss
@@ -34,7 +34,7 @@
   .ma__content-eyebrow__tags,
   .ma__page-header__tags,
   .ma__footer,
-  #feedback,
+  .ma__fixed-feedback-button,
   .messages--error,
   *[aria-hidden="true"],
   .ma__download-link__icon,
@@ -57,7 +57,8 @@
   .ma__page-banner--small .ma__page-banner__icon,
   .ma__banner-carousel,
   .ma__quick-actions,
-  .ma__wait-time {
+  .ma__wait-time,
+  .ma__video {
     display: none !important;
   }
 

--- a/changelogs/DP-5232.txt
+++ b/changelogs/DP-5232.txt
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+Changed
+patch
+- patternlab / DP-5232: Fix print styles: remove feedback button


### PR DESCRIPTION
## Description
Hides the feedback button and video wrappers in print styles

## Related Issue / Ticket

- [DP-5232](https://jira.mass.gov/browse/DP-5232)

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. From any page, open the print preview to see the feedback button is hidden
2. From the service page in Mayflower, open the print preview to see the video wrapper is hidden

