### PR TITLE
DP-9186: change section tags to divs on rich text pattern

### DIFF
--- a/patternlab/styleguide/source/_patterns/03-organisms/by-author/rich-text.twig
+++ b/patternlab/styleguide/source/_patterns/03-organisms/by-author/rich-text.twig
@@ -1,7 +1,7 @@
 {% set headerIndent =  richText.headerIndent ? ' js-ma-outline-indent' : '' %}
 {% set anchorLinks = richText.anchorLinks ? ' js-ma-insert-heading-anchors' : '' %}
 
-<section class="ma__rich-text js-ma-rich-text{{headerIndent}}{{anchorLinks}}">
+<div class="ma__rich-text js-ma-rich-text{{headerIndent}}{{anchorLinks}}">
   {% if richText.compHeading %}
     {% set compHeading = richText.compHeading %}
     {% include "@atoms/04-headings/comp-heading.twig" %}
@@ -25,4 +25,4 @@
       {% include "@atoms/decorative-link.twig" %}
     </div>
   {% endif %}
-</section>
+</div>


### PR DESCRIPTION
## Description
Change section tags to div tags on rich text pattern for better semantics. 

## Related Issue / Ticket

- [DP-9186](https://jira.mass.gov/browse/DP-9186)


## Steps to Test

1. Visit an information details page and inspect one of the rich text sections to see that the section tags have been changed to divs 

## Screenshots
<img width="760" alt="screen shot 2018-12-28 at 10 56 55 am" src="https://user-images.githubusercontent.com/18662734/50522205-5558e100-0a8f-11e9-9796-55af65b82cd1.png">


