### PR TITLE
Patternlab/DP-9775  MF Adjust print styles for topic and org pages to have less space at top.

### DIFF
--- a/assets/scss/08-print/_print.scss
+++ b/assets/scss/08-print/_print.scss
@@ -197,6 +197,28 @@
     }
   }
 
+  .ma__page-banner--columns {
+    min-height: 0 !important;
+    margin: 0 !important;
+    padding: 0 !important;
+
+    .ma__page-banner__content {
+      height: auto !important;
+      top: auto !important;
+    }
+
+    .ma__page-banner__container {
+      min-height: 0 !important;
+    }
+
+    .ma__page-banner__description {
+      padding: 0 !important;
+      float: none !important;
+      width: 100% !important;
+      max-width: none;
+    }
+  }
+
   .main-content {
     margin-bottom: 0;
   }

--- a/assets/scss/08-print/_print.scss
+++ b/assets/scss/08-print/_print.scss
@@ -117,6 +117,10 @@
     }
   }
 
+  .ma__organization-navigation {
+    display: none !important;
+  }
+
   .sidebar--colored .ma__comp-heading {
     padding-left: 0;
     margin-left: 0;
@@ -145,11 +149,15 @@
     background-repeat: no-repeat;
     background-size: cover;
     -webkit-print-color-adjust: exact;
-
+  }
+  
+  .ma__relationship-indicators {
+    display: none !important;
   }
 
   .ma__page-banner {
     margin-bottom: 0;
+    margin-top: 0 !important;
     padding: 0;
     min-height: 0;
     height: auto;
@@ -184,7 +192,7 @@
       width: 100%;
       height: auto;
       top: 0;
-      max-width: none;
+      max-width: none !important;
       color: $c-font-heading;
 
       &::before, {
@@ -217,6 +225,14 @@
       width: 100% !important;
       max-width: none;
     }
+  }
+
+  .ma__page-banner--large {
+    height: auto !important; 
+    width: 100% !important;
+    max-width: none;
+    margin-right: 0 !important;
+    margin-bottom: 20px;
   }
 
   .main-content {

--- a/changelogs/DP-9775.txt
+++ b/changelogs/DP-9775.txt
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+Changed
+Patch
+- patternlab / DP-9775: MF Adjust print styles for topic and org pages to have less space at top.


### PR DESCRIPTION
## Description
Updates banners for print styles on org and topic pages

## Related Issue / Ticket

- [DP-9775](https://jira.mass.gov/browse/DP-9775)

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. From a topic page, open the print preview to check the banner height
2. From an organization page, open the print preview to check the banner height

## Screenshots
<img width="504" alt="screen shot 2018-12-28 at 12 01 06 pm" src="https://user-images.githubusercontent.com/18662734/50524040-1596f700-0a99-11e9-9afe-8380f6ba8b11.png">
<img width="506" alt="screen shot 2018-12-28 at 12 01 29 pm" src="https://user-images.githubusercontent.com/18662734/50524044-17f95100-0a99-11e9-81be-574d3ae910a4.png">


