### PR TITLE
[React] DP-11888: Budget & Mayflower: Tabs & Anchor Link.

### DIFF
--- a/changelogs/DP-11888.txt
+++ b/changelogs/DP-11888.txt
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+Changed
+Minor
+- (React) DP-11888: Adds the ability to pass a function to tabs to run after its default click handler.

--- a/react/src/components/organisms/TabContainer/index.js
+++ b/react/src/components/organisms/TabContainer/index.js
@@ -49,6 +49,7 @@ class TabContainer extends React.Component {
     );
   }
 }
+TabContainer.contextType = TabContext;
 
 TabContainer.defaultProps = {
   nested: false,

--- a/react/src/components/organisms/TabContainer/tab.js
+++ b/react/src/components/organisms/TabContainer/tab.js
@@ -51,10 +51,11 @@ Tab.defaultProps = {
 };
 
 Tab.propTypes = {
-  // When true, the tab will be open by default when used with TabContainer.
+   /** When true, the tab will be open by default when used with TabContainer. */
   default: PropTypes.bool,
-  // The text of the tab.
+   /** The text of the tab. */
   title: PropTypes.string.isRequired,
+  /** A callback function ran after the tab has been clicked. */
   handleClick: PropTypes.func
 };
 

--- a/react/src/components/organisms/TabContainer/tab.js
+++ b/react/src/components/organisms/TabContainer/tab.js
@@ -32,6 +32,9 @@ class Tab extends React.Component {
               onClick={(e) => {
                 e.target.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' });
                 setActiveTab(this.tabIdent, this.props.children);
+                if (typeof this.props.handleClick === 'function') {
+                  this.props.handleClick(e, this.tabIdent, this.props.children);
+                }
               }}
             >
               {this.props.title}
@@ -51,7 +54,8 @@ Tab.propTypes = {
   // When true, the tab will be open by default when used with TabContainer.
   default: PropTypes.bool,
   // The text of the tab.
-  title: PropTypes.string.isRequired
+  title: PropTypes.string.isRequired,
+  handleClick: PropTypes.func
 };
 
 export default Tab;


### PR DESCRIPTION
## Description
This adds the ability for the Tab component (used with TabContainer) to accept a function that's ran after the onClick function runs.

## Related Issue / Ticket
- [JIRA issue](https://jira.mass.gov/browse/DP-11888)

## Steps to Test
1. Pull the branch and ensure that the TabContainer and Tab components have no errors in storybook.
