### PR TITLE
DP-11437 MF Location search by city/zip doesn't work if you click a map marker first

### DIFF
--- a/changelogs/DP-11437.txt
+++ b/changelogs/DP-11437.txt
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+Fixed
+Patch
+- (Patternlab) DP-11437: MF Location search by city/zip fix for autocomplete issue.

--- a/patternlab/styleguide/source/assets/js/modules/locationListing.js
+++ b/patternlab/styleguide/source/assets/js/modules/locationListing.js
@@ -307,7 +307,9 @@ export default (function (window, document, $) {
     if (listings.hasFilter(filteredData.resultsHeading.tags, "location")) {
       place = listings.getFilterValues(filteredData.resultsHeading.tags, "location")[0]; // returns array
       // If place argument was selected from the locationFilter autocomplete (initiated on the zipcode text input).
-      let autocompletePlace = ma.autocomplete.getPlace();
+      if (typeof ma.autocomplete !== "undefined") {
+        let autocompletePlace = ma.autocomplete.getPlace();
+      }
       // Geocode the address, then sort the markers and instance of locationListing masterData.
       ma.geocoder = ma.geocoder ? ma.geocoder : new google.maps.Geocoder();
       if (typeof autocompletePlace !== "undefined" && autocompletePlace.hasOwnProperty("place_id")) {


### PR DESCRIPTION
## Description
Updating JS to fix autocomplete error when searching city/zip.

## Related Issue / Ticket

- [https://jira.mass.gov/browse/DP-11437]

## Steps to Test
See the steps outlined for recreating this issue in: https://jira.mass.gov/browse/DP-11437
Note: I was only able to get this error to be reproduced for me by using IE11 inside browserstack
