### PR TITLE
React/DP-12183: Fixes spacing issue in IE for decorative link

### DIFF
--- a/assets/scss/01-atoms/_decorative-link.scss
+++ b/assets/scss/01-atoms/_decorative-link.scss
@@ -40,7 +40,7 @@
       position: relative;
 
       svg {
-        margin-right: unset;
+        margin-right: 0;
         width: 29px;
         height: 30px;
       }

--- a/changelogs/DP-12183.txt
+++ b/changelogs/DP-12183.txt
@@ -1,0 +1,3 @@
+___DESCRIPTION___
+Patch - Fixed
+- (React) DP-12183: Fixes alignment issue of download icon in the decorative link react component in IE11 #403


### PR DESCRIPTION
## Description
Fixes alignment issue of download icon in the decorative link react component in IE11

## Related Issue / Ticket

- [DP-12183](https://jira.mass.gov/browse/DP-12183)

## Screenshots
Before
<img width="186" alt="screen shot 2019-01-14 at 12 11 41 pm" src="https://user-images.githubusercontent.com/9359261/51141820-3a6cc780-1818-11e9-9b7d-516687ff7330.png">

After
<img width="804" alt="screen shot 2019-01-14 at 4 19 32 pm" src="https://user-images.githubusercontent.com/9359261/51141829-3f317b80-1818-11e9-9914-bec428322d1f.png">
