### PR TITLE
React/DP-11667: a11y Add missing role to header search

### DIFF
--- a/changelogs/DP-11667.txt
+++ b/changelogs/DP-11667.txt
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+Fixed
+Path
+- (React) DP-11667: Add search role to HeaderSearch molecule for a11y. #405

--- a/react/src/components/molecules/HeaderSearch/index.js
+++ b/react/src/components/molecules/HeaderSearch/index.js
@@ -37,7 +37,7 @@ class HeaderSearch extends React.Component {
           </div>
         }
         <section className="ma__header-search">
-          <form action="#" className="ma__form" onSubmit={headerSearch.onSubmit}>
+          <form action="#" className="ma__form" onSubmit={headerSearch.onSubmit} role="search">
             <label
               htmlFor={headerSearch.id}
               className="ma__header-search__label"


### PR DESCRIPTION
## Description
Adds search role to React HeaderSearch molecule for a11y.

## Related Issue / Ticket

- [DP-11667](https://jira.mass.gov/browse/DP-11667)

## Steps to Test
1. `npm install`
2. `npm start`
3. navigate to the headersearch story to confirm the role is assigned.
