### PR TITLE
React/DP-11683: [a11y] Title not rendered in Decorative Link Atom

### DIFF
--- a/changelogs/DP-11683.txt
+++ b/changelogs/DP-11683.txt
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+Fixed
+Patch
+- (React) DP-11683: Set a condition in the decorative link atom to only add title when its value is available. #407

--- a/changelogs/DP-11684.txt
+++ b/changelogs/DP-11684.txt
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+Fixed
+Patch
+- (React) DP-11683: Hides arrow in decorative link so not read by the screen reader. #407

--- a/react/src/components/atoms/links/DecorativeLink/index.js
+++ b/react/src/components/atoms/links/DecorativeLink/index.js
@@ -38,7 +38,7 @@ const DecorativeLink = (props) => {
       <a
         href={props.href}
         className="js-clickable-link"
-        title={props.info}
+        title={props.info || false}
       >
         {decIcon && <span className="ma__download-link--icon">{decIcon}&nbsp;</span>}{props.text}&nbsp;<Icon name="arrow" />
       </a>
@@ -55,7 +55,6 @@ DecorativeLink.propTypes = {
 
 DecorativeLink.defaultProps = {
   href: '#',
-  info: '',
   text: 'Lorem ipsum dolor sit amet',
   showFileIcon: false
 };

--- a/react/src/components/atoms/links/DecorativeLink/index.js
+++ b/react/src/components/atoms/links/DecorativeLink/index.js
@@ -40,7 +40,7 @@ const DecorativeLink = (props) => {
         className="js-clickable-link"
         title={props.info || false}
       >
-        {decIcon && <span className="ma__download-link--icon">{decIcon}&nbsp;</span>}{props.text}&nbsp;<Icon name="arrow" aria-hidden="true"/>
+        {decIcon && <span className="ma__download-link--icon">{decIcon}&nbsp;</span>}{props.text}&nbsp;<Icon name="arrow" aria-hidden="true" />
       </a>
     </span>
   );

--- a/react/src/components/atoms/links/DecorativeLink/index.js
+++ b/react/src/components/atoms/links/DecorativeLink/index.js
@@ -40,7 +40,7 @@ const DecorativeLink = (props) => {
         className="js-clickable-link"
         title={props.info || false}
       >
-        {decIcon && <span className="ma__download-link--icon">{decIcon}&nbsp;</span>}{props.text}&nbsp;<Icon name="arrow" />
+        {decIcon && <span className="ma__download-link--icon">{decIcon}&nbsp;</span>}{props.text}&nbsp;<Icon name="arrow" aria-hidden="true"/>
       </a>
     </span>
   );


### PR DESCRIPTION
## Description
Set a condition in the decorative link atom to only add title when its value is available. Hides arrow in decorative link so not read by the screen reader.

## Related Issue / Ticket

- [DP-11683](https://jira.mass.gov/browse/DP-11683)
- [DP-11684](https://jira.mass.gov/browse/DP-11684)