### PR TITLE
react/DP-12080: Add passable id prop to the input tag InputTextFuzzy atom

### DIFF
--- a/changelogs/DP-12080.txt
+++ b/changelogs/DP-12080.txt
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+Fixed/Added
+Minor
+- (React) DP-12080: Add capacity to pass an id to the input tag of the InputTextFuzzy atom.

--- a/react/src/components/atoms/forms/InputTextFuzzy/InputTextFuzzy.stories.js
+++ b/react/src/components/atoms/forms/InputTextFuzzy/InputTextFuzzy.stories.js
@@ -19,6 +19,7 @@ storiesOf('atoms/forms', module).addDecorator(withKnobs)
         options: inputOptions.options.orgSelector.filter((option) => option.text !== ''),
         placeholder: text('InputTextFuzzy.placeholder', 'All Organizations'),
         id: text('InputTextFuzzy.id', 'org-typeahead'),
+        inputId: text('InputTextFuzzy.inputId', 'input-org-typeahead'),
         selected: select(
           'InputTextFuzzy.selected',
           inputOptions.options.orgSelector.map((option) => option.text),

--- a/react/src/components/atoms/forms/InputTextFuzzy/index.js
+++ b/react/src/components/atoms/forms/InputTextFuzzy/index.js
@@ -75,6 +75,7 @@ class InputTextFuzzy extends React.Component {
         onChange: this.handleChange,
         value: this.state.value,
         disabled: this.props.disabled,
+        id: this.props.inputId,
         onKeyDown: (event, { newHighlightedSectionIndex, newHighlightedItemIndex }) => {
           switch(event.key) {
             case 'ArrowDown':
@@ -177,7 +178,7 @@ class InputTextFuzzy extends React.Component {
     });
     return(
       <React.Fragment>
-        {this.props.label && (<label htmlFor={this.props.id} className="ma__label">{this.props.label}</label>)}
+        {this.props.label && (<label htmlFor={this.props.inputId} className="ma__label">{this.props.label}</label>)}
         <div className={inputTextTypeAheadClasses}>
           <Autowhatever {...autoProps} />
         </div>
@@ -209,6 +210,8 @@ InputTextFuzzy.propTypes = {
   onSuggestionClick: PropTypes.func,
   /** The default value for the select box. */
   selected: PropTypes.string,
+  /** The id of the the input tag */
+  inputId: PropTypes.string
 };
 
 InputTextFuzzy.defaultProps = {


### PR DESCRIPTION
## Description
Add capacity to pass an id to the input tag of the InputTextFuzzy atom.

## Related Issue / Ticket
- [DP-12080(https://jira.mass.gov/browse/DP-12080)
