### PR TITLE
DP-11662 utility nav container

### DIFF
--- a/changelogs/DP-11662.txt
+++ b/changelogs/DP-11662.txt
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+Changed
+Minor
+- (Patternlab/React) DP-11662: Replace the markup validation flagged elements <section> with <div> for .ma__utility-nav and .ma__utility-panel.

--- a/patternlab/styleguide/source/_patterns/03-organisms/by-template/utility-nav.twig
+++ b/patternlab/styleguide/source/_patterns/03-organisms/by-template/utility-nav.twig
@@ -1,4 +1,4 @@
-<section class="ma__utility-nav js-util-nav">
+<div class="ma__utility-nav js-util-nav">
   <ul class="ma__utility-nav__items">
     {% if googleLanguages %}
       <li class="ma__utility-nav__item">
@@ -36,4 +36,4 @@
       </li>
     {% endfor %}
   </ul>
-</section>
+</div>

--- a/patternlab/styleguide/source/_patterns/03-organisms/by-template/utility-panel.twig
+++ b/patternlab/styleguide/source/_patterns/03-organisms/by-template/utility-panel.twig
@@ -1,4 +1,4 @@
-<section class="ma__utility-panel">
+<div class="ma__utility-panel">
   <div class="ma__utility-panel__description {{ utilityPanel.links ? '' : 'ma__utility-panel__description--full' }}">
     {% set richText = utilityPanel.description.richText %}
     {% include "@organisms/by-author/rich-text.twig" %}
@@ -10,4 +10,4 @@
       </li>
     {% endfor %}
   </ul>
-</section>
+</div>

--- a/react/src/components/organisms/UtilityNav/index.js
+++ b/react/src/components/organisms/UtilityNav/index.js
@@ -31,7 +31,7 @@ class UtilityNav extends Component {
     const { navSelected } = this.state;
     const { googleLanguages, items } = this.props;
     return((
-      <section className="ma__utility-nav js-util-nav">
+      <div className="ma__utility-nav js-util-nav">
         <ul className="ma__utility-nav__items">
           {googleLanguages && <GoogleLanguages />}
           {items.map((item, itemIndex) => {
@@ -47,7 +47,7 @@ class UtilityNav extends Component {
               );
           })}
         </ul>
-      </section>
+      </div>
     ));
   }
 }

--- a/react/src/components/organisms/UtilityPanel/index.js
+++ b/react/src/components/organisms/UtilityPanel/index.js
@@ -12,7 +12,7 @@ const UtilityPanel = (utilityPanel) => {
     descriptionClasses.push('ma__utility-panel__description--full');
   }
   return(
-    <section className="ma__utility-panel">
+    <div className="ma__utility-panel">
       <div className={descriptionClasses.join(' ')}>
         <Paragraph {...utilityPanel.description} />
       </div>
@@ -24,7 +24,7 @@ const UtilityPanel = (utilityPanel) => {
           </li>
         ))}
       </ul>
-    </section>
+    </div>
   );
 };
 


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/dev/docs/change-log-instructions.md)


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
Replace the markup validation flagged elements with valid elements.
In this case, `<section>` requires a heading for it. Looking though the markup, it's not necessary to use `<section>`.  The change doesn't affect the component's functionality or its visual.


## Related Issue / Ticket

- [DP-11662](https://jira.mass.gov/browse/DP-11662)

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Check the markup for the utility nav on both React and Patternlab. No `<section>` is used in the area.
     - `.ma__utility-nav`
     - `.ma__utility-panel`

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* 

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
