### PR TITLE
DP-11666 .ma__header-search container

### DIFF
--- a/changelogs/DP-11666.txt
+++ b/changelogs/DP-11666.txt
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+Changed
+Minor
+- (Patternlab/React) DP-11666: Replace <section> with <div> for.ma__header-search  #417#

--- a/patternlab/styleguide/source/_patterns/02-molecules/header-search.twig
+++ b/patternlab/styleguide/source/_patterns/02-molecules/header-search.twig
@@ -1,5 +1,5 @@
-<section class="ma__header-search">
-  <form action="#" class="ma__form js-header-search-form">
+<div class="ma__header-search">
+  <form action="#" class="ma__form js-header-search-form" role="search">
     <label
         for="{{headerSearch.id}}"
         class="ma__header-search__label">{{headerSearch.label}}</label>
@@ -11,4 +11,4 @@
     {% set buttonSearch = headerSearch.buttonSearch %}
     {% include "@atoms/01-buttons/button-search.twig" %}
   </form>
-</section>
+</div>

--- a/react/src/components/molecules/HeaderSearch/index.js
+++ b/react/src/components/molecules/HeaderSearch/index.js
@@ -36,7 +36,7 @@ class HeaderSearch extends React.Component {
             <TypeAheadDropdown {...orgDropdown} />
           </div>
         }
-        <section className="ma__header-search">
+        <div className="ma__header-search">
           <form action="#" className="ma__form" onSubmit={headerSearch.onSubmit} role="search">
             <label
               htmlFor={headerSearch.id}
@@ -57,7 +57,7 @@ class HeaderSearch extends React.Component {
             </div>
             <ButtonWithIcon {...headerSearch.buttonSearch} />
           </form>
-        </section>
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/dev/docs/change-log-instructions.md)


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
Replace the markup validation flagged elements with valid elements.
In this case, `<section>` requires a heading for it. Looking though the markup, it's not necessary to use `<section>`. The change doesn't affect the component's functionality or its visual.

[Patternlab only] A missing, `role="search"`, is added to `<form>`. 

## Related Issue / Ticket

- [DP-11666](https://jira.mass.gov/browse/DP-11666)

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Check the markup for the header search on both React and Patternlab. No `<section>` is used with `.ma__header-search` container.

2. [Patternlab only] Find `<form>` has `role="search"`.  It's consistent to React.


## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* 

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
