### PR TITLE
Patternlab/DP-12387 add block step-order and action-step twig

### DIFF
--- a/changelogs/DP-12387.txt
+++ b/changelogs/DP-12387.txt
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+Added
+Minor
+- (Patternlab) DP-12387: Added a block formDownloads to the steps-ordered.twig to use a view mode on the Drupal twig. #428

--- a/changelogs/DP-12387.txt
+++ b/changelogs/DP-12387.txt
@@ -1,4 +1,4 @@
 ___DESCRIPTION___
 Added
 Minor
-- (Patternlab) DP-12387: Added a block formDownloads to the steps-ordered.twig to use a view mode on the Drupal twig. #428
+- (Patternlab) DP-12387: Added a block to the steps-ordered.twig and action-step.twig to use a view mode on the Drupal twig. #428

--- a/patternlab/styleguide/source/_patterns/02-molecules/action-step.twig
+++ b/patternlab/styleguide/source/_patterns/02-molecules/action-step.twig
@@ -24,10 +24,12 @@
   <div class="ma__action-step__content {{ accordion ? 'js-accordion-content' : '' }}">
   {% set richText = actionStep.richText %}
   {% include "@organisms/by-author/rich-text.twig" %}
-  {% if actionStep.downloadLinks %}
-    {% set formDownloads = { "downloadLinks": actionStep.downloadLinks } %}
-    {% include "@organisms/by-author/form-downloads.twig" %}
-  {% endif %}
+  {% block formDownloads %}
+    {% if actionStep.downloadLinks %}
+      {% set formDownloads = { "downloadLinks": actionStep.downloadLinks } %}
+      {% include "@organisms/by-author/form-downloads.twig" %}
+      {% endif %}
+  {% endblock %}
   {% if actionStep.decorativeLink %}
     <div class="ma__action-step__more">
       {% set decorativeLink = actionStep.decorativeLink %}

--- a/patternlab/styleguide/source/_patterns/03-organisms/by-author/steps-ordered.twig
+++ b/patternlab/styleguide/source/_patterns/03-organisms/by-author/steps-ordered.twig
@@ -11,17 +11,19 @@
     {% include "@atoms/04-headings/sidebar-heading.twig" %}
     {% set stepHeading = (sidebarHeading.level ? : stepHeading) + 1 %}
   {% endif %}
-  {% if stepsOrdered.steps|length > 1 %}
-    <ol class="ma__steps-ordered__items">
-      {% for actionStep in stepsOrdered.steps %}
-        <li class="ma__steps-ordered__item">
-          {% set actionStep = actionStep|merge({"level":stepHeading}) %}
-          {% include "@molecules/action-step.twig" %}
-        </li>
-      {% endfor %}
-    </ol>
-  {% else %}
-    {% set actionStep = stepsOrdered.steps|first|merge({"level":stepHeading}) %}
-    {% include "@molecules/action-step.twig" %}
-  {% endif %}
+  {% block formDownloads %}
+    {% if stepsOrdered.steps|length > 1 %}
+      <ol class="ma__steps-ordered__items">
+        {% for actionStep in stepsOrdered.steps %}
+          <li class="ma__steps-ordered__item">
+            {% set actionStep = actionStep|merge({"level":stepHeading}) %}
+            {% include "@molecules/action-step.twig" %}
+          </li>
+          {% endfor %}
+        </ol>
+    {% else %}
+      {% set actionStep = stepsOrdered.steps|first|merge({"level":stepHeading}) %}
+      {% include "@molecules/action-step.twig" %}
+    {% endif %}
+  {% endblock %}
 </section>

--- a/patternlab/styleguide/source/_patterns/03-organisms/by-author/steps-ordered.twig
+++ b/patternlab/styleguide/source/_patterns/03-organisms/by-author/steps-ordered.twig
@@ -11,7 +11,7 @@
     {% include "@atoms/04-headings/sidebar-heading.twig" %}
     {% set stepHeading = (sidebarHeading.level ? : stepHeading) + 1 %}
   {% endif %}
-  {% block formDownloads %}
+  {% block actionSteps %}
     {% if stepsOrdered.steps|length > 1 %}
       <ol class="ma__steps-ordered__items">
         {% for actionStep in stepsOrdered.steps %}


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/dev/docs/change-log-instructions.md)


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
Needed to add a block to the step-order.twig and action-step.twig to allow the view mode to display the change to the document URLs on the how-to page. 

## Related Issue / Ticket

- [Jira Issue DP-12387](https://jira.mass.gov/browse/DP-12387)
- [Github issue]()

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. 

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* 

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
