### PR TITLE
DP-9204 [a11y] Video transcription access

### DIFF
--- a/assets/scss/01-atoms/_video.scss
+++ b/assets/scss/01-atoms/_video.scss
@@ -3,6 +3,13 @@
 
   &__container {
     padding: 13px;
+
+    position: relative;
+    padding-bottom: 12px + 29px + 13px;// 12px + 1.5rem + 13px
+
+    @media ($bp-large-min) {
+      padding-bottom: 12px + 32px + 13px;
+    }
   }
 
   @media ($bp-small-min) {
@@ -38,6 +45,9 @@
 
   &__link {
     margin-top: 12px;
+
+    position: absolute;
+    bottom: 13px;
   }
 }
 

--- a/changelogs/DP-9204.txt
+++ b/changelogs/DP-9204.txt
@@ -1,4 +1,4 @@
 ___DESCRIPTION___
 Changed
 Minor
-- (Patternlab) DP-9204: Add a label to the video container. Change the reading order to 1. label, 2. transcript link, 3. video for screenreader users. #PR#
+- (Patternlab) DP-9204: Add a label to the video container. Change the reading order to 1. label, 2. transcript link, 3. video for screenreader users. #433#

--- a/changelogs/DP-9204.txt
+++ b/changelogs/DP-9204.txt
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+Changed
+Minor
+- (Patternlab) DP-9204: Add a label to the video container. Change the reading order to 1. label, 2. transcript link, 3. video for screenreader users. #PR#

--- a/patternlab/styleguide/source/_patterns/01-atoms/09-media/video.twig
+++ b/patternlab/styleguide/source/_patterns/01-atoms/09-media/video.twig
@@ -1,7 +1,7 @@
 {% set posClass = video.position ? "ma__video--" ~ video.position : '' %}
   {# backward compatibile with v5.6 - toggle new styles with ma__video--new #}
-<div class="ma__video ma__video--new {{ posClass }}">
-  <div class="ma__video__container js-ma-responsive-video" aria-label="Video {{ video.label }}"{% if not video.link %} style="padding-bottom: 13px;"{% endif %}>
+<div class="ma__video ma__video--new {{ posClass }}" aria-label="Video {{ video.label }}">
+  <div class="ma__video__container js-ma-responsive-video"{% if not video.link %} style="padding-bottom: 13px;"{% endif %}>
     {% if video.link %}
       <div class="ma__video__link">
       {% set video = video|merge({'link': {

--- a/patternlab/styleguide/source/_patterns/01-atoms/09-media/video.twig
+++ b/patternlab/styleguide/source/_patterns/01-atoms/09-media/video.twig
@@ -1,13 +1,19 @@
 {% set posClass = video.position ? "ma__video--" ~ video.position : '' %}
   {# backward compatibile with v5.6 - toggle new styles with ma__video--new #}
 <div class="ma__video ma__video--new {{ posClass }}">
-  <div class="ma__video__container js-ma-responsive-video">
-    <iframe width="{{ video.width }}" height="{{ video.height }}" src="{{ video.src }}" frameborder="0" allowfullscreen aria-label="{{ video.label }}"></iframe>
+  <div class="ma__video__container js-ma-responsive-video" aria-label="Video {{ video.label }}"{% if not video.link %} style="padding-bottom: 13px;"{% endif %}>
     {% if video.link %}
       <div class="ma__video__link">
+      {% set video = video|merge({'link': {
+                                    'href': video.link.href,
+                                    'text': video.link.text,
+                                    'info': video.link.info,
+                                    'labelContext': video.label,
+                                    'property': video.link.property }}) %}
         {% set decorativeLink = video.link %}
         {% include "@atoms/decorative-link.twig" %}
       </div>
     {% endif %}
+    <iframe width="{{ video.width }}" height="{{ video.height }}" src="{{ video.src }}" frameborder="0" allowfullscreen aria-label="{{ video.label }}"></iframe>
   </div>
 </div>


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/dev/docs/change-log-instructions.md)


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
- Add the video component container a label, so screenreader users would know that contains video when they reach the container element, `div.ma__video`, **aria-label** tells screenreader users that contains video as "Video VIDEO TITLE".
- No visual change, but the reading order is changed to 1. video container label, 2. transcript link, then 3. video. So, screenreader users  can access transcript without going through the video.

## Related Issue / Ticket

- [DP-9204 \[a11y\] Video transcription access](https://jira.mass.gov/browse/DP-9204)
- [DP-9204 \[a11y\] Video transcription access #2965](https://github.com/massgov/mass/pull/2965)

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Go to http://localhost:3000/patterns/01-atoms-09-media-video/01-atoms-09-media-video.html.
2. Find aria-label on div.ma__video:
```
<div class="ma__video ma__video--new " aria-label="Video Using a gas grill safely">
...
```
3. In the `div.ma__video__container`, find `div.ma__video__link` which contains the transcription link comes first before `div.fluid-width-video-wrapper`.
```
...
   <div class="ma__video__container js-ma-responsive-video">
        <div class="ma__video__link">...</div>
        <div class="fluid-width-video-wrapper" style="padding-top: 56.272%;"><iframe src="https://www.youtube.com/embed/dEkUq-Rs-Tc" frameborder="0" allowfullscreen="" aria-label="Using a gas grill safely" id="fitvid994324"></iframe></div>
  </div>
</div>
```


## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* 

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
