### PR TITLE
pass value to callback for up/button onclick callback

### DIFF
--- a/changelogs/fix-input-number-callback.txt
+++ b/changelogs/fix-input-number-callback.txt
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+Fixed
+Patch
+- (React) bugfix: Allow InputNumber up/down button onClick callback to access value from input. #439

--- a/react/src/components/atoms/forms/InputNumber/index.js
+++ b/react/src/components/atoms/forms/InputNumber/index.js
@@ -50,7 +50,7 @@ const NumberInput = (props) => (
             context.updateState({ value: floatValue, ...updateError });
 
             if (typeof props.onChange === 'function') {
-              props.onChange(e);
+              props.onChange(e, floatValue);
             }
           };
 
@@ -64,7 +64,7 @@ const NumberInput = (props) => (
             const updateError = displayErrorMessage(newValue, props.min, props.max, props.required);
             context.updateState({ value: newValue, ...updateError });
             if (typeof props.onChange === 'function') {
-              props.onChange(e);
+              props.onChange(e, newValue);
             }
           };
 


### PR DESCRIPTION
currently in calculators, up/down buttons onclick don't get the value from input. This pr allows onChange function to get the value.