### PR TITLE
Release 8.23.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 **For example**
 - DP-1234: The short description text on a [service detail](http://mayflower.digital.mass.gov/?p=pages-detail-for-service-howto-location) page banner ([@organisms/by-template/page-banner](http://mayflower.digital.mass.gov/?p=organisms-page-banner)) should now render ([PR #493](https://github.com/massgov/mayflower/pull/493))
 
+## 8.23.2 (01/30/2019)
+
+### Fixed
+- (React) hotfix: preventDefault inputSlider handle onClick.
+
 ## 8.23.1 (01/30/2019)
 
 ### Fixed

--- a/react/src/components/atoms/forms/CompoundSlider/index.js
+++ b/react/src/components/atoms/forms/CompoundSlider/index.js
@@ -20,6 +20,9 @@ const Handle = (props) => {
     'aria-valuemax': max,
     'aria-valuenow': roundedValue,
     role: 'slider',
+    onClick: (e) => {
+      e.preventDefault();
+    },
     ...getHandleProps(id)
   };
   if (axis === 'x') {


### PR DESCRIPTION
## 8.23.2 (01/30/2019)

### Fixed
- (React) hotfix: preventDefault inputSlider handle onClick.