### PR TITLE
DP-12464/DP-9464 Add block for decorative link

### DIFF
--- a/changelogs/DP-12464.txt
+++ b/changelogs/DP-12464.txt
@@ -1,0 +1,3 @@
+Added
+Minor
+- (Patternlab) DP-12464: Added a block to the action-steps.twig for decorativeLink.

--- a/changelogs/DP-9464.txt
+++ b/changelogs/DP-9464.txt
@@ -1,3 +1,0 @@
-Added
-Minor
-- (Patternlab) DP-9464: Added a block to the action-steps.twig for decorativeLink.

--- a/changelogs/DP-9464.txt
+++ b/changelogs/DP-9464.txt
@@ -1,0 +1,3 @@
+Added
+Minor
+- (Patternlab) DP-9464: Added a block to the action-steps.twig for decorativeLink.

--- a/patternlab/styleguide/source/_patterns/02-molecules/action-step.twig
+++ b/patternlab/styleguide/source/_patterns/02-molecules/action-step.twig
@@ -30,10 +30,12 @@
       {% include "@organisms/by-author/form-downloads.twig" %}
       {% endif %}
   {% endblock %}
+  {% block decorativeLink %}
   {% if actionStep.decorativeLink %}
     <div class="ma__action-step__more">
       {% set decorativeLink = actionStep.decorativeLink %}
       {% include "@atoms/decorative-link.twig" %}
     </div>
   {% endif %}
+  {% endblock %}
 </section>


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/dev/docs/change-log-instructions.md)


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
To fix the display of the decorative link for How-to pages that are using the Next Step links.

## Related Issue / Ticket

- [JIRA issue](https://jira.mass.gov/browse/DP-12464)
- [Github issue]()

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Check https://mayflower.digital.mass.gov/?p=molecules-action-step to see if any changes to display of the decorative link for the `Learn more`

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* 

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
