### PR TITLE
React/dp 12807 hotfix

### DIFF
--- a/changelogs/DP-12807.txt
+++ b/changelogs/DP-12807.txt
@@ -1,0 +1,5 @@
+___DESCRIPTION___
+Fixed
+Patch
+- (React) DP-12807: Prevent InputCurrency returning NaN when default value is set to null #484
+- (React) DP-12806: Fix error message inline styling #484

--- a/react/src/components/atoms/forms/Input/style.scss
+++ b/react/src/components/atoms/forms/Input/style.scss
@@ -14,7 +14,6 @@
     #{$group}-right {
       display: flex;
         flex-direction: column;
-        align-items: flex-end;
         @media ($bp-small-max) {
           align-items: flex-start;
         }

--- a/react/src/components/atoms/forms/InputCurrency/index.js
+++ b/react/src/components/atoms/forms/InputCurrency/index.js
@@ -82,12 +82,14 @@ const Currency = (props) => (
               stringValue = context.value;
             }
             const numberValue = numbro.unformat(stringValue);
+            // default to 0 if defaultValue is NaN
+            const baseValue = numberValue || 0;
             if (!Number.isNaN(numberValue)) {
               let newValue;
               if (direction === 'up') {
-                newValue = Number(Number.parseFloat(numberValue + props.step).toFixed(2));
+                newValue = Number(Number.parseFloat(baseValue + props.step).toFixed(2));
               } else if (direction === 'down') {
-                newValue = Number(Number.parseFloat(numberValue - props.step).toFixed(2));
+                newValue = Number(Number.parseFloat(baseValue - props.step).toFixed(2));
               }
               const { showError, errorMsg } = validNumber(newValue, props.min, props.max);
               context.updateState({ showError, errorMsg, value: toCurrency(newValue, 2) }, () => {


### PR DESCRIPTION
Fixed
Patch
- (React) DP-12807: Prevent InputCurrency returning NaN when default value is set to null #484
![screen shot 2019-02-21 at 4 09 45 pm](https://user-images.githubusercontent.com/5789411/53203694-dd72e700-35f7-11e9-8574-d661851bf6d8.png)


- (React) DP-12806: Fix error message inline styling #484
Before:
![screen shot 2019-02-21 at 4 07 48 pm](https://user-images.githubusercontent.com/5789411/53203652-bc11fb00-35f7-11e9-852b-3df6d9144cc8.png)
after:
![screen shot 2019-02-21 at 4 07 51 pm](https://user-images.githubusercontent.com/5789411/53203655-be745500-35f7-11e9-882e-bcb61579af8c.png)
