### PR TITLE
fix error message positioning

### DIFF
--- a/assets/scss/01-atoms/_error-msg.scss
+++ b/assets/scss/01-atoms/_error-msg.scss
@@ -6,6 +6,7 @@
   line-height: 1.2rem;
   margin: .3em 0;
   font-weight: 500;
+  width: 100%;
 
  svg {
    flex: 0 0 1.2rem;

--- a/react/src/components/atoms/forms/Input/style.scss
+++ b/react/src/components/atoms/forms/Input/style.scss
@@ -14,6 +14,7 @@
     #{$group}-right {
       display: flex;
         flex-direction: column;
+        align-items: flex-end;
         @media ($bp-small-max) {
           align-items: flex-start;
         }


### PR DESCRIPTION
<img width="445" alt="screen shot 2019-02-22 at 4 57 31 pm" src="https://user-images.githubusercontent.com/5789411/53350827-ee6c7280-38ed-11e9-8da7-ea28d63f8abc.png">

before:
![screen shot 2019-02-25 at 11 10 55 am](https://user-images.githubusercontent.com/5789411/53350867-0c39d780-38ee-11e9-9822-51acd9a64ed6.png)
