### PR TITLE
Patternlab/Add class for GTM

### DIFF
--- a/changelogs/DP-12928.md
+++ b/changelogs/DP-12928.md
@@ -1,1 +1,3 @@
+Patch
+Added
 (Patternlab) [OrganizationNavigation] DP-12928: Add Subnav specific class to sections for GTA. #504

--- a/changelogs/DP-12928.md
+++ b/changelogs/DP-12928.md
@@ -1,0 +1,1 @@
+(Patternlab) [OrganizationNavigation] DP-12928: Add Subnav specific class to sections for GTA. #504

--- a/changelogs/DP-12928.md
+++ b/changelogs/DP-12928.md
@@ -1,3 +1,3 @@
 Patch
 Added
-(Patternlab) [OrganizationNavigation] DP-12928: Add Subnav specific class to sections for GTA. #504
+(Patternlab) [OrganizationNavigation] DP-12928: Add link list specific classes: `ma__org-nav-i-want-to__findService`, `ma__org-nav-i-want-to__learnAbout`,`ma__org-nav-i-want-to__login` to sections for GTM. #504

--- a/patternlab/styleguide/source/_patterns/03-organisms/by-template/org-nav-i-want-to-menu.twig
+++ b/patternlab/styleguide/source/_patterns/03-organisms/by-template/org-nav-i-want-to-menu.twig
@@ -2,7 +2,7 @@
 
   {% block findService %}
   {% if findService  %}
-  <div class="ma__org-nav-i-want-to-section">
+  <div class="ma__org-nav-i-want-to-section ma__org-nav-i-want-to__findService">
     {% set linkList = findService.linkList %}
     {% include "@organisms/by-author/link-list.twig" %}
   </div>
@@ -11,7 +11,7 @@
 
   {% block learnAbout %}
   {% if learnAbout  %}
-  <div class="ma__org-nav-i-want-to-section">
+  <div class="ma__org-nav-i-want-to-section ma__org-nav-i-want-to__learnAbout">
     {% set linkList = learnAbout.linkList %}
     {% include "@organisms/by-author/link-list.twig" %}
   </div>
@@ -20,7 +20,7 @@
 
   {% block login %}
   {% if login.href %}
-  <div class="ma__org-nav-i-want-to-section">
+  <div class="ma__org-nav-i-want-to-section ma__org-nav-i-want-to__login">
     <h3 class="ma__comp-heading">Log in to...</h3>
     <a class="ma__link-list__container" href="{{ login.href }}">{{ login.text }}</a>
   </div>


### PR DESCRIPTION
Patch
Added
(Patternlab) [OrganizationNavigation] DP-12928: Add link list specific classes: `ma__org-nav-i-want-to__findService`, `ma__org-nav-i-want-to__learnAbout`,`ma__org-nav-i-want-to__login` to sections for GTM. #504


[Jira](https://jira.mass.gov/browse/DP-12928)


To track organization subnav menu use, we need unique class identifiers such that we can differentiate between "Find a service or task", "Learn more about", and "Log in to" in Google Tag Manager.

Example org pages with different subnav menu configurations: 
https://www.mass.gov/orgs/civil-service
https://www.mass.gov/orgs/massachusetts-supreme-judicial-court

Right now, the three sections in org-sub-nav.png all have ma__org-nav-i-want-to-section as a class. This ticket is done when these three sections have different classes.