### PR TITLE
react/fix inputNumber handleAdjust logic

### DIFF
--- a/changelogs/DP-13167.md
+++ b/changelogs/DP-13167.md
@@ -1,0 +1,4 @@
+Patch
+Fixed
+- (React) [InputCurrency, InputNumber] DP-13167: Fixed handleAdjust logic so that min/max are not required for up/down buttons to work. #518
+- (React) [InputNumber] DP-13167: Fixed the initial steps when using up/down without a default value. #518

--- a/changelogs/DP-13167.md
+++ b/changelogs/DP-13167.md
@@ -1,4 +1,4 @@
 Patch
 Fixed
 - (React) [InputCurrency, InputNumber] DP-13167: Fixed handleAdjust logic so that min/max are not required for up/down buttons to work. #518
-- (React) [InputNumber] DP-13167: Fixed the initial steps when using up/down without a default value. #518
+- (React) [InputNumber] DP-13167: Fixed the initial steps when using up/down without a default value and decimal formatting onBlur. #518

--- a/react/src/components/atoms/forms/InputCurrency/index.js
+++ b/react/src/components/atoms/forms/InputCurrency/index.js
@@ -47,7 +47,7 @@ const Currency = (props) => {
             }
             return number;
           };
-          const hasProperty = (obj, property) => Object.prototype.hasOwnProperty.call(obj, property) && !is.nil(obj[property]);
+          const hasNumberProperty = (obj, property) => Object.prototype.hasOwnProperty.call(obj, property) && is.number(obj[property]);
           const handleChange = (e) => {
             const { type } = e;
             const stringValue = ref.current.value;
@@ -98,7 +98,7 @@ const Currency = (props) => {
               } else if (direction === 'down') {
                 newValue = Number(numbro(numberValue).subtract(props.step).format({ mantissa: countDecimals(props.step) }));
               }
-              if ((!hasProperty(props, 'min') || newValue >= props.min) && (!hasProperty(props, 'max') || (newValue <= props.max))) {
+              if ((!hasNumberProperty(props, 'min') || (newValue >= props.min)) && (!hasNumberProperty(props, 'max') || (newValue <= props.max))) {
                 const { showError, errorMsg } = validNumber(newValue, props.min, props.max);
                 context.updateState({
                   showError,
@@ -126,7 +126,7 @@ const Currency = (props) => {
               let newValue = numberValue;
               if (key === 'ArrowDown') {
                 newValue = Number(numbro(numberValue).subtract(props.step).format({ mantissa: countDecimals(props.step) }));
-                if ((!hasProperty(props, 'min') || newValue >= props.min) && (!hasProperty(props, 'max') || (newValue <= props.max))) {
+                if ((!hasNumberProperty(props, 'min') || newValue >= props.min) && (!hasNumberProperty(props, 'max') || (newValue <= props.max))) {
                   const { showError, errorMsg } = validNumber(newValue, props.min, props.max);
                   context.updateState({
                     showError,
@@ -140,7 +140,7 @@ const Currency = (props) => {
                 }
               } else if (key === 'ArrowUp') {
                 newValue = Number(numbro(numberValue).add(props.step).format({ mantissa: countDecimals(props.step) }));
-                if ((!hasProperty(props, 'min') || newValue >= props.min) && (!hasProperty(props, 'max') || (newValue <= props.max))) {
+                if ((!hasNumberProperty(props, 'min') || newValue >= props.min) && (!hasNumberProperty(props, 'max') || (newValue <= props.max))) {
                   const { showError, errorMsg } = validNumber(newValue, props.min, props.max);
                   context.updateState({
                     showError,
@@ -167,10 +167,10 @@ const Currency = (props) => {
               context.updateState({ showError: true, errorMsg });
             } else if (!is.empty(stringValue)) {
               let newValue = numberValue;
-              if (hasProperty(props, 'max') && newValue > props.max) {
+              if (!hasNumberProperty(props, 'max') || newValue > props.max) {
                 newValue = props.max;
               }
-              if (hasProperty(props, 'min') && newValue < props.min) {
+              if (!hasNumberProperty(props, 'min') || newValue < props.min) {
                 newValue = props.min;
               }
               const { showError, errorMsg } = validNumber(newValue, props.min, props.max);

--- a/react/src/components/atoms/forms/InputCurrency/index.js
+++ b/react/src/components/atoms/forms/InputCurrency/index.js
@@ -89,7 +89,7 @@ const Currency = (props) => {
             const direction = (e.currentTarget === upRef.current) ? 'up' : 'down';
             const { type } = e;
             const stringValue = ref.current.value;
-            const numberValue = stringValue ? Number(numbro.unformat(ref.current.value)) : 0;
+            const numberValue = stringValue ? Number(numbro.unformat(stringValue)) : 0;
             let newValue;
             if (direction === 'up') {
               newValue = Number(numbro(numberValue).add(props.step).format({ mantissa: countDecimals(props.step) }));

--- a/react/src/components/atoms/forms/InputCurrency/index.js
+++ b/react/src/components/atoms/forms/InputCurrency/index.js
@@ -74,7 +74,7 @@ const Currency = (props) => {
           const handleChange = (e) => {
             const { type } = e;
             const stringValue = ref.current.value;
-            const numberValue = stringValue ? Number(numbro.unformat(ref.current.value)) : 0;
+            const numberValue = !is.empty(stringValue) ? Number(numbro.unformat(stringValue)) : 0;
             // If the stringvalue is empty, set to empty string so the required error
             // message is rendered. Otherwise pass the number value for the min/max check.
             const updateError = displayErrorMessage(!is.empty(stringValue) ? numberValue : '');

--- a/react/src/components/atoms/forms/InputCurrency/index.js
+++ b/react/src/components/atoms/forms/InputCurrency/index.js
@@ -74,7 +74,7 @@ const Currency = (props) => {
           const handleChange = (e) => {
             const { type } = e;
             const stringValue = ref.current.value;
-            const numberValue = !is.empty(stringValue) ? Number(numbro.unformat(stringValue)) : 0;
+            const numberValue = stringValue ? Number(numbro.unformat(stringValue)) : 0;
             // If the stringvalue is empty, set to empty string so the required error
             // message is rendered. Otherwise pass the number value for the min/max check.
             const updateError = displayErrorMessage(!is.empty(stringValue) ? numberValue : '');

--- a/react/src/components/atoms/forms/InputCurrency/index.js
+++ b/react/src/components/atoms/forms/InputCurrency/index.js
@@ -140,6 +140,7 @@ const Currency = (props) => {
           const handleBlur = () => {
             const inputEl = ref.current;
             const stringValue = inputEl.value;
+            // isNotNumber returns true if stringValue is null, undefined or 'NaN'
             const isNotNumber = !stringValue || isNaN(Number(numbro.unformat(stringValue)));
             if (isNotNumber) {
               inputEl.setAttribute('placeholder', props.placeholder);

--- a/react/src/components/atoms/forms/InputCurrency/index.js
+++ b/react/src/components/atoms/forms/InputCurrency/index.js
@@ -48,6 +48,8 @@ const Currency = (props) => {
             return number;
           };
           const hasNumberProperty = (obj, property) => Object.prototype.hasOwnProperty.call(obj, property) && is.number(obj[property]);
+          const greaterThanMin = (val) => !hasNumberProperty(props, 'min') || (val >= props.min);
+          const lessThanMax = (val) => !hasNumberProperty(props, 'max') || (val <= props.max);
           const handleChange = (e) => {
             const { type } = e;
             const stringValue = ref.current.value;
@@ -98,7 +100,7 @@ const Currency = (props) => {
               } else if (direction === 'down') {
                 newValue = Number(numbro(numberValue).subtract(props.step).format({ mantissa: countDecimals(props.step) }));
               }
-              if ((!hasNumberProperty(props, 'min') || (newValue >= props.min)) && (!hasNumberProperty(props, 'max') || (newValue <= props.max))) {
+              if (greaterThanMin(newValue) && lessThanMax(newValue)) {
                 const { showError, errorMsg } = validNumber(newValue, props.min, props.max);
                 context.updateState({
                   showError,
@@ -126,7 +128,7 @@ const Currency = (props) => {
               let newValue = numberValue;
               if (key === 'ArrowDown') {
                 newValue = Number(numbro(numberValue).subtract(props.step).format({ mantissa: countDecimals(props.step) }));
-                if ((!hasNumberProperty(props, 'min') || newValue >= props.min) && (!hasNumberProperty(props, 'max') || (newValue <= props.max))) {
+                if (greaterThanMin(newValue) && lessThanMax(newValue)) {
                   const { showError, errorMsg } = validNumber(newValue, props.min, props.max);
                   context.updateState({
                     showError,
@@ -140,7 +142,7 @@ const Currency = (props) => {
                 }
               } else if (key === 'ArrowUp') {
                 newValue = Number(numbro(numberValue).add(props.step).format({ mantissa: countDecimals(props.step) }));
-                if ((!hasNumberProperty(props, 'min') || newValue >= props.min) && (!hasNumberProperty(props, 'max') || (newValue <= props.max))) {
+                if (greaterThanMin(newValue) && lessThanMax(newValue)) {
                   const { showError, errorMsg } = validNumber(newValue, props.min, props.max);
                   context.updateState({
                     showError,

--- a/react/src/components/atoms/forms/InputNumber/index.js
+++ b/react/src/components/atoms/forms/InputNumber/index.js
@@ -52,19 +52,17 @@ const NumberInput = (props) => {
               errorMsg: ''
             };
           };
-          const hasProperty = (obj, property) => Object.prototype.hasOwnProperty.call(obj, property) && !is.nil(obj[property]);
+          const hasNumberProperty = (obj, property) => Object.prototype.hasOwnProperty.call(obj, property) && is.number(obj[property]);
 
           const handleOnBlur = (e) => {
             e.persist();
             const inputEl = ref.current;
             let newValue = Number(inputEl.value);
-            if ((hasProperty(props, 'max') && newValue > props.max) || (hasProperty(props, 'min') && newValue < props.min)) {
-              if (hasProperty(props, 'max') && newValue > props.max) {
-                newValue = props.max;
-              }
-              if (hasProperty(props, 'min') && newValue < props.min) {
-                newValue = props.min;
-              }
+            if (hasNumberProperty(props, 'max') && newValue > props.max) {
+              newValue = props.max;
+            }
+            if (hasNumberProperty(props, 'min') && newValue < props.min) {
+              newValue = props.min;
             }
             if (!is.empty(inputEl.value)) {
               inputEl.value = Number(numbro(newValue)
@@ -107,7 +105,7 @@ const NumberInput = (props) => {
               direction = 'down';
             }
             const inputEl = ref.current;
-            if (direction === 'up' && (!hasProperty(inputEl, 'max') || inputEl.value < inputEl.max)) {
+            if (direction === 'up' && (!hasNumberProperty(props, 'max') || inputEl.value < props.max)) {
               if (is.empty(inputEl.value)) {
                 inputEl.value = props.step;
               } else {
@@ -115,7 +113,7 @@ const NumberInput = (props) => {
                   .add(props.step).value());
               }
               handleChange(e);
-            } else if (direction === 'down' && (!hasProperty(props, 'min') || inputEl.value > inputEl.min)) {
+            } else if (direction === 'down' && (!hasNumberProperty(props, 'min') || inputEl.value > props.min)) {
               if (is.empty(inputEl.value)) {
                 inputEl.value = -props.step;
               } else {

--- a/react/src/components/atoms/forms/InputNumber/index.js
+++ b/react/src/components/atoms/forms/InputNumber/index.js
@@ -107,17 +107,17 @@ const NumberInput = (props) => {
               direction = 'down';
             }
             const inputEl = ref.current;
-            if (direction === 'up' && (!hasProperty(props, 'max') || inputEl.value < props.max)) {
+            if (direction === 'up' && (!hasProperty(inputEl, 'max') || inputEl.value < inputEl.max)) {
               if (is.empty(inputEl.value)) {
-                inputEl.value = 1;
+                inputEl.value = props.step;
               } else {
                 inputEl.value = Number(numbro(inputEl.value)
                   .add(props.step).value());
               }
               handleChange(e);
-            } else if (direction === 'down' && (!hasProperty(props, 'min') || inputEl.value > props.min)) {
+            } else if (direction === 'down' && (!hasProperty(props, 'min') || inputEl.value > inputEl.min)) {
               if (is.empty(inputEl.value)) {
-                inputEl.value = -1;
+                inputEl.value = -props.step;
               } else {
                 inputEl.value = Number(numbro(inputEl.value)
                   .subtract(props.step).value());

--- a/react/src/components/atoms/forms/InputNumber/index.js
+++ b/react/src/components/atoms/forms/InputNumber/index.js
@@ -115,7 +115,7 @@ const NumberInput = (props) => {
               handleChange(e);
             } else if (direction === 'down' && (!hasNumberProperty(props, 'min') || inputEl.value > props.min)) {
               if (is.empty(inputEl.value)) {
-                inputEl.value = -props.step;
+                inputEl.value = props.step * -1;
               } else {
                 inputEl.value = Number(numbro(inputEl.value)
                   .subtract(props.step).value());

--- a/react/src/components/atoms/forms/InputNumber/index.js
+++ b/react/src/components/atoms/forms/InputNumber/index.js
@@ -52,6 +52,7 @@ const NumberInput = (props) => {
               errorMsg: ''
             };
           };
+
           const hasNumberProperty = (obj, property) => Object.prototype.hasOwnProperty.call(obj, property) && is.number(obj[property]);
 
           const handleOnBlur = (e) => {
@@ -77,17 +78,12 @@ const NumberInput = (props) => {
           };
 
           const handleChange = (e) => {
-            const inputEl = ref.current;
             e.persist();
-            let newValue;
-            if (is.empty(inputEl.value)) {
-              newValue = inputEl.value;
-            } else {
-              newValue = Number(inputEl.value);
-              if (is.number(newValue)) {
-                newValue = Number(numbro(inputEl.value)
+            const inputEl = ref.current;
+            let newValue = inputEl.value;
+            if (!is.empty(newValue)) {
+              newValue = is.number(Number(inputEl.value)) && Number(numbro(inputEl.value)
                   .format({ mantissa: countDecimals(props.step) }));
-              }
             }
             const updateError = displayErrorMessage(newValue);
             context.updateState({ value: newValue, ...updateError }, () => {

--- a/react/src/components/atoms/forms/InputNumber/index.js
+++ b/react/src/components/atoms/forms/InputNumber/index.js
@@ -58,20 +58,19 @@ const NumberInput = (props) => {
           const handleOnBlur = (e) => {
             e.persist();
             const inputEl = ref.current;
-            let newValue = Number(inputEl.value);
+            let newValue = inputEl.value ? Number(inputEl.value) : inputEl.value;
             if (hasNumberProperty(props, 'max') && newValue > props.max) {
               newValue = props.max;
             }
             if (hasNumberProperty(props, 'min') && newValue < props.min) {
               newValue = props.min;
             }
-            if (!is.empty(inputEl.value)) {
-              inputEl.value = Number(numbro(newValue)
-                .format({ mantissa: countDecimals(props.step) }));
+            if (is.number(newValue)) {
+              newValue = newValue.toFixed(countDecimals(props.step));
               const updateError = displayErrorMessage(newValue);
-              context.updateState({ value: inputEl.value, ...updateError }, () => {
+              context.updateState({ value: newValue, ...updateError }, () => {
                 if (is.fn(props.onBlur)) {
-                  props.onBlur(e, inputEl.value);
+                  props.onBlur(e, newValue);
                 }
               });
             }
@@ -80,11 +79,7 @@ const NumberInput = (props) => {
           const handleChange = (e) => {
             e.persist();
             const inputEl = ref.current;
-            let newValue = inputEl.value;
-            if (!is.empty(newValue)) {
-              newValue = is.number(Number(inputEl.value)) && Number(numbro(inputEl.value)
-                  .format({ mantissa: countDecimals(props.step) }));
-            }
+            const newValue = inputEl.value ? Number(inputEl.value) : inputEl.value;
             const updateError = displayErrorMessage(newValue);
             context.updateState({ value: newValue, ...updateError }, () => {
               if (is.fn(props.onChange)) {
@@ -94,6 +89,7 @@ const NumberInput = (props) => {
           };
 
           const handleAdjust = (e) => {
+            e.persist();
             let direction;
             if (e.currentTarget === upRef.current) {
               direction = 'up';
@@ -101,22 +97,23 @@ const NumberInput = (props) => {
               direction = 'down';
             }
             const inputEl = ref.current;
-            if (direction === 'up' && (!hasNumberProperty(props, 'max') || inputEl.value < props.max)) {
-              if (is.empty(inputEl.value)) {
-                inputEl.value = props.step;
-              } else {
-                inputEl.value = Number(numbro(inputEl.value)
-                  .add(props.step).value());
-              }
-              handleChange(e);
-            } else if (direction === 'down' && (!hasNumberProperty(props, 'min') || inputEl.value > props.min)) {
-              if (is.empty(inputEl.value)) {
-                inputEl.value = props.step * -1;
-              } else {
-                inputEl.value = Number(numbro(inputEl.value)
-                  .subtract(props.step).value());
-              }
-              handleChange(e);
+            let newValue = inputEl.value ? Number(inputEl.value) : inputEl.value;
+            if (direction === 'up' && (!hasNumberProperty(props, 'max') || newValue < props.max)) {
+              newValue = newValue ? (newValue + props.step).toFixed(countDecimals(props.step)) : props.step;
+              const updateError = displayErrorMessage(newValue);
+              context.updateState({ value: newValue, ...updateError }, () => {
+                if (is.fn(props.onChange)) {
+                  props.onChange(e, newValue, props.id);
+                }
+              });
+            } else if (direction === 'down' && (!hasNumberProperty(props, 'min') || newValue > props.min)) {
+              newValue = newValue ? (newValue + props.step * -1).toFixed(countDecimals(props.step)) : (props.step * -1);
+              const updateError = displayErrorMessage(newValue);
+              context.updateState({ value: newValue, ...updateError }, () => {
+                if (is.fn(props.onChange)) {
+                  props.onChange(e, newValue, props.id);
+                }
+              });
             }
           };
 

--- a/react/src/components/atoms/forms/InputNumber/index.js
+++ b/react/src/components/atoms/forms/InputNumber/index.js
@@ -66,7 +66,8 @@ const NumberInput = (props) => {
               newValue = props.min;
             }
             if (is.number(newValue)) {
-              newValue = newValue.toFixed(countDecimals(props.step));
+              // Since to Fixed returns a string, we have to cast it back to a Number
+              newValue = Number(newValue.toFixed(countDecimals(props.step)));
               const updateError = displayErrorMessage(newValue);
               context.updateState({ value: newValue, ...updateError }, () => {
                 if (is.fn(props.onBlur)) {
@@ -99,7 +100,8 @@ const NumberInput = (props) => {
             const inputEl = ref.current;
             let newValue = inputEl.value ? Number(inputEl.value) : inputEl.value;
             if (direction === 'up' && (!hasNumberProperty(props, 'max') || newValue < props.max)) {
-              newValue = newValue ? (newValue + props.step).toFixed(countDecimals(props.step)) : props.step;
+              // Since to Fixed returns a string, we have to cast it back to a Number
+              newValue = newValue ? Number((newValue + props.step).toFixed(countDecimals(props.step))) : props.step;
               const updateError = displayErrorMessage(newValue);
               context.updateState({ value: newValue, ...updateError }, () => {
                 if (is.fn(props.onChange)) {
@@ -107,7 +109,8 @@ const NumberInput = (props) => {
                 }
               });
             } else if (direction === 'down' && (!hasNumberProperty(props, 'min') || newValue > props.min)) {
-              newValue = newValue ? (newValue + props.step * -1).toFixed(countDecimals(props.step)) : (props.step * -1);
+              // Since to Fixed returns a string, we have to cast it back to a Number
+              newValue = newValue ? Number((newValue + props.step * -1).toFixed(countDecimals(props.step))) : (props.step * -1);
               const updateError = displayErrorMessage(newValue);
               context.updateState({ value: newValue, ...updateError }, () => {
                 if (is.fn(props.onChange)) {


### PR DESCRIPTION
Fixed
- (React) [InputCurrency, InputNumber] DP-13167: Fixed handleAdjust logic so that min/max are not required for up/down buttons to work. #518
- (React) [InputNumber] DP-13167: Fixed the initial steps when using up/down without a default value. #518 

To test:
- In InputCurrency, InputNumber stories, remove min and max props and click the up/down buttons. 
- In InputNumber story, set step to 0.1 and use up/down button.
