### PR TITLE
React: Fixes warning caused by using start instead of flex-start within FilterBox component stying.

### DIFF
--- a/react/src/components/organisms/FilterBox/style.scss
+++ b/react/src/components/organisms/FilterBox/style.scss
@@ -35,7 +35,7 @@ $assets-path: '../../../assets';
 			}
 			 flex-direction: column;
        align-items: baseline;
-			 justify-content: start;
+			 justify-content: flex-start;
 			 margin: 1rem 0;
 
 			 > div {


### PR DESCRIPTION
## Description
This doesn't have a ticket, but this PR fixes the warning on build about using flex-start instead of start for the justify-content rule within FilterBox's css file. Nothing should be broken/changed by switching over to flex-start instead.

## Steps to Test
1. Pull the branch, run either `npm run build` or `npm start`. You should no longer see the warning related to FilterBox and start within the css file.
