### PR TITLE
React/helptip bypass mobile style style fix 1

### DIFF
--- a/assets/scss/03-organisms/_callout-alert.scss
+++ b/assets/scss/03-organisms/_callout-alert.scss
@@ -140,4 +140,15 @@
     fill: $c-error-red;
   }
 
+  //c-white
+  &--c-white &__content {
+    background-color: tint($c-white, 90%);
+    border-color: tint($c-gray-dark, 50%);
+    box-shadow: 0 0.25rem 0.5rem rgba(#000, 0.25);
+  }
+
+  &--c-white &__icon svg {
+    fill: $c-white;
+  }
+
 }

--- a/assets/scss/03-organisms/_help-tip.scss
+++ b/assets/scss/03-organisms/_help-tip.scss
@@ -186,6 +186,12 @@ $border-width: 1px;
         }
       }
     }
+    &--c-white {
+      background-color: $c-white;
+      #{$helpTipBaseClass}__close-desktop {
+        fill: $c-gray-dark;
+      }
+    }
   }
 
   &.mobile-tray {

--- a/changelogs/DP-13672.md
+++ b/changelogs/DP-13672.md
@@ -2,6 +2,6 @@ Patch
 Fixed
 - (React) [HelpTip] DP-13672: Fix css for bypassMobileStyle. #551
 
-Minor
 Added
 - (React) [InputCurrency] DP-13672: Add `showButtons` prop to control whether the up/down buttons are shown. #550
+- (React) [HelpTip, CalloutAlert] DP-13672: Add white theme option styles. #552

--- a/react/src/components/organisms/CalloutAlert/CalloutAlert.stories.js
+++ b/react/src/components/organisms/CalloutAlert/CalloutAlert.stories.js
@@ -14,7 +14,8 @@ const themeOptions = {
   'c-primary': 'c-primary',
   'c-primary-alt': 'c-primary-alt',
   'c-gray-dark': 'c-gray-dark',
-  'c-error-red': 'c-error-red'
+  'c-error-red': 'c-error-red',
+  'c-white': 'c-white'
 };
 
 storiesOf('organisms/CalloutAlert', module)


### PR DESCRIPTION
This pr fixes c-white theme in a callout box that has a background color.
Also fixed https://mayflower-react.digital.mass.gov/?path=/story/organisms-helptip--helptip-with-children c-white to children callout alert by adding a white theme to CalloutAlert

![Screen Shot 2019-05-02 at 2 52 46 PM](https://user-images.githubusercontent.com/5789411/57099715-1d86d200-6ceb-11e9-93c9-6886a3444c28.png)

Built with npm link --> https://calculator.digital.mass.gov/iframe/ui/yourbenefits
