### PR TITLE
react/ Refactor Illustrated Header and Page Header for semantic markup

### DIFF
--- a/assets/scss/03-organisms/_illustrated-header.scss
+++ b/assets/scss/03-organisms/_illustrated-header.scss
@@ -150,9 +150,9 @@ $bp-illustrated-header-image-width: 360px;
 }
 
 .ma__illustrated-header--inverted {
-  &, 
+  &,
   .ma__page-header__title,
-  .ma__illustrated-header__category {
+  .ma__page-header__category {
     color: $c-white;
   }
   &,

--- a/assets/scss/03-organisms/_illustrated-header.scss
+++ b/assets/scss/03-organisms/_illustrated-header.scss
@@ -76,14 +76,6 @@ $bp-illustrated-header-image-width: 360px;
 
   }
 
-  &__category {
-    font-size: 1.375rem;
-    font-weight: 700;
-    color: $c-font-detail;
-    letter-spacing: $letter-spacing-large;
-    text-transform: uppercase;
-  }
-
   .ma__page-header {
     padding: 0;
 
@@ -138,9 +130,6 @@ $bp-illustrated-header-image-width: 360px;
     }
   }
 
-  &__category {
-    font-weight: 700;
-  }
 
   .ma__page-header {
 

--- a/assets/scss/03-organisms/_page-header.scss
+++ b/assets/scss/03-organisms/_page-header.scss
@@ -175,6 +175,8 @@ $page-header-widget-width: 350px;
 
   &__category {
     font-size: 1.375rem;
+    padding-bottom: 1rem;
+    line-height: 1.1;
     font-weight: 700;
     letter-spacing: $letter-spacing-large;
     text-transform: uppercase;

--- a/assets/scss/03-organisms/_page-header.scss
+++ b/assets/scss/03-organisms/_page-header.scss
@@ -175,8 +175,6 @@ $page-header-widget-width: 350px;
 
   &__category {
     font-size: 1.375rem;
-    padding-bottom: 1rem;
-    line-height: 1.1;
     font-weight: 700;
     letter-spacing: $letter-spacing-large;
     text-transform: uppercase;
@@ -210,7 +208,7 @@ $page-header-widget-width: 350px;
   }
 
   // Control font size and line height
-  // regardless of it's added to page 
+  // regardless of it's added to page
   &__sub-title,
   &__sub-title * {
     font-size: 1.625rem !important;

--- a/assets/scss/08-print/_print.scss
+++ b/assets/scss/08-print/_print.scss
@@ -37,7 +37,6 @@
   .ma__fixed-feedback-button,
   .post-content #feedback,
   .messages--error,
-  *[aria-hidden="true"],
   .ma__download-link__icon,
   .ma__sidebar-widget__more,
   .ma__page-banner__icon,
@@ -71,8 +70,8 @@
     white-space: nowrap;
   }
 
-  .pre-content::after, 
-  .main-content::after, 
+  .pre-content::after,
+  .main-content::after,
   .post-content::after {
     display: none;
     clear: none;
@@ -152,7 +151,7 @@
     background-size: cover;
     -webkit-print-color-adjust: exact;
   }
-  
+
   .ma__relationship-indicators {
     display: none !important;
   }
@@ -230,7 +229,7 @@
   }
 
   .ma__page-banner--large {
-    height: auto !important; 
+    height: auto !important;
     width: 100% !important;
     max-width: none;
     margin-right: 0 !important;
@@ -252,9 +251,9 @@
   .ma__section-links,
   .ma__about-section-person,
   .ma__location-banner__image {
-    page-break-before: auto; 
+    page-break-before: auto;
     page-break-after: auto;
-    page-break-inside: avoid !important; 
+    page-break-inside: avoid !important;
     break-inside: avoid !important;
   }
 
@@ -342,7 +341,7 @@
     .ma__action-step__icon {
       display: none;
     }
-    
+
     .ma__action-step__content {
       display: inline !important;
       border-width: 0;
@@ -380,12 +379,12 @@
       border-width: 0;
       margin: 0;
       text-align: left;
-  
-      a, 
+
+      a,
       .ma__image {
         display: none;
       }
-  
+
       .ma__decorative-link a {
         display: block !important;
       }
@@ -415,7 +414,7 @@
   .ma__link-list__items {
     // important to over write custom html styles.
     padding-left: 0 !important;
-    
+
     .ma__link-list__item {
       width: 100%;
       flex-basis: 100% !important;
@@ -456,7 +455,7 @@
       height: auto;
       padding-left: 0;
       font-size: 1.4rem;
-      page-break-inside: avoid !important; 
+      page-break-inside: avoid !important;
       break-inside: avoid !important;
     }
 
@@ -485,7 +484,7 @@
   }
 
   .ma__action-step--accordion {
-    border-width: 0 !important; 
+    border-width: 0 !important;
 
     button::after {
       display: none;

--- a/changelogs/react-print-unhide-header-category
+++ b/changelogs/react-print-unhide-header-category
@@ -1,3 +1,6 @@
 Minor
-Added
-- (React) [IllustratedHeader] Add `categoryAriaHidden` prop to allow category text for SR and print #560
+Fixed
+- (Patternlab, React) [IllustratedHeader, PageHeader] Remove duplicated markup for category text in PageHeader and IllustratedHeader. #560
+
+Removed
+- (Patternlab, React) [Print styles] Allow aria-hidden tags to display for print. #560

--- a/changelogs/react-print-unhide-header-category
+++ b/changelogs/react-print-unhide-header-category
@@ -1,0 +1,3 @@
+Minor
+Added
+- (React) [IllustratedHeader] Add `categoryAriaHidden` prop to allow category text for SR and print #560

--- a/patternlab/styleguide/source/_patterns/03-organisms/by-template/illustrated-header.json
+++ b/patternlab/styleguide/source/_patterns/03-organisms/by-template/illustrated-header.json
@@ -2,10 +2,10 @@
   "illustratedHeader": {
     "bgInfo": "Forest of the Berkshires",
     "bgImage": "../../assets/images/placeholder/600x450.png",
-    "category": "Guide",
     "pageHeader": {
       "title": "Moving to Massachusetts",
       "subTitle": "",
+      "category": "Guide",
       "optionalContents": [{
         "path": "@organisms/by-author/rich-text.twig",
         "data": {

--- a/patternlab/styleguide/source/_patterns/03-organisms/by-template/illustrated-header.twig
+++ b/patternlab/styleguide/source/_patterns/03-organisms/by-template/illustrated-header.twig
@@ -16,9 +16,6 @@
 <section class="{{illustratedHeaderClass}}">
   <div class="ma__illustrated-header__container">
     <div class="ma__illustrated-header__content">
-      <div class="ma__illustrated-header__category" aria-hidden="true">
-        {{illustratedHeader.category}}
-      </div>
       {% set pageHeader = illustratedHeader.pageHeader %}
       {% set pageHeader = pageHeader|merge({ 'prefix': illustratedHeader.category }) %}
       {% include "@organisms/by-template/page-header.twig" %}

--- a/patternlab/styleguide/source/_patterns/03-organisms/by-template/illustrated-header~colored.json
+++ b/patternlab/styleguide/source/_patterns/03-organisms/by-template/illustrated-header~colored.json
@@ -2,8 +2,8 @@
   "illustratedHeader": {
     "bgInfo": "",
     "bgImage": "",
-    "category": "Guide",
     "pageHeader": {
+      "category": "Guide",
       "title": "Moving to Massachusetts",
       "subTitle": "",
       "optionalContents": [{

--- a/patternlab/styleguide/source/_patterns/03-organisms/by-template/illustrated-header~image-centered.json
+++ b/patternlab/styleguide/source/_patterns/03-organisms/by-template/illustrated-header~image-centered.json
@@ -4,8 +4,8 @@
     "bgImage": "../../assets/images/placeholder/800x400.png",
     "retinaBgImage": "../../assets/images/placeholder/1600x800.png",
     "bgCentered": true,
-    "category": "Guide",
     "pageHeader": {
+      "category": "Guide",
       "title": "Moving to Massachusetts",
       "subTitle": "",
       "optionalContents": [{

--- a/patternlab/styleguide/source/_patterns/03-organisms/by-template/illustrated-header~inverted.json
+++ b/patternlab/styleguide/source/_patterns/03-organisms/by-template/illustrated-header~inverted.json
@@ -2,9 +2,9 @@
   "illustratedHeader": {
     "bgInfo": "Forest of the Berkshires",
     "bgImage": "../../assets/images/placeholder/600x450.png",
-    "category": "Law Library",
     "inverted": true,
     "pageHeader": {
+      "category": "Law Library",
       "title": "Rules of Criminal Procedure",
       "subTitle": "",
       "optionalContents": [{

--- a/patternlab/styleguide/source/_patterns/03-organisms/by-template/page-header.twig
+++ b/patternlab/styleguide/source/_patterns/03-organisms/by-template/page-header.twig
@@ -22,11 +22,6 @@
         {% include "@atoms/11-text/publish-state.twig" %}
       </div>
     {% endif %}
-    {% if pageHeader.category %}
-      <div class="ma__page-header__category">
-        {{ pageHeader.category }}
-      </div>
-    {% endif %}
 
     {% if pageHeader.subCategory %}
       <div class="ma__page-header__subCategory">
@@ -36,7 +31,12 @@
       </div>
     {% endif %}
 
-    <h1 class="ma__page-header__title">{% if prefix %}<span class="visually-hidden">{{ prefix }}&nbsp;</span>{% endif %}{{pageHeader.title}}</h1>
+    <h1 class="ma__page-header__title">
+      {% if prefix %}
+        <div class="ma__page-header__category">{{ prefix }}</div>
+      {% endif %}
+      {{pageHeader.title}}
+    </h1>
     {% if pageHeader.subTitle %}
       <div class="ma__page-header__sub-title">{{pageHeader.subTitle}}</div>
     {% endif %}

--- a/react/src/components/organisms/IllustratedHeader/IllustratedHeader.knobs.options.js
+++ b/react/src/components/organisms/IllustratedHeader/IllustratedHeader.knobs.options.js
@@ -4,10 +4,10 @@ export default {
     bgImage: 'https://mayflower.digital.mass.gov/assets/images/placeholder/600x450.png',
     category: 'Guide',
     inverted: false,
-    publishState: {
-      text: 'publish state'
-    },
     pageHeader: {
+      publishState: {
+        text: 'publish state'
+      },
       category: 'Guide',
       title: 'Moving to Massachusetts',
       subTitle: '',

--- a/react/src/components/organisms/IllustratedHeader/IllustratedHeader.knobs.options.js
+++ b/react/src/components/organisms/IllustratedHeader/IllustratedHeader.knobs.options.js
@@ -8,6 +8,7 @@ export default {
       text: 'publish state'
     },
     pageHeader: {
+      category: 'Guide',
       title: 'Moving to Massachusetts',
       subTitle: '',
       optionalContents: [{

--- a/react/src/components/organisms/IllustratedHeader/IllustratedHeader.stories.js
+++ b/react/src/components/organisms/IllustratedHeader/IllustratedHeader.stories.js
@@ -14,13 +14,12 @@ storiesOf('organisms', module)
       const props = {
         bgInfo: text('bgInfo', defaultProps.bgInfo),
         bgImage: text('bgImage', defaultProps.bgImage),
-        category: text('category', defaultProps.category),
-        categoryAriaHidden: boolean('categoryAriaHidden'),
         inverted: boolean('inverted', defaultProps.inverted),
         publishState: {
           text: text('publishState', defaultProps.publishState.text)
         },
         pageHeader: {
+          category: text('IllustratedHeader pageHeader: category', defaultProps.pageHeader.category, 'Category'),
           title: text('IllustratedHeader pageHeader: title', defaultProps.pageHeader.title, 'PageHeader'),
           subTitle: text('IllustratedHeader pageHeader: subtitle', defaultProps.pageHeader.subTitle, 'PageHeader'),
           optionalContents: [{

--- a/react/src/components/organisms/IllustratedHeader/IllustratedHeader.stories.js
+++ b/react/src/components/organisms/IllustratedHeader/IllustratedHeader.stories.js
@@ -15,10 +15,10 @@ storiesOf('organisms', module)
         bgInfo: text('bgInfo', defaultProps.bgInfo),
         bgImage: text('bgImage', defaultProps.bgImage),
         inverted: boolean('inverted', defaultProps.inverted),
-        publishState: {
-          text: text('publishState', defaultProps.publishState.text)
-        },
         pageHeader: {
+          publishState: {
+            text: text('publishState', defaultProps.pageHeader.publishState.text)
+          },
           category: text('IllustratedHeader pageHeader: category', defaultProps.pageHeader.category, 'Category'),
           title: text('IllustratedHeader pageHeader: title', defaultProps.pageHeader.title, 'PageHeader'),
           subTitle: text('IllustratedHeader pageHeader: subtitle', defaultProps.pageHeader.subTitle, 'PageHeader'),

--- a/react/src/components/organisms/IllustratedHeader/IllustratedHeader.stories.js
+++ b/react/src/components/organisms/IllustratedHeader/IllustratedHeader.stories.js
@@ -17,9 +17,9 @@ storiesOf('organisms', module)
         inverted: boolean('inverted', defaultProps.inverted),
         pageHeader: {
           publishState: {
-            text: text('publishState', defaultProps.pageHeader.publishState.text)
+            text: text('IllustratedHeader pageHeader: publishState', defaultProps.pageHeader.publishState.text, 'PageHeader')
           },
-          category: text('IllustratedHeader pageHeader: category', defaultProps.pageHeader.category, 'Category'),
+          category: text('IllustratedHeader pageHeader: category', defaultProps.pageHeader.category, 'PageHeader'),
           title: text('IllustratedHeader pageHeader: title', defaultProps.pageHeader.title, 'PageHeader'),
           subTitle: text('IllustratedHeader pageHeader: subtitle', defaultProps.pageHeader.subTitle, 'PageHeader'),
           optionalContents: [{

--- a/react/src/components/organisms/IllustratedHeader/IllustratedHeader.stories.js
+++ b/react/src/components/organisms/IllustratedHeader/IllustratedHeader.stories.js
@@ -15,6 +15,7 @@ storiesOf('organisms', module)
         bgInfo: text('bgInfo', defaultProps.bgInfo),
         bgImage: text('bgImage', defaultProps.bgImage),
         category: text('category', defaultProps.category),
+        categoryAriaHidden: boolean('categoryAriaHidden'),
         inverted: boolean('inverted', defaultProps.inverted),
         publishState: {
           text: text('publishState', defaultProps.publishState.text)

--- a/react/src/components/organisms/IllustratedHeader/index.js
+++ b/react/src/components/organisms/IllustratedHeader/index.js
@@ -18,14 +18,6 @@ const IllustratedHeader = (illustratedHeader) => {
     <section className={`ma__illustrated-header ${illustratedHeaderClass}`}>
       <div className="ma__illustrated-header__container">
         <div className="ma__illustrated-header__content">
-          { publishState.text && (
-            <div className="ma__page-header__publish-state">
-              <PublishState {...publishState} />
-            </div>
-          )}
-          <div className="ma__illustrated-header__category">
-            {category}
-          </div>
           <PageHeader {...pageHeaderProps} />
           {
             // Allows IllustratedHeader to render custom children component (this feature is used in rideshare report and it's not in Mayflower PatternLab)

--- a/react/src/components/organisms/IllustratedHeader/index.js
+++ b/react/src/components/organisms/IllustratedHeader/index.js
@@ -9,7 +9,7 @@ import './style.css';
 
 const IllustratedHeader = (illustratedHeader) => {
   const {
-    bgInfo, bgImage, inverted, category, pageHeader, publishState, children
+    bgInfo, bgImage, inverted, category, pageHeader, publishState, children, categoryAriaHidden
   } = illustratedHeader;
   const imageAlt = bgInfo || '';
   const pageHeaderProps = pageHeader;
@@ -23,7 +23,7 @@ const IllustratedHeader = (illustratedHeader) => {
               <PublishState {...publishState} />
             </div>
           )}
-          <div className="ma__illustrated-header__category" aria-hidden="true">
+          <div className="ma__illustrated-header__category" aria-hidden={categoryAriaHidden}>
             {category}
           </div>
           <PageHeader {...pageHeaderProps} />
@@ -58,7 +58,13 @@ IllustratedHeader.propTypes = {
   /** category prefix text rendered in all caps above the page header title */
   category: PropTypes.string,
   /** render PageHeader component @organisms/PageHeader */
-  pageHeader: PropTypes.shape(PageHeader.propTypes)
+  pageHeader: PropTypes.shape(PageHeader.propTypes),
+  /** hide category in screen reader and print */
+  categoryAriaHidden: PropTypes.bool
+};
+
+IllustratedHeader.defaultProps = {
+  categoryAriaHidden: true
 };
 
 export default IllustratedHeader;

--- a/react/src/components/organisms/IllustratedHeader/index.js
+++ b/react/src/components/organisms/IllustratedHeader/index.js
@@ -3,13 +3,12 @@ import PropTypes from 'prop-types';
 
 // import child components
 import PageHeader from '../PageHeader';
-import PublishState from '../../atoms/text/PublishState';
 
 import './style.css';
 
 const IllustratedHeader = (illustratedHeader) => {
   const {
-    bgInfo, bgImage, inverted, category, pageHeader, publishState, children
+    bgInfo, bgImage, inverted, pageHeader, children
   } = illustratedHeader;
   const imageAlt = bgInfo || '';
   const pageHeaderProps = pageHeader;
@@ -48,11 +47,7 @@ IllustratedHeader.propTypes = {
   /** invert to change style */
   inverted: PropTypes.bool,
   /** render PageHeader component @organisms/PageHeader */
-  pageHeader: PropTypes.shape(PageHeader.propTypes),
-};
-
-IllustratedHeader.defaultProps = {
-  categoryAriaHidden: true
+  pageHeader: PropTypes.shape(PageHeader.propTypes)
 };
 
 export default IllustratedHeader;

--- a/react/src/components/organisms/IllustratedHeader/index.js
+++ b/react/src/components/organisms/IllustratedHeader/index.js
@@ -9,7 +9,7 @@ import './style.css';
 
 const IllustratedHeader = (illustratedHeader) => {
   const {
-    bgInfo, bgImage, inverted, category, pageHeader, publishState, children, categoryAriaHidden
+    bgInfo, bgImage, inverted, category, pageHeader, publishState, children
   } = illustratedHeader;
   const imageAlt = bgInfo || '';
   const pageHeaderProps = pageHeader;
@@ -23,7 +23,7 @@ const IllustratedHeader = (illustratedHeader) => {
               <PublishState {...publishState} />
             </div>
           )}
-          <div className="ma__illustrated-header__category" aria-hidden={categoryAriaHidden}>
+          <div className="ma__illustrated-header__category">
             {category}
           </div>
           <PageHeader {...pageHeaderProps} />
@@ -55,12 +55,8 @@ IllustratedHeader.propTypes = {
   bgImage: PropTypes.string,
   /** invert to change style */
   inverted: PropTypes.bool,
-  /** category prefix text rendered in all caps above the page header title */
-  category: PropTypes.string,
   /** render PageHeader component @organisms/PageHeader */
   pageHeader: PropTypes.shape(PageHeader.propTypes),
-  /** hide category in screen reader and print */
-  categoryAriaHidden: PropTypes.bool
 };
 
 IllustratedHeader.defaultProps = {

--- a/react/src/components/organisms/PageHeader/index.js
+++ b/react/src/components/organisms/PageHeader/index.js
@@ -19,15 +19,11 @@ const PageHeader = (pageHeader) => {
             <PublishState {...publishState} />
           </div>
         )}
-        { category && (
-          <div className="ma__page-header__category">
-            { category }
-          </div>
-        )}
         <h1 className="ma__page-header__title">
           { category && (
-          <span className="visually-hidden">{ category }&nbsp;</span>
-        )}{title}
+          <div className="ma__page-header__category">{ category }</div>
+          )}
+          {title}
         </h1>
         { subTitle && (
           <div className="ma__page-header__sub-title">{subTitle}</div>


### PR DESCRIPTION
In React and Patternlab, Illustrated Header was rendering duplicated category and publishState fields that are now removed/replaced by the same fields in PageHeader inside of IllustratedHeader. This will fix the ordering issue seen in tnc report, allow the category to be visible for screen readers and print style
<img width="992" alt="Screen Shot 2019-05-24 at 2 46 15 PM" src="https://user-images.githubusercontent.com/5789411/58349984-c0d28f00-7e32-11e9-958c-c8910c178413.png">

The markup of PageHeader has category text repeated in two different tag, one is for SR only and one is for SR hidden. Now they are combined into one.
Before:
```
  <div class="ma__illustrated-header__content">
    <div class="ma__illustrated-header__category" aria-hidden="true">
      Guide
    </div>

    <section class="ma__page-header">
      <div class="ma__page-header__content">
        <h1 class="ma__page-header__title">
          <span class="visually-hidden">Guide&nbsp;</span>
          Moving to Massachusetts
        </h1>
...
```
Same fix is also ported into patternlab.