### PR TITLE
DP-13967 Fix the display of heading size for Related Service/Additional Resources on service page

### DIFF
--- a/changelogs/DP-13967.txt
+++ b/changelogs/DP-13967.txt
@@ -1,0 +1,3 @@
+Minor
+Fixed
+- (Patternlab) DP-13967: Fix the heading size for the Related Services and Additional Resources heading from h3 to h2.

--- a/patternlab/styleguide/source/_patterns/05-pages/service.json
+++ b/patternlab/styleguide/source/_patterns/05-pages/service.json
@@ -471,9 +471,11 @@
             "path": "@organisms/by-author/link-list.twig",
             "data": {
               "linkList": {
-                "sidebarHeading": {
+                "compHeading": {
                   "title": "Related Services",
-                  "titleContext": "to Unemployment Benefits"
+                  "titleContext": "to Unemployment Benefits",
+                  "sub": true,
+                  "sidebar": true
                 },
                 "stacked": true,
                 "links": [
@@ -519,9 +521,11 @@
             "path": "@organisms/by-author/form-downloads.twig",
             "data": {
               "formDownloads": {
-                "sidebarHeading": {
+                "compHeading": {
                   "title": "Additional Resources",
-                  "titleContext": "for Unemployment Benefits"
+                  "titleContext": "for Unemployment Benefits",
+                  "sub": true,
+                  "sidebar": true
                 },
                 "downloadLinks": [
                   {


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/dev/docs/change-log-instructions.md)


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
@clair0917 fixed this issue I'm just creating a PR for it. When inspecting the service page `https://mayflower.digital.mass.gov/?p=pages-service` particularly the Additional Resources/Related Services these headings were showing an h2 when they were supposed to be showing h3.

## Related Issue / Ticket

- [JIRA issue](https://jira.mass.gov/browse/DP-13967)
- [Github issue]()

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Compare `https://mayflower.digital.mass.gov/?p=pages-service` to `http://localhost:3000/?p=pages-service`.
2. Inspect the `Related Services` and `Additional Resources` under the `More Information` section
3. Both sections `Related Services` and `Additional Resources` should have h3 not h2 listed.

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

Changes to the heading:
![Screen Shot 2019-05-21 at 2 05 46 PM](https://user-images.githubusercontent.com/19477691/58120694-bfeff200-7bd3-11e9-866f-a3051ec415e5.png)

The current display in Mayflower:
![Screen Shot 2019-05-21 at 2 22 23 PM](https://user-images.githubusercontent.com/19477691/58120798-f6c60800-7bd3-11e9-967f-722e288f6392.png)


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* 

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
