### PR TITLE
Sync Develop with Master (Release 9.9.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 **For example**
 - DP-1234: The short description text on a [service detail](http://mayflower.digital.mass.gov/?p=pages-detail-for-service-howto-location) page banner ([@organisms/by-template/page-banner](http://mayflower.digital.mass.gov/?p=organisms-page-banner)) should now render ([PR #493](https://github.com/massgov/mayflower/pull/493))
 
+## 9.9.1 (06/03/2019)
+
+### Fixed
+- (React) hotfix: Install `airbnb-prop-types` package as direct instead of dev package dependency in Mayflower-React.
+
 ## 9.9.0 (06/03/2019)
 
 ### Added

--- a/changelogs/react-patch-dependency.md
+++ b/changelogs/react-patch-dependency.md
@@ -1,4 +1,0 @@
-___DESCRIPTION___
-Patch
-Fixed
-- (React) hotfix: Install `airbnb-prop-types` package as direct instead of dev package dependency in Mayflower-React.


### PR DESCRIPTION
## 9.9.1 (06/03/2019)

### Fixed
- (React) hotfix: Install `airbnb-prop-types` package as direct instead of dev package dependency in Mayflower-React.