### PR TITLE
React/DP-14273:  b-jsonp throws windows undefined server side rendering

### DIFF
--- a/changelogs/DP-14273.md
+++ b/changelogs/DP-14273.md
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+Minor
+Fixed
+- (React) [FeedbackForm] DP-14273: Fixes a bug when the FeedbackForm is used with server side rendering caused by b-jsonp not checking for window.


### PR DESCRIPTION
## Description
Using the FeedbackForm component in Gatsby causes builds to fail during server side rendering, as the b-jsonp package does not check to see if the `window` object exists. This was fixed by only importing b-jsonp when window exists using a dynamic import.

## Related Issue / Ticket

- [JIRA issue](https://jira.mass.gov/browse/DP-14273)

## Steps to Test
1. Pull the branch, start up storybook locally `npm run start`. Browse to the FeedbackForm story and verify that no functionality has changed in any way.
2. Make a local build using `npm run build`, then make a link with `yarn link`. In your budget repo, run `yarn link-mayflower` then build any site (ex. `yarn run build:govbudget`). Verify that the build completes with no errors.
