### PR TITLE
React/DP-14234: InputDate in FilterBox on Select

### DIFF
--- a/assets/scss/00-base/_pikaday.scss
+++ b/assets/scss/00-base/_pikaday.scss
@@ -52,4 +52,7 @@
     box-shadow: none;
     border-radius: 0;
   }
+  .is-today.is-selected & {
+    color: $c-font-inverse;
+  }
 }

--- a/changelogs/DP-14234.md
+++ b/changelogs/DP-14234.md
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+Minor
+Fixed
+- (React) [InputDate] DP-14234: Fixes a bug where the numeric date would be hidden if the current date was today and the date was selected.

--- a/changelogs/DP-14234.md
+++ b/changelogs/DP-14234.md
@@ -1,4 +1,4 @@
 ___DESCRIPTION___
-Minor
+Patch
 Fixed
 - (React) [InputDate] DP-14234: Fixes a bug where the numeric date would be hidden if the current date was today and the date was selected.


### PR DESCRIPTION
## Description
This fixes a bug caused by there being no CSS rule for when the date is both today and currently selected for pikaday, causing the numeric date to not display because it's the same color as the background.

## Related Issue / Ticket

- [JIRA issue](https://jira.mass.gov/browse/DP-14234)

## Steps to Test. 
1. Pull the branch, run `npm run start`. Browse to the InputDate atom and verify that if today's date is selected and viewed, you can now see the numeric date.

## Screenshots
<img width="327" alt="Screen Shot 2019-06-06 at 12 55 37 PM" src="https://user-images.githubusercontent.com/5257660/59051342-aa78fa00-885a-11e9-8146-803fb9247ba1.png">
