### PR TITLE
react/[InputCurrency] pass id and type into onblur callback

### DIFF
--- a/changelogs/DP-14078.md
+++ b/changelogs/DP-14078.md
@@ -1,0 +1,2 @@
+Added
+- (React) [InputCurrency] DP-14078: Pass input id and event type to InputCurrency onBlur callback #629

--- a/react/src/components/atoms/forms/InputCurrency/InputCurrency.knobs.options.js
+++ b/react/src/components/atoms/forms/InputCurrency/InputCurrency.knobs.options.js
@@ -26,5 +26,6 @@ export default {
   }),
   showButtons: () => boolean('showButtons', true),
   onChange: () => action('onChange'),
+  onBlur: () => action('onBlur'),
   language: () => select('language', ['English', 'Chinese', 'French', 'Russian'], 'English')
 };

--- a/react/src/components/atoms/forms/InputCurrency/index.js
+++ b/react/src/components/atoms/forms/InputCurrency/index.js
@@ -157,7 +157,7 @@ const Currency = (props) => {
               const updateError = displayErrorMessage(newValue);
               context.updateState({ value: toCurrency(newValue, countDecimals(props.step)), ...updateError }, () => {
                 if (is.fn(props.onBlur)) {
-                  props.onBlur(newValue, { id: props.id, type });
+                  props.onBlur({value: newValue, id: props.id, type });
                 }
               });
             }

--- a/react/src/components/atoms/forms/InputCurrency/index.js
+++ b/react/src/components/atoms/forms/InputCurrency/index.js
@@ -157,7 +157,7 @@ const Currency = (props) => {
               const updateError = displayErrorMessage(newValue);
               context.updateState({ value: toCurrency(newValue, countDecimals(props.step)), ...updateError }, () => {
                 if (is.fn(props.onBlur)) {
-                  props.onBlur(newValue, props.id, type);
+                  props.onBlur(newValue, { id: props.id, type });
                 }
               });
             }

--- a/react/src/components/atoms/forms/InputCurrency/index.js
+++ b/react/src/components/atoms/forms/InputCurrency/index.js
@@ -137,7 +137,8 @@ const Currency = (props) => {
             }
           };
 
-          const handleBlur = () => {
+          const handleBlur = (e) => {
+            const { type } = e;
             const inputEl = ref.current;
             const stringValue = inputEl.value;
             // isNotNumber returns true if stringValue is null, undefined or 'NaN'
@@ -156,7 +157,7 @@ const Currency = (props) => {
               const updateError = displayErrorMessage(newValue);
               context.updateState({ value: toCurrency(newValue, countDecimals(props.step)), ...updateError }, () => {
                 if (is.fn(props.onBlur)) {
-                  props.onBlur(newValue);
+                  props.onBlur(newValue, props.id, type);
                 }
               });
             }

--- a/react/src/components/atoms/forms/InputCurrency/index.js
+++ b/react/src/components/atoms/forms/InputCurrency/index.js
@@ -157,7 +157,7 @@ const Currency = (props) => {
               const updateError = displayErrorMessage(newValue);
               context.updateState({ value: toCurrency(newValue, countDecimals(props.step)), ...updateError }, () => {
                 if (is.fn(props.onBlur)) {
-                  props.onBlur({value: newValue, id: props.id, type });
+                  props.onBlur(newValue, {id: props.id, type });
                 }
               });
             }


### PR DESCRIPTION
This pr passes form id and event type to InputCurrency onBlur callback
This is necessary for using onBlur to set form context in the UI benefits calculator in order for InputCurrency to allow decimal places using formContext --> https://jira.mass.gov/browse/DP-14078


For more info, npm link to https://github.com/massgov/calculators/pull/180