### PR TITLE
React/remove default unused link class

### DIFF
--- a/changelogs/link-remove-default-class.md
+++ b/changelogs/link-remove-default-class.md
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+Minor
+Added
+- (React) [Link, DecorativeLink] DP-12128: Remove unused default class. #645

--- a/react/src/components/atoms/links/DecorativeLink/index.js
+++ b/react/src/components/atoms/links/DecorativeLink/index.js
@@ -1,15 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
 import Icon from '../../icons/Icon';
 import './style.css';
 
 const DecorativeLink = (props) => {
-  const classes = ['ma__decorative-link'];
+  const classes = classNames({
+    'ma__decorative-link': true,
+    'ma__download-link': props.showFileIcon
+  });
   let decIcon = null;
   let title;
   if (props.showFileIcon) {
-    classes.push('ma__download-link');
     // eslint-disable-next-line no-bitwise
     const getFileExtension = (filename) => filename.slice((filename.lastIndexOf('.') - 1 >>> 0) + 2);
     let ext = getFileExtension(props.href);
@@ -34,7 +37,7 @@ const DecorativeLink = (props) => {
     }
   }
   return(
-    <span className={classes.join(' ')}>
+    <span className={classes}>
       <a
         href={props.href}
         title={props.info || null}

--- a/react/src/components/atoms/links/DecorativeLink/index.js
+++ b/react/src/components/atoms/links/DecorativeLink/index.js
@@ -37,7 +37,6 @@ const DecorativeLink = (props) => {
     <span className={classes.join(' ')}>
       <a
         href={props.href}
-        className="js-clickable-link"
         title={props.info || null}
       >
         {decIcon && <span className="ma__download-link--icon">{decIcon}&nbsp;</span>}{props.text}&nbsp;<Icon name="arrow" aria-hidden="true" />

--- a/react/src/components/molecules/Link/index.js
+++ b/react/src/components/molecules/Link/index.js
@@ -8,13 +8,12 @@ import { Icon } from '../../../index';
 const Link = (props) => {
   const icon = props.icon ? (<Icon name={props.icon} svgWidth={13.2} svgHeight={13.2} />) : '';
   const classes = classNames({
-    'js-clickable-link': true,
     [props.classes]: props.classes
   });
   return(
     <a
       href={props.href}
-      className={classes}
+      className={classes || null}
       title={props.info}
     >{ (props.children) ? props.children : props.text }&nbsp;{ icon }
     </a>


### PR DESCRIPTION
- (React) [Link, DecorativeLink] DP-12128: Remove unused default class. #645

In GTM, link type is relying on getting the link classname and if there's no class on <a> it will get the parent classname. Remove the js-clickable-link class to get the parent classname 
![Screen Shot 2019-06-26 at 5 00 53 PM](https://user-images.githubusercontent.com/5789411/60216774-ec350900-9838-11e9-91ef-e6b63ad062f8.png)
![Screen Shot 2019-06-26 at 5 00 46 PM](https://user-images.githubusercontent.com/5789411/60216817-0ec72200-9839-11e9-9ab6-5e81bdd9ded3.png)
