### PR TITLE
Feature/dp 13965 change title and h1

### DIFF
--- a/assets/scss/03-organisms/_page-header.scss
+++ b/assets/scss/03-organisms/_page-header.scss
@@ -188,6 +188,10 @@ $page-header-widget-width: 350px;
     &:last-child {
       margin-bottom: 0;
     }
+
+    .ma__page-header__sub-title {
+      margin-top: .8em;
+    }
   }
 
   .ma__page-banner ~ & &__title {
@@ -210,7 +214,7 @@ $page-header-widget-width: 350px;
   }
 
   // Control font size and line height
-  // regardless of it's added to page 
+  // regardless of it's added to page
   &__sub-title,
   &__sub-title * {
     font-size: 1.625rem !important;

--- a/changelogs/DP-13965.md
+++ b/changelogs/DP-13965.md
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+Minor
+Added
+- (Patternlab) [page-header] DP-13965: MF Change title and H1 on news overflow pages

--- a/patternlab/styleguide/source/_patterns/03-organisms/by-template/page-header-for-news-overflow.md
+++ b/patternlab/styleguide/source/_patterns/03-organisms/by-template/page-header-for-news-overflow.md
@@ -1,0 +1,6 @@
+### Description
+This is a variant of the [Page Header](./?p=organisms-page-header) pattern showing an example of how it is being used on the news overflow page.
+
+### How to generate
+* set the `nested` variable to true
+* add a `title`, `subTitle`, and `headerTags`

--- a/patternlab/styleguide/source/_patterns/03-organisms/by-template/page-header.twig
+++ b/patternlab/styleguide/source/_patterns/03-organisms/by-template/page-header.twig
@@ -35,10 +35,18 @@
         {% include "@atoms/04-headings/comp-heading.twig" %}
       </div>
     {% endif %}
-
-    <h1 class="ma__page-header__title">{% if prefix %}<span class="visually-hidden">{{ prefix }}&nbsp;</span>{% endif %}{{pageHeader.title}}</h1>
-    {% if pageHeader.subTitle %}
-      <div class="ma__page-header__sub-title">{{pageHeader.subTitle}}</div>
+    {% if pageHeader.nested %}
+        <h1 class="ma__page-header__title">{% if prefix %}<span class="visually-hidden">{{ prefix }}&nbsp;</span>{% endif %}{{pageHeader.title}}
+        {% if pageHeader.subTitle %}
+          <div class="ma__page-header__sub-title">{{pageHeader.subTitle}}</div>
+        {% endif %}
+        </h1>
+    {% else %}
+      <h1 class="ma__page-header__title">{% if prefix %}<span class="visually-hidden">{{ prefix }}&nbsp;</span>{% endif %}{{pageHeader.title}}
+      </h1>
+      {% if pageHeader.subTitle %}
+        <div class="ma__page-header__sub-title">{{pageHeader.subTitle}}</div>
+      {% endif %}
     {% endif %}
     {% if pageHeader.optionalContents %}
       <div class="ma__page-header__optional-content">

--- a/patternlab/styleguide/source/_patterns/03-organisms/by-template/page-header~for-news-overflow.json
+++ b/patternlab/styleguide/source/_patterns/03-organisms/by-template/page-header~for-news-overflow.json
@@ -1,0 +1,14 @@
+{
+  "pageHeader": {
+    "title": "News and Announcements",
+    "nested": true,
+    "subTitle": "For <a href=''>Office of Attorney General Maura Healey</a>",
+    "headerTags": {
+      "label": "Related to:",
+      "taxonomyTerms": [{
+        "href": "#",
+        "text": "Office of Attorney General Maura Healey"
+      }]
+    }
+  }
+}


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/dev/docs/change-log-instructions.md)


## Description
Add page header variation for news overflow pages.

## Related Issue / Ticket

- https://jira.mass.gov/browse/DP-13965

## Steps to Test

1. Go To: /patterns/03-organisms-by-template-page-header-for-news-overflow/03-organisms-by-template-page-header-for-news-overflow.html
2. You Should See This: The subheading should be inside the h1 tag 

## Screenshots
N/A


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* 

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
