### PR TITLE
Sync Develop with Master (Release 9.14.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 **For example**
 - DP-1234: The short description text on a [service detail](http://mayflower.digital.mass.gov/?p=pages-detail-for-service-howto-location) page banner ([@organisms/by-template/page-banner](http://mayflower.digital.mass.gov/?p=organisms-page-banner)) should now render ([PR #493](https://github.com/massgov/mayflower/pull/493))
 
+## 9.14.0 (06/27/2019)
+
+### Fixed
+- (Patternlab) [location-banner] DP-12216: Update banner image scss to avoid background repeating. #634
+
+### Changed
+- (React) [Link, DecorativeLink] DP-12128: Remove unused default class. #645
+- (React) [TabContainer] DP-14424: Got rid of the need to track Tab children in state. Refactored TabContainer organism to use React Portals for rendering its children. #637
+- (React) [Tab] DP-14424: Added TabBody component for rendering Tab children directly into TabContainer organism. Removed unused default prop. Converted component to be a class from a function and removed the need for React.forwardRef. #637
+
 ## 9.13.0 (06/26/2019)
 
 ### Added

--- a/changelogs/DP-12216.md
+++ b/changelogs/DP-12216.md
@@ -1,4 +1,0 @@
-___DESCRIPTION___
-Minor
-Added
-- (Patternlab) [location-banner] DP-12216: Update banner image scss to avoid background repeating.

--- a/changelogs/DP-14424.md
+++ b/changelogs/DP-14424.md
@@ -1,7 +1,0 @@
-___DESCRIPTION___
-Major
-Changed
-- (React) [TabContainer] DP-14424: Refactored TabContainer organism to use React Portals for rendering its children.
-- (React) [TabContainer] DP-14424: Got rid of the need to track Tab children in state.
-- (React) [Tab] DP-14424: Added TabBody component for rendering Tab children directly into TabContainer organism.
-- (React) [Tab] DP-14424: Removed unused default prop. Converted component to be a class from a function and removed the need for React.forwardRef.

--- a/changelogs/link-remove-default-class.md
+++ b/changelogs/link-remove-default-class.md
@@ -1,4 +1,0 @@
-___DESCRIPTION___
-Minor
-Added
-- (React) [Link, DecorativeLink] DP-12128: Remove unused default class. #645


### PR DESCRIPTION
## 9.14.0 (06/27/2019)

### Fixed
- (Patternlab) [location-banner] DP-12216: Update banner image scss to avoid background repeating. #634

### Changed
- (React) [Link, DecorativeLink] DP-12128: Remove unused default class. #645
- (React) [TabContainer] DP-14424: Got rid of the need to track Tab children in state. Refactored TabContainer organism to use React Portals for rendering its children. #637
- (React) [Tab] DP-14424: Added TabBody component for rendering Tab children directly into TabContainer organism. Removed unused default prop. Converted component to be a class from a function and removed the need for React.forwardRef. #637