### PR TITLE
Feature/dp 11891 mf printer styles off

### DIFF
--- a/assets/scss/08-print/_print.scss
+++ b/assets/scss/08-print/_print.scss
@@ -457,8 +457,12 @@
     display: none;
   }
 
+  .ma__details__stick-nav {
+    display: none;
+  }
+
   .ma__details__content {
-    margin-left: 0;
+    margin-left: 0 !important;
   }
 
   .ma__callout-time__text {

--- a/changelogs/DP-11891.md
+++ b/changelogs/DP-11891.md
@@ -1,0 +1,3 @@
+Minor
+Changed
+- (Patternlab) [How-To Pages] DP-11891: Fixed How-to pages printer style being incorrectly indented.


### PR DESCRIPTION
## Description
Fixes a printing issue with How-To Pages being incorrectly indented

## Related Issue / Ticket

- https://jira.mass.gov/browse/DP-11891

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Go To: http://localhost:3000/patterns/05-pages-howto/05-pages-howto.html
2. Do This: Open print preview
3. You Should See This: The page should not be indented when it gets to the "What you need" section and the content's left margin should match the rest of the page.