### PR TITLE
DP-15056: Update contact-row template

### DIFF
--- a/changelogs/DP-15056.txt
+++ b/changelogs/DP-15056.txt
@@ -1,0 +1,3 @@
+Minor
+Added
+- (Patternlab) [contact-row] DP-15056: Added blocks around contact groups to allow overriding on a field-by-field basis.

--- a/patternlab/styleguide/source/_patterns/03-organisms/by-author/contact-row.twig
+++ b/patternlab/styleguide/source/_patterns/03-organisms/by-author/contact-row.twig
@@ -17,31 +17,39 @@
   <div class="ma__contact-row__columns">
     {% block additionalContacts %}
 
-    {% if  contactRow.addressContactGroup %}
+    {% if contactRow.addressContactGroup %}
       <div class="ma__contact-row--address ma__contact-set">
-        {% set contactGroup = contactRow.addressContactGroup %}
-        {% include "@molecules/contact-group.twig" %}
+        {% block addressContactGroup %}
+          {% set contactGroup = contactRow.addressContactGroup %}
+          {% include "@molecules/contact-group.twig" %}
+        {% endblock %}
       </div>
     {% endif %}
 
     {% if contactRow.phoneContactGroup %}
       <div class="ma__contact-row--phone ma__contact-set">
-        {% set contactGroup = contactRow.phoneContactGroup %}
-        {% include "@molecules/contact-group.twig" %}
+        {% block phoneContactGroup %}
+          {% set contactGroup = contactRow.phoneContactGroup %}
+          {% include "@molecules/contact-group.twig" %}
+        {% endblock %}
       </div>
     {% endif %}
 
-    {% if  contactRow.onlineContactGroup %}
+    {% if contactRow.onlineContactGroup %}
       <div class="ma__contact-row--online ma__contact-set">
-        {% set contactGroup = contactRow.onlineContactGroup %}
-        {% include "@molecules/contact-group.twig" %}
+        {% block onlineContactGroup %}
+          {% set contactGroup = contactRow.onlineContactGroup %}
+          {% include "@molecules/contact-group.twig" %}
+        {% endblock %}
       </div>
     {% endif %}
 
     {% if contactRow.faxContactGroup %}
       <div class="ma__contact-row--fax ma__contact-set">
-        {% set contactGroup = contactRow.faxContactGroup %}
-        {% include "@molecules/contact-group.twig" %}
+        {% block faxContactGroup %}
+          {% set contactGroup = contactRow.faxContactGroup %}
+          {% include "@molecules/contact-group.twig" %}
+        {% endblock %}
       </div>
     {% endif %}
 


### PR DESCRIPTION
## Description
Added blocks around contact fields to allow overriding each on a field-by-field basis. This prevents having to duplicate markup in Drupal in order to inject the contact information.

## Related Issue / Ticket

- [JIRA issue](https://jira.mass.gov/browse/DP-15056)
- [Related Drupal issue](https://jira.mass.gov/browse/DP-11107)

## Steps to Test

This should have no affect on the output of the markup in patternlab. So the test is to verify that markup on the contact-row template is outputted as before.

1. /?p=organisms-contact-row
2. /?p=pages-contact-row-examples