### PR TITLE
DP-9262: MF [a11y] No indication of link at hover-over

### DIFF
--- a/assets/scss/02-molecules/_image-link.scss
+++ b/assets/scss/02-molecules/_image-link.scss
@@ -35,6 +35,14 @@
 .ma__image-link--block {
     background: $c-gray-lightest;
 
+    &:hover,
+    &:active,
+    &:focus {
+        .ma__image-link__text {
+            text-decoration: underline;
+        }
+    }
+
     .ma__image-link__text {
         color: $c-gray-dark;
     }

--- a/changelogs/DP-9262.md
+++ b/changelogs/DP-9262.md
@@ -1,3 +1,4 @@
+___DESCRIPTION___
 Patch
 Changed
-- (Patternlab) [image-link] DP-9262: Add underline to :hover and :focus states of image links (#TK)
+- (Patternlab) [image-link] DP-9262: Add underline to :hover and :focus states of image links (#678)

--- a/changelogs/DP-9262.md
+++ b/changelogs/DP-9262.md
@@ -1,0 +1,3 @@
+Patch
+Changed
+- (Patternlab) [image-link] DP-9262: Add underline to :hover and :focus states of image links (#TK)


### PR DESCRIPTION
## Description

Modified the image-link component to underline the text of image link blocks in :hover, :active, and :focus states.

## Related Issue / Ticket

- [JIRA issue](https://jira.mass.gov/browse/DP-9262)


## Steps to Test

### Go here

- http://mass.local/orgs/office-of-the-governor

### Do this

- Scroll down to the "Our Organizations" section
- Hover over the blocks

### You should see

Underlined text on hover

### Do this

Tab down the page until one of the Our Organizations blocks has keyboard focus

### You should see

Underlined text on the focused block, as well as the usual browser outline around it

## Screenshots

<img width="1272" alt="Screen Shot 2019-07-18 at 4 10 36 PM" src="https://user-images.githubusercontent.com/52927667/61492276-a15d6b80-a976-11e9-9d75-b69ea4cc5196.png">

## Additional Notes:

Anything else to add?

#### Impacted Areas in Application

* Image link blocks