### PR TITLE
DP-9274 MF [a11y] Add more context to more link text

### DIFF
--- a/changelogs/DP-9274.md
+++ b/changelogs/DP-9274.md
@@ -1,0 +1,6 @@
+___DESCRIPTION___
+Patch
+Added
+- (Patternlab) [Link] DP-9274: Added `labelContext` variable for an optional visually-hidden suffix #TK
+Changed
+- (Patternlab) [PressListingAsGrid] DP-9274: Changed JSON to use the `link` component’s new `labelContext` variable in the style guide #TK

--- a/changelogs/DP-9274.md
+++ b/changelogs/DP-9274.md
@@ -1,6 +1,6 @@
 ___DESCRIPTION___
 Patch
 Added
-- (Patternlab) [Link] DP-9274: Added `labelContext` variable for an optional visually-hidden suffix #TK
+- (Patternlab) [Link] DP-9274: Added `labelContext` variable for an optional visually-hidden suffix #683
 Changed
-- (Patternlab) [PressListingAsGrid] DP-9274: Changed JSON to use the `link` component’s new `labelContext` variable in the style guide #TK
+- (Patternlab) [PressListingAsGrid] DP-9274: Changed JSON to use the `link` component’s new `labelContext` variable in the style guide #683

--- a/patternlab/styleguide/source/_patterns/01-atoms/11-text/link.json
+++ b/patternlab/styleguide/source/_patterns/01-atoms/11-text/link.json
@@ -2,6 +2,7 @@
   "link": {
     "href": "#",
     "text":"This is a link",
+    "labelContext": "to show as an example",
     "info": "",
     "chevron": ""
   }

--- a/patternlab/styleguide/source/_patterns/01-atoms/11-text/link.twig
+++ b/patternlab/styleguide/source/_patterns/01-atoms/11-text/link.twig
@@ -17,4 +17,4 @@
 <a 
   class="ma__content-link {{ classChevron ? 'ma__content-link--chevron' : '' }}" 
   href="{{ link.href }}"
-  title="{{ link.info }}"><span>{{ link.text }}</span></a>
+  {% if link.info %} title="{{ link.info }}"{% endif %}><span>{{ link.text }}</span>{% if link.labelContext %}<span class="ma__visually-hidden"> {{ link.labelContext }}</span>{% endif %}</a>

--- a/patternlab/styleguide/source/_patterns/03-organisms/by-author/press-listing~as-grid.json
+++ b/patternlab/styleguide/source/_patterns/03-organisms/by-author/press-listing~as-grid.json
@@ -201,8 +201,8 @@
     "more":{
       "href": "#",
       "text": "See all news and announcements",
-      "chevron": true,
-      "label": "See all news and announcements for the blah blah location"
+      "labelContext": "for the blah blah location",
+      "chevron": true
     }
   }
 }

--- a/patternlab/styleguide/source/_patterns/05-pages/organization-elected-official.json
+++ b/patternlab/styleguide/source/_patterns/05-pages/organization-elected-official.json
@@ -998,7 +998,7 @@
                 "href": "#",
                 "text": "See all news and announcements",
                 "chevron": true,
-                "label": "See all news and announcements for the Executive Office of Health and Human Services"
+                "labelContext": "for the Executive Office of Health and Human Services"
               }
             }
           }

--- a/patternlab/styleguide/source/_patterns/05-pages/organization-elected-official.json
+++ b/patternlab/styleguide/source/_patterns/05-pages/organization-elected-official.json
@@ -1020,8 +1020,8 @@
               "events": null,
               "pastMore": {
                 "href": "#",
-                "text": "See all events, agendas, and meeting minutes",
-                "info": "view all past events for Office of the Treasurer & Receiver General",
+                "text": "See all past events, agendas, and meeting minutes",
+                "labelContext": "for the Office of the Treasurer & Receiver General",
                 "chevron": true
               }
             }


### PR DESCRIPTION
## Description

Prepared the `link` component to accept the labelContext variable for accessible, lengthy descriptions. Updated the `press-listing-as-grid` component's style guide example to use this new variable.

## Related Issue / Ticket

- [JIRA issue](https://jira.mass.gov/browse/DP-9274)


## Steps to Test

#### Go here and do this

1. `npm run gulp` the style guide
2. Visit http://localhost:3000/?p=atoms-link
3. Inspect the link in the browser developer tools

#### What you should see

A previously unseen visually-hidden span with " to show as an example" following the visible link text

#### Go here and do this

1. Go to http://localhost:3000/?p=organisms-press-listing-as-grid
2. Scroll to the bottom and inspect the "See all news and announcements" link in the browser developer tools

#### What you should see

A visually-hidden span with " for the blah blah location" after the visible link text (this is the same as the previous title text)

## Additional Notes:

To fully achieve the goal of DP-9274, some back-end changes will be required. A ticket for that part of the work is forthcoming.

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

* Create ticket for back-end portion of the work
    * Work needed is to change the method that prepares the news section "More" links to output the accessibility text after the link text instead of a `title` attribute on the link