### PR TITLE
DP-6174 MF restyle or remove large X in search box in IE

### DIFF
--- a/assets/scss/02-molecules/_header-search.scss
+++ b/assets/scss/02-molecules/_header-search.scss
@@ -18,6 +18,9 @@ $bp-header-search-reduce-button: "max-width: 700px";
     padding-left: 17px;
     width: 100%;
 
+    &::-ms-clear {
+      display: none;
+    }
 
     @media ($bp-header-search-reduce-button) {
       padding-right: 60px

--- a/changelogs/DP-6174.md
+++ b/changelogs/DP-6174.md
@@ -1,4 +1,4 @@
 ___DESCRIPTION___
 Patch
 Changed
-- (Patternlab) [HeaderSearch] DP-6174: Removed search field clear button in IE #TK
+- (Patternlab) [HeaderSearch] DP-6174: Removed search field clear button in IE #688

--- a/changelogs/DP-6174.md
+++ b/changelogs/DP-6174.md
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+Patch
+Changed
+- (Patternlab) [HeaderSearch] DP-6174: Removed search field clear button in IE #TK


### PR DESCRIPTION

Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/dev/docs/change-log-instructions.md)


## Description
Hid (with CSS) the big X button that appeared in Internet Explorer when any text was typed in the search field.

## Related Issue / Ticket

- [JIRA issue](https://jira.mass.gov/browse/DP-6174)


## Steps to Test

#### Go here and do this

- Run the style guide
- Go to localhost:3000/?p=molecules-header-search in Internet Explorer 10 or 11
- Type some text in the search field

#### What you should see

No big X button appears to clear the field.

## Screenshots

![Screen Shot 2019-07-26 at 2 43 59 PM](https://user-images.githubusercontent.com/52927667/61977353-df304480-afb3-11e9-823b-0cf5cadc7819.png)

#### Impacted Areas in Application

* Front page