### PR TITLE
fix error message success color

### DIFF
--- a/assets/scss/01-atoms/_error-msg.scss
+++ b/assets/scss/01-atoms/_error-msg.scss
@@ -12,13 +12,15 @@
    margin-right: 3px;
  }
 
-  &--success {
-    display: flex;
-    color: $c-primary-alt;
-  }
+ &.has-error{
+   display: flex;
+   color: $c-font-error;
 
-  &.has-error{
-    display: flex;
-    color: $c-font-error;
-  }
+   &.ma__error-msg--success {
+       display: flex;
+       color: $c-primary-alt;
+     }
+ }
+
+
 }


### PR DESCRIPTION
(React) [ErrorMessage] Hotfix: fix success message color  #691 

Before:
<img width="100" alt="Screen Shot 2019-08-02 at 10 29 41 AM" src="https://user-images.githubusercontent.com/5789411/62378249-67fa3380-b512-11e9-9623-f6a38d0e9d10.png">
After:
<img width="97" alt="Screen Shot 2019-08-02 at 10 37 45 AM" src="https://user-images.githubusercontent.com/5789411/62378248-67fa3380-b512-11e9-8f85-3d82256bb54c.png">

