### PR TITLE
react/DP-14479: Patch Tabs scrollIntoView

### DIFF
--- a/changelogs/DP-14479.md
+++ b/changelogs/DP-14479.md
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+Patch
+Changed
+- (React) [Tabs] DP-14479: Path Tabs molecule so scrollinto view action only called if it exist. #693

--- a/changelogs/DP-14479.md
+++ b/changelogs/DP-14479.md
@@ -1,4 +1,4 @@
 ___DESCRIPTION___
 Patch
 Changed
-- (React) [Tabs] DP-14479: Path Tabs molecule so scrollinto view action only called if it exist. #693
+- (React) [Tabs] DP-14479: Patch Tabs molecule so scrollIntoView action only called if it exists. #693 

--- a/react/src/components/molecules/Tabs/index.js
+++ b/react/src/components/molecules/Tabs/index.js
@@ -6,8 +6,9 @@ import './style.css';
 const Tabs = (tabs) => {
   const handleAllClick = (e) => {
     const selTab = e.target;
-    selTab.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'center' });
-
+    if(selTab && selTab.scrollIntoView) {
+      selTab.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'center' });
+    }
     // invokes custom function if passed in the component
     if (typeof tabs.handleClick === 'function') {
       const selectedTab = selTab.name;

--- a/react/src/components/molecules/Tabs/index.js
+++ b/react/src/components/molecules/Tabs/index.js
@@ -6,7 +6,7 @@ import './style.css';
 const Tabs = (tabs) => {
   const handleAllClick = (e) => {
     const selTab = e.target;
-    if(selTab && selTab.scrollIntoView) {
+    if (selTab && selTab.scrollIntoView) {
       selTab.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'center' });
     }
     // invokes custom function if passed in the component


### PR DESCRIPTION
___DESCRIPTION___
Patch
Changed
- (React) [Tabs] DP-14479: Patch Tabs molecule so scrollIntoView action only called if it exists. #693 
