### PR TITLE
DP-8937 MF Adjust breakpoints for contact accordion to stack in main well

### DIFF
--- a/assets/scss/02-molecules/_contact-us.scss
+++ b/assets/scss/02-molecules/_contact-us.scss
@@ -71,15 +71,6 @@
     padding: 0 20px 30px;
   }
 
-  .js &--accordion &__content &__content-wrap {
-    // width overlaps parent's 1px borders & negates parent padding
-    // This is so we can have divider borders (left border) and since we have a wrapping
-    // flexbox grid, the first item on each show needs its left border hidden.
-    width: calc(100% + 42px);
-    position: relative;
-      left: -21px;
-  }
-
   // Flexible contact group layout
   // Max 4 column layout, items are no narrower than 18rem & then wrap
   &__content-wrap {
@@ -87,7 +78,25 @@
     flex-wrap: wrap;
     justify-content: flex-start;
     flex-basis: 25%;
+  }
 
+  .js &--accordion &__content &__content-wrap {
+    // width overlaps parent's 1px borders & negates parent padding
+    // This is so we can have divider borders (left border) and since we have a wrapping
+    // flexbox grid, the first item on each show needs its left border hidden.
+    width: calc(100% + 42px);
+    position: relative;
+    left: -21px;
+  }
+
+  &--accordion &__content-wrap {
+    // Always display contact groups stacked when inside accordions
+    display: block;
+
+    .ma__contact-group {
+      max-width: none;
+      padding-bottom: 0;
+    }
   }
 
   &__content-wrap .ma__contact-group {

--- a/changelogs/DP-8937.md
+++ b/changelogs/DP-8937.md
@@ -1,0 +1,5 @@
+___DESCRIPTION___
+Patch
+Changed
+- (Patternlab) [ContactUs] DP-8937: Made contact groups inside accordions always stack vertically. #TK
+

--- a/changelogs/DP-9274.md
+++ b/changelogs/DP-9274.md
@@ -1,0 +1,6 @@
+___DESCRIPTION___
+Patch
+Added
+- (Patternlab) [Link] DP-9274: Added `labelContext` variable for an optional visually-hidden suffix #TK
+Changed
+- (Patternlab) [PressListingAsGrid] DP-9274: Changed JSON to use the `link` component’s new `labelContext` variable in the style guide #TK

--- a/changelogs/DP-9274.md
+++ b/changelogs/DP-9274.md
@@ -1,6 +1,6 @@
 ___DESCRIPTION___
 Patch
 Added
-- (Patternlab) [Link] DP-9274: Added `labelContext` variable for an optional visually-hidden suffix #TK
+- (Patternlab) [Link] DP-9274: Added `labelContext` variable for an optional visually-hidden suffix #683
 Changed
-- (Patternlab) [PressListingAsGrid] DP-9274: Changed JSON to use the `link` component’s new `labelContext` variable in the style guide #TK
+- (Patternlab) [PressListingAsGrid] DP-9274: Changed JSON to use the `link` component’s new `labelContext` variable in the style guide #683

--- a/patternlab/styleguide/source/_patterns/01-atoms/11-text/link.json
+++ b/patternlab/styleguide/source/_patterns/01-atoms/11-text/link.json
@@ -2,6 +2,7 @@
   "link": {
     "href": "#",
     "text":"This is a link",
+    "labelContext": "to show as an example",
     "info": "",
     "chevron": ""
   }

--- a/patternlab/styleguide/source/_patterns/01-atoms/11-text/link.twig
+++ b/patternlab/styleguide/source/_patterns/01-atoms/11-text/link.twig
@@ -17,4 +17,4 @@
 <a 
   class="ma__content-link {{ classChevron ? 'ma__content-link--chevron' : '' }}" 
   href="{{ link.href }}"
-  title="{{ link.info }}"><span>{{ link.text }}</span></a>
+  {% if link.info %} title="{{ link.info }}"{% endif %}><span>{{ link.text }}</span>{% if link.labelContext %}<span class="ma__visually-hidden"> {{ link.labelContext }}</span>{% endif %}</a>

--- a/patternlab/styleguide/source/_patterns/03-organisms/by-author/press-listing~as-grid.json
+++ b/patternlab/styleguide/source/_patterns/03-organisms/by-author/press-listing~as-grid.json
@@ -201,8 +201,8 @@
     "more":{
       "href": "#",
       "text": "See all news and announcements",
-      "chevron": true,
-      "label": "See all news and announcements for the blah blah location"
+      "labelContext": "for the blah blah location",
+      "chevron": true
     }
   }
 }

--- a/patternlab/styleguide/source/_patterns/05-pages/organization-elected-official.json
+++ b/patternlab/styleguide/source/_patterns/05-pages/organization-elected-official.json
@@ -998,7 +998,7 @@
                 "href": "#",
                 "text": "See all news and announcements",
                 "chevron": true,
-                "label": "See all news and announcements for the Executive Office of Health and Human Services"
+                "labelContext": "for the Executive Office of Health and Human Services"
               }
             }
           }

--- a/patternlab/styleguide/source/_patterns/05-pages/organization-elected-official.json
+++ b/patternlab/styleguide/source/_patterns/05-pages/organization-elected-official.json
@@ -1020,8 +1020,8 @@
               "events": null,
               "pastMore": {
                 "href": "#",
-                "text": "See all events, agendas, and meeting minutes",
-                "info": "view all past events for Office of the Treasurer & Receiver General",
+                "text": "See all past events, agendas, and meeting minutes",
+                "labelContext": "for the Office of the Treasurer & Receiver General",
                 "chevron": true
               }
             }


### PR DESCRIPTION
## Description
Made contact groups always stack vertically when inside an accordion.

## Related Issue / Ticket

- [JIRA issue](https://jira.mass.gov/browse/DP-8937)

## Steps to Test

#### Go here and do this

Go to `?p=pages-howto` in Mayflower and expand the accordions under "Contact Us" toward the bottom.

Also go to `?p=molecules-contact-us-collapsed-with-more-link`.

#### You should see

In both cases, the contact details should stack vertically at all browser widths.

## Screenshots

![Screen Shot 2019-08-07 at 1 22 25 PM](https://user-images.githubusercontent.com/52927667/62647571-71bad700-b916-11e9-8d6e-a35ea591ec00.png)

![Screen Shot 2019-08-07 at 1 21 32 PM](https://user-images.githubusercontent.com/52927667/62647581-78494e80-b916-11e9-8b57-98d7dfd52930.png)