### PR TITLE
Feature/dp 8937  stacked contact us accordions

### DIFF
--- a/assets/scss/02-molecules/_contact-us.scss
+++ b/assets/scss/02-molecules/_contact-us.scss
@@ -71,15 +71,6 @@
     padding: 0 20px 30px;
   }
 
-  .js &--accordion &__content &__content-wrap {
-    // width overlaps parent's 1px borders & negates parent padding
-    // This is so we can have divider borders (left border) and since we have a wrapping
-    // flexbox grid, the first item on each show needs its left border hidden.
-    width: calc(100% + 42px);
-    position: relative;
-      left: -21px;
-  }
-
   // Flexible contact group layout
   // Max 4 column layout, items are no narrower than 18rem & then wrap
   &__content-wrap {
@@ -87,7 +78,25 @@
     flex-wrap: wrap;
     justify-content: flex-start;
     flex-basis: 25%;
+  }
 
+  .js &--accordion &__content &__content-wrap {
+    // width overlaps parent's 1px borders & negates parent padding
+    // This is so we can have divider borders (left border) and since we have a wrapping
+    // flexbox grid, the first item on each show needs its left border hidden.
+    width: calc(100% + 42px);
+    position: relative;
+    left: -21px;
+  }
+
+  &--accordion &__content-wrap {
+    // Always display contact groups stacked when inside accordions
+    display: block;
+
+    .ma__contact-group {
+      max-width: none;
+      padding-bottom: 0;
+    }
   }
 
   &__content-wrap .ma__contact-group {

--- a/changelogs/DP-8937.md
+++ b/changelogs/DP-8937.md
@@ -1,0 +1,5 @@
+___DESCRIPTION___
+Patch
+Changed
+- (Patternlab) [ContactUs] DP-8937: Made contact groups inside accordions always stack vertically. #TK
+

--- a/changelogs/DP-8937.md
+++ b/changelogs/DP-8937.md
@@ -1,5 +1,5 @@
 ___DESCRIPTION___
 Patch
 Changed
-- (Patternlab) [ContactUs] DP-8937: Made contact groups inside accordions always stack vertically. #TK
+- (Patternlab) [ContactUs] DP-8937: Made contact groups inside accordions always stack vertically. #697
 


### PR DESCRIPTION
## Description
Made contact groups always stack vertically when inside an accordion.

## Related Issue / Ticket

- [JIRA issue](https://jira.mass.gov/browse/DP-8937)

## Steps to Test

#### Go here and do this

Go to `?p=pages-howto` in Mayflower and expand the accordions under "Contact Us" toward the bottom.

Also go to `?p=molecules-contact-us-collapsed-with-more-link`.

#### You should see

In both cases, the contact details should stack vertically at all browser widths.

## Screenshots

![Screen Shot 2019-08-07 at 1 22 25 PM](https://user-images.githubusercontent.com/52927667/62647571-71bad700-b916-11e9-8d6e-a35ea591ec00.png)

![Screen Shot 2019-08-07 at 1 21 32 PM](https://user-images.githubusercontent.com/52927667/62647581-78494e80-b916-11e9-8b57-98d7dfd52930.png)