### PR TITLE
Patternlab/DP-14912  mobile sticky toc fix

### DIFF
--- a/assets/scss/03-organisms/_sticky-toc.scss
+++ b/assets/scss/03-organisms/_sticky-toc.scss
@@ -90,15 +90,27 @@
     line-height: .65em;
     overflow: hidden;
     position: absolute;
-      right: 10px;
-      top: 9px;
-    transition: transform .2s ease;
-    transform-origin: center center;
+    right: 10px;
+    width: 100%;
+    height: 100%;
+    max-height: 45px;
+   
     z-index: 1;
 
-    .is-open & {
-      transform: rotate(135deg);
+    &::after {
+      content: "+";
+      position: absolute;
+      top: 10px;
+      right: 10px;
+      transition: transform .2s ease;
+      transform-origin: center center;
+
+      .is-open & {
+        transform: rotate(135deg);
+      }
     }
+
+    
 
     @media ($bp-x-small-min) {
       display: none;
@@ -498,6 +510,8 @@
       top:0;
       right: 0;
       transition: right 0.3s ease-out;
+      position: fixed;
+      z-index: 9999;
     }
   }
 }

--- a/assets/scss/03-organisms/_sticky-toc.scss
+++ b/assets/scss/03-organisms/_sticky-toc.scss
@@ -447,7 +447,7 @@
   
   overflow: auto;
 
-  @media($bp-small-min) {
+  @media($bp-medium-min) {
    padding-top: 35px;
   }
 
@@ -475,7 +475,7 @@
     width: 100%;
     max-width: 550px;
 
-    @media($bp-small-min) {
+    @media($bp-medium-min) {
       right: -600px;
     }
 
@@ -516,7 +516,7 @@
 
     .ma__sticky-toc__secondary-label {
 
-      @media($bp-small-min) {
+      @media($bp-medium-min) {
         top:0;
         right: 0;
         transition: right 0.3s ease-out;

--- a/assets/scss/03-organisms/_sticky-toc.scss
+++ b/assets/scss/03-organisms/_sticky-toc.scss
@@ -444,8 +444,12 @@
   z-index: 99;
   background-color: $c-white;
   transition: right 0.3s ease-out;
-  padding-top: 35px;
+  
   overflow: auto;
+
+  @media($bp-small-min) {
+   padding-top: 35px;
+  }
 
   @media ($bp-header-toggle-min) {
     top: 0;
@@ -456,7 +460,7 @@
     display: flex;
     z-index: 99;
     position: fixed;
-    right: -600px;
+    
     align-items: center;
     justify-content: space-between;
     border: 0;
@@ -470,6 +474,10 @@
     padding: 10px 20px;
     width: 100%;
     max-width: 550px;
+
+    @media($bp-small-min) {
+      right: -600px;
+    }
 
     &::after {
       content: '';
@@ -507,11 +515,14 @@
     z-index: 10000;
 
     .ma__sticky-toc__secondary-label {
-      top:0;
-      right: 0;
-      transition: right 0.3s ease-out;
-      position: fixed;
-      z-index: 9999;
+
+      @media($bp-small-min) {
+        top:0;
+        right: 0;
+        transition: right 0.3s ease-out;
+        position: fixed;
+        z-index: 9999;
+      }
     }
   }
 }

--- a/changelogs/DP-14912.md
+++ b/changelogs/DP-14912.md
@@ -1,0 +1,4 @@
+___DESCRIPTION___
+Patch
+Fixed
+- (Patternlab) [StickyTOC] DP-14912: reposition stickyTOC on mobile screens

--- a/patternlab/styleguide/source/_patterns/03-organisms/by-template/sticky-toc.twig
+++ b/patternlab/styleguide/source/_patterns/03-organisms/by-template/sticky-toc.twig
@@ -8,7 +8,7 @@
     <div class="ma__sticky-toc__container">
       <h2 class="ma__sticky-toc__title" id="page-contents">{{ stickyTOC.title }}</h2>
       <nav class="ma__sticky-toc__links" aria-labelledby="page-contents">
-        <button class="ma__sticky-toc__toggle-link">+</button>
+        <button class="ma__sticky-toc__toggle-link"></button>
         <div class="ma__sticky-toc__column">
           <div class="ma__sticky-toc__secondary-label">{{ stickyTOC.title }} <span class="secondary-label-close"></span></div>
           {% for link in stickyTOC.links %}


### PR DESCRIPTION
## Description
Repositions the sticky TOC on mobile screens

## Related Issue / Ticket

- [DP-14912](https://jira.mass.gov/browse/DP-14912)

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. On a mobile phone, open the link and scroll the page until the sticky TOC gets stuck to the top.
2. Click to open the link
https://mayflower.digital.mass.gov/b/patternlab/DP-14912--mobile-sticky-TOC-fix/patterns/05-pages-regulation/05-pages-regulation.html
3. You should see that the stick TOC now sits below the menu, rather than being stuck underneath it.

## Screenshots
![File](https://user-images.githubusercontent.com/18662734/62903981-2c3d4600-bd2a-11e9-8dfd-b5f98835efd8.jpg)

