### PR TITLE
DP-14105: MF/DEV Add overview rich text area above TOC in information details page in MF

### DIFF
--- a/assets/scss/04-templates/_information-details.scss
+++ b/assets/scss/04-templates/_information-details.scss
@@ -9,7 +9,7 @@
 }
 //theme
 .ma__information-details {
-  
+
   .pre-content .ma__rich-text {
     margin-bottom: 30px;
   }

--- a/assets/scss/04-templates/_information-details.scss
+++ b/assets/scss/04-templates/_information-details.scss
@@ -9,6 +9,10 @@
 }
 //theme
 .ma__information-details {
+  
+  .pre-content .ma__rich-text {
+    margin-bottom: 30px;
+  }
 
   &__content,
   &__post-content {

--- a/changelogs/DP-14105.md
+++ b/changelogs/DP-14105.md
@@ -1,5 +1,5 @@
 ___DESCRIPTION___
 Minor
 Added
-- (Patternlab) [InformationDetails] DP-14105: Added Overview field to Information Details pages #TK
+- (Patternlab) [InformationDetails] DP-14105: Added Overview field to Information Details pages #725
 

--- a/changelogs/DP-14105.md
+++ b/changelogs/DP-14105.md
@@ -1,0 +1,5 @@
+___DESCRIPTION___
+Minor
+Added
+- (Patternlab) [InformationDetails] DP-14105: Added Overview field to Information Details pages #TK
+

--- a/patternlab/styleguide/source/_patterns/04-templates/01-content-types/information-details.twig
+++ b/patternlab/styleguide/source/_patterns/04-templates/01-content-types/information-details.twig
@@ -12,7 +12,9 @@
       {% include "@organisms/by-template/page-header.twig" %}
 
       {% block overview %}
-        {% include "@base/placeholder.twig" with {'placeholder':{'text':'Overview text'}} %}
+        <div class="ma__rich-text">
+          <p>Overview text. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+        </div>
       {% endblock %}
 
       {% if stickyTOC %}

--- a/patternlab/styleguide/source/_patterns/04-templates/01-content-types/information-details.twig
+++ b/patternlab/styleguide/source/_patterns/04-templates/01-content-types/information-details.twig
@@ -11,6 +11,10 @@
       {% include "@molecules/relationship-indicators.twig" %}
       {% include "@organisms/by-template/page-header.twig" %}
 
+      {% block overview %}
+        {% include "@base/placeholder.twig" with {'placeholder':{'text':'Overview text'}} %}
+      {% endblock %}
+
       {% if stickyTOC %}
       <div class="ma__information-details__pre-content-media">
         {% block stickyTOC %}

--- a/patternlab/styleguide/source/_patterns/05-pages/information-details.json
+++ b/patternlab/styleguide/source/_patterns/05-pages/information-details.json
@@ -32,6 +32,18 @@
       }]
     }
   },
+  "overview": {
+    "rteElements": [
+      {
+        "path": "@atoms/11-text/paragraph.twig",
+        "data": {
+          "paragraph": {
+            "text": "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+          }
+        }
+      }
+    ]
+  },
   "pageContent": {
     "section1": {
       "compHeading": {

--- a/patternlab/styleguide/source/_patterns/05-pages/information-details.json
+++ b/patternlab/styleguide/source/_patterns/05-pages/information-details.json
@@ -10,6 +10,18 @@
       "subTitle": "MassWildlife's Habitat Programs are designed to help wildlife that rely on open habitats (grassland, shrubland, and young forests).",
       "widgets": null
     },
+    "overview": {
+      "rteElements": [
+        {
+          "path": "@atoms/11-text/paragraph.twig",
+          "data": {
+            "paragraph": {
+              "text": "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+            }
+          }
+        }
+      ]
+    },
     "stickyTOC": {
       "title": "Table of Contents",
       "parent": "#main-content",
@@ -31,18 +43,6 @@
         "title": "Mass Dept of Transportation"
       }]
     }
-  },
-  "overview": {
-    "rteElements": [
-      {
-        "path": "@atoms/11-text/paragraph.twig",
-        "data": {
-          "paragraph": {
-            "text": "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
-          }
-        }
-      }
-    ]
   },
   "pageContent": {
     "section1": {

--- a/patternlab/styleguide/source/_patterns/05-pages/information-details.twig
+++ b/patternlab/styleguide/source/_patterns/05-pages/information-details.twig
@@ -10,17 +10,16 @@
   {% set pageHeader = preContent.pageHeader %}
   {% include "@organisms/by-template/page-header.twig" %}
 
+  {% block overview %}
+    {% if preContent.overview.rteElements %}
+      {% set richText = preContent.overview %}
+      {% include "@organisms/by-author/rich-text.twig" %}
+    {% endif %}
+  {% endblock %}
+
   {% if preContent.stickyTOC %}
     {% set stickyTOC = preContent.stickyTOC %}
     {% include "@organisms/by-template/sticky-toc.twig" %}
-  {% endif %}
-{% endblock %}
-
-{% block overview %}
-  <h1>Boop</h1>
-  {% if overview.rteElements %}
-    {% set richText = overview %}
-    {% include "@organisms/by-author/rich-text.twig" %}
   {% endif %}
 {% endblock %}
 

--- a/patternlab/styleguide/source/_patterns/05-pages/information-details.twig
+++ b/patternlab/styleguide/source/_patterns/05-pages/information-details.twig
@@ -16,13 +16,20 @@
   {% endif %}
 {% endblock %}
 
+{% block overview %}
+  <h1>Boop</h1>
+  {% if overview.rteElements %}
+    {% set richText = overview %}
+    {% include "@organisms/by-author/rich-text.twig" %}
+  {% endif %}
+{% endblock %}
+
 {% block preContentMedia %}
   {% set richText = preContentMedia.post_header_media %}
   {% include "@organisms/by-author/rich-text.twig" %}
 {% endblock %}
 
 {% block pageContent %}
-
   {% if pageContent.section1 %}
     {% set richText = pageContent.section1 %}
     {% include "@organisms/by-author/rich-text.twig" %}


### PR DESCRIPTION
## Description
Added an overview rich text field to the information-details component.

## Related Issue / Ticket

- [JIRA issue](https://jira.mass.gov/browse/DP-14105)

## Steps to Test

#### Go here and do this

Go to ?p=pages-information-details in Mayflower

#### What you should see

Overview text between the bold teaser text and the Table of Contents.

## Screenshots

![Screen Shot 2019-08-28 at 9 19 14 AM](https://user-images.githubusercontent.com/52927667/63864122-f11b5380-c974-11e9-901a-3a6950015c6a.png)