### PR TITLE
DP-15856 address filtering not accurate

### DIFF
--- a/changelogs/DP-15856.md
+++ b/changelogs/DP-15856.md
@@ -1,0 +1,3 @@
+Patch
+Fixed
+- (Patternlab) [Locations] DP-15856: Uses google map's viewport biasing when converting user's input into a geocode so that places from and around Massachusetts are returned, thereby fixing previously faulty location filtering.

--- a/patternlab/styleguide/source/assets/js/helpers/listing.js
+++ b/patternlab/styleguide/source/assets/js/helpers/listing.js
@@ -436,13 +436,16 @@ export default (function(window, document, undefined, $, moment){
    *   Upon success, the return value of the passed callback function.
    */
   function geocodeAddressString(address, callback) {
-    // Only attempt to execute if google's geocode library is loaded.
-    if (typeof ma.geocoder === "undefined") {
+    // Only attempt to execute if google's geocode library is loaded and viewport bounds are set.
+    if (typeof ma.geocoder === "undefined" || typeof ma.viewportBounds === "undefined" ) {
       return;
     }
 
     // Geocode address string, then execute callback with argument upon success.
-    ma.geocoder.geocode({address: address}, function (results, status) {
+    // NOTE: We use viewport bounds based bias to get geocodes from the geography of our interest.
+    // See: https://jira.mass.gov/browse/DP-15856
+    // See: https://developers.google.com/maps/documentation/javascript/geocoding#GeocodingViewports
+    ma.geocoder.geocode({address: address, 'bounds': ma.viewportBounds}, function (results, status) {
       if (status === google.maps.GeocoderStatus.OK) {
         let place =  results[0];
         return callback(place);
@@ -465,13 +468,16 @@ export default (function(window, document, undefined, $, moment){
    *   Upon success, the return value of the passed callback function.
    */
   function geocodePlaceId(place_id, callback) {
-    // Only attempt to execute if google's geocode library is loaded.
-    if (typeof ma.geocoder === "undefined") {
+    // Only attempt to execute if google's geocode library is loaded and viewport bounds are set.
+    if (typeof ma.geocoder === "undefined" || typeof ma.viewportBounds === "undefined" ) {
       return;
     }
 
     // Geocode address string, then execute callback with argument upon success.
-    ma.geocoder.geocode({ 'placeId': place_id}, function(results, status) {
+    // NOTE: We use viewport bounds based bias to get geocodes from the geography of our interest.
+    // See: https://jira.mass.gov/browse/DP-15856
+    // See: https://developers.google.com/maps/documentation/javascript/geocoding#GeocodingViewports
+    ma.geocoder.geocode({ 'placeId': place_id, 'bounds': ma.viewportBounds}, function(results, status) {
       if (status === google.maps.GeocoderStatus.OK) {
         let place =  results[0];
         return callback(place);

--- a/patternlab/styleguide/source/assets/js/modules/eventFilters.js
+++ b/patternlab/styleguide/source/assets/js/modules/eventFilters.js
@@ -22,7 +22,7 @@ export default (function (window,document,$,undefined) {
           strictBounds: true,
           types: ['geocode'],
           componentRestrictions: {country: 'us'},
-          placeIdOnly: true
+          fields: ['place_id']
         };
         ma.autocomplete = new google.maps.places.Autocomplete(locationInput, options);
       }

--- a/patternlab/styleguide/source/assets/js/modules/eventListingInteractive.js
+++ b/patternlab/styleguide/source/assets/js/modules/eventListingInteractive.js
@@ -240,8 +240,14 @@ export default (function (window,document,$,undefined) {
       }
       // If place argument was populated from locationFilter (zipcode text input) but not from Place autocomplete.
       else {
+        // When users just enter a cityname, google's `geocoder` inside the `geocodeAddressString` is not precise
+        // even with 'bounds' parameter set, so we add " MA, USA" to acheive desired accuracy.
+        // NOTE: This is NOT done when autocomplete result is selected by user, in which case the above `if` situation is executed.
+        var user_entered_location_string = place;
+        var user_entered_location_parts = user_entered_location_string.split(",");
+        var reasonable_formatted_location = user_entered_location_parts.pop() + " MA, USA";
         // This is an asynchronous function
-        listings.geocodeAddressString(place, function(result) {
+        listings.geocodeAddressString(reasonable_formatted_location, function(result) {
           transformReturn.data = sortDataAroundPlace(result, filteredData);
           transformReturn.geocode = result;
           // Return the data sorted by location and the geocoded place object

--- a/patternlab/styleguide/source/assets/js/modules/locationFilters.js
+++ b/patternlab/styleguide/source/assets/js/modules/locationFilters.js
@@ -26,7 +26,7 @@ export default (function (window,document,$,undefined) {
           strictBounds: true,
           types: ['geocode'],
           componentRestrictions: {country: 'us'},
-          placeIdOnly: true
+          fields: ['place_id']
         };
         ma.autocomplete = new google.maps.places.Autocomplete(locationInput, options);
       }

--- a/patternlab/styleguide/source/assets/js/modules/locationListing.js
+++ b/patternlab/styleguide/source/assets/js/modules/locationListing.js
@@ -337,8 +337,14 @@ export default (function (window, document, $) {
       }
       // If place argument was populated from locationFilter (zipcode text input) but not from Place autocomplete.
       else {
+        // When users just enter a cityname, google's `geocoder` inside the `geocodeAddressString` is not precise
+        // even with 'bounds' parameter set, so we add " MA, USA" to acheive desired accuracy.
+        // NOTE: This is NOT done when autocomplete result is selected by user, in which case the above `if` situation is executed.
+        var user_entered_location_string = place;
+        var user_entered_location_parts = user_entered_location_string.split(",");
+        var reasonable_formatted_location = user_entered_location_parts.pop() + " MA, USA";
         // This is an asynchronous function
-        listings.geocodeAddressString(place, function (result) {
+        listings.geocodeAddressString(reasonable_formatted_location, function (result) {
           transformReturn.data = sortDataAroundPlace(result, filteredData);
           transformReturn.geocode = result;
           // Return the data sorted by location and the geocoded place object

--- a/patternlab/styleguide/source/assets/js/modules/locationListing.js
+++ b/patternlab/styleguide/source/assets/js/modules/locationListing.js
@@ -35,6 +35,19 @@ export default (function (window, document, $) {
 
     // Listen for Google Map api library load completion, with geocode, geometry, and places libraries
     $(document).on("ma:LibrariesLoaded:GoogleMaps", function () {
+      // Set up global geocoder object that will be used later in `listing.js` functions that fetch geocodes from user input.
+      ma.geocoder = ma.geocoder ? ma.geocoder : new google.maps.Geocoder();
+
+      // Set up viewport bounds that will be used as additional properties of GeocoderRequest objects.
+      // NOTE: We set similar "local" bounds in `eventFilters.js` and `locationFilters.js` but we need to set "global"
+      // variable that holds the bounds here so that it can be used current gecoding functions in `listing.js`.
+      let $locationFilterParent = $('.js-filter-by-location', $el);
+      let swLat = $locationFilterParent.data('maPlaceBoundsSwLat');
+      let swLng = $locationFilterParent.data('maPlaceBoundsSwLng');
+      let neLat = $locationFilterParent.data('maPlaceBoundsNeLat');
+      let neLng = $locationFilterParent.data('maPlaceBoundsNeLng');
+      ma.viewportBounds = new google.maps.LatLngBounds(new google.maps.LatLng(swLat,swLng), new google.maps.LatLng(neLat,neLng));
+
       // Set up click handler for location listing rows.
       $el.on("click", row, function (e) {
         // If the link has an href, allow the normal link functionality
@@ -311,7 +324,8 @@ export default (function (window, document, $) {
         let autocompletePlace = ma.autocomplete.getPlace();
       }
       // Geocode the address, then sort the markers and instance of locationListing masterData.
-      ma.geocoder = ma.geocoder ? ma.geocoder : new google.maps.Geocoder();
+      // NOTE: We used to declare a global `ma.geocoder` here, but we have corrected that, and now declare it in the
+      // same file but in the callback that is run on completion of Google Map api library load.
       if (typeof autocompletePlace !== "undefined" && autocompletePlace.hasOwnProperty("place_id")) {
         // This is an asynchronous function
         listings.geocodePlaceId(autocompletePlace.place_id, function (result) {


### PR DESCRIPTION
## Description

- When user's entered city names in location listing pages, the map did not zoom to expected area, even if there were actual location items in the entered city area.
- After a lot of debugging on the drupal and mayflower side, we found the root cause was that google maps API geocoded entered city in a global fashion (for example: it thought `cambridge` was the `cambridge, UK` city).
- We tried to correct with my using `bounds` as we do with autocomplete, but that didn't work every time either. So we have a combined solution now.

## Related Issue / Ticket

- https://jira.mass.gov/browse/DP-15856

## Steps to Test

### === 😢😭 BEFORE  😢😭 ===

Follow numbered steps from below image

<img width="1445" alt="see_ma_cities_in_maps_not_working" src="https://user-images.githubusercontent.com/140441/65184544-b4062680-da33-11e9-9ad8-992f18e45cd6.png">

1. On `develop` branch ... goto `mayflower/patternlab/styleguide/` ... run `gulp` ... and then open this URL in your browser = http://localhost:3000/?p=pages-location-listing (refresh the page)
1. From chrome dev tools open the sources tab
1. Click on the three-dots-menu and open the file `locationListing.js`
1. Set a breakpoint in the `sortDataAroundPlace()` function towards the end by which point sorting is already done.
1. On the webpage enter the cityname `cambridge` and dismiss any autocomplete suggestions that come up by pressing ESC
1. Click submit button to filter
1. Notice that the breakpoint is hit and google geocodes your input as an unexpected city 😢😭 

NOTE: Also see the order of listing on the webpage after you release the breakpoint hold.

### === 😃😃 AFTER  😃😃 ===

Follow numbered steps from below image

<img width="1440" alt="ensure_ma_cities_in_maps_work" src="https://user-images.githubusercontent.com/140441/65184570-c718f680-da33-11e9-90a8-40db3fcba5dd.png">

1. Checkout this branch that is `DP-15856-address-filtering-not-accurate` branch ... goto `mayflower/patternlab/styleguide/` ... run `gulp` ... and then open this URL in your browser = http://localhost:3000/?p=pages-location-listing (refresh the page)
1. From chrome dev tools open the sources tab
1. Click on the three-dots-menu and open the file `locationListing.js`
1. Set a breakpoint in the `sortDataAroundPlace()` function towards the end by which point sorting is already done.
1. On the webpage enter the cityname `cambridge` and dismiss any autocomplete suggestions that come up by pressing ESC
1. Click submit button to filter
1. Notice that the breakpoint is hit things work as you would expect 😃😃

NOTE: Also see the order of listing on the webpage after you release the breakpoint hold.

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* 

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
