### PR TITLE
(React) DP-16483: Collapse animation ie11 fix

### DIFF
--- a/changelogs/DP-16483.md
+++ b/changelogs/DP-16483.md
@@ -1,3 +1,3 @@
 Patch
 Fixed
-- (React) [Collapse] DP-16483: Fixed collapse animation if max dimension passed on IE11. #
+- (React) [Collapse] DP-16483: Fixed collapse animation if max dimension passed on IE11. #823

--- a/changelogs/DP-16483.md
+++ b/changelogs/DP-16483.md
@@ -1,0 +1,3 @@
+Patch
+Fixed
+- (React) [Collapse] DP-16483: Fixed collapse animation if max dimension passed on IE11. #

--- a/react/src/components/animations/Collapse/index.js
+++ b/react/src/components/animations/Collapse/index.js
@@ -57,7 +57,7 @@ class Collapse extends React.Component {
     const currentDim = parseInt(css(elem, dimension), 10);
     const setDim = (minDimension <= currentDim) ? minDimension : currentDim;
     elem.style[dimension] = `${setDim}px`; // eslint-disable-line no-param-reassign
-    elem.style[`max${capitalize(dimension)}`] = 'unset'; // eslint-disable-line no-param-reassign
+    elem.style[`max${capitalize(dimension)}`] = 'none'; // eslint-disable-line no-param-reassign
   }
 
   handleEntering(elem) {
@@ -123,7 +123,7 @@ class Collapse extends React.Component {
           React.cloneElement(children, {
             ...innerProps,
             style: {
-              [`max${capitalize(dimension)}`]: minDimensionOnMount ? `${minDimension}px` : 'unset'
+              [`max${capitalize(dimension)}`]: minDimensionOnMount ? `${minDimension}px` : 'none'
             },
             className: classNames(
               className,


### PR DESCRIPTION
Patch
Fixed
- (React) [Collapse] DP-16483: Fixed collapse animation if max dimension passed on IE11. #823