### PR TITLE
[React] (a11y) decorative SVG icon with no text alternative is visible to AT.

### DIFF
--- a/changelogs/DP-11663.md
+++ b/changelogs/DP-11663.md
@@ -1,0 +1,3 @@
+Minor
+Fixed
+- (React) [UtilityNav] DP-11663: set `ariaHidden` on decorative SVG icon. #827

--- a/react/src/components/organisms/UtilityNav/index.js
+++ b/react/src/components/organisms/UtilityNav/index.js
@@ -106,10 +106,14 @@ const NavItem = (obj) => {
 
 const NavItemLink = (obj) => {
   const item = obj.data;
+  const iconProps = {
+    name: item.icon,
+    ariaHidden: !item.ariaLabelText
+  };
   return(
     <li className="ma__utility-nav__item js-util-nav-toggle">
       <a className="ma__utility-nav__link" href={item.href} aria-label={item.ariaLabelText || item.text}>
-        <Icon name={item.icon} />
+        <Icon {...iconProps} />
         <span>{item.text}</span>
       </a>
     </li>

--- a/react/src/components/organisms/UtilityNav/index.js
+++ b/react/src/components/organisms/UtilityNav/index.js
@@ -75,10 +75,14 @@ const NavItem = (obj) => {
     'aria-hidden': isExpanded ? 'false' : 'true',
     id: divId
   };
+  const iconProps = {
+    name: item.icon,
+    ariaHidden: !item.ariaLabelText
+  };
   return(
     <li className="ma__utility-nav__item js-util-nav-toggle">
       <button onClick={(e) => obj.handleClick(divId, e)} className={`ma__utility-nav__link ${isExpanded}`} href="#" aria-label={item.ariaLabelText || item.text}>
-        <Icon name={item.icon} />
+        <Icon {...iconProps} />
         <span>{item.text}</span>
       </button>
       <div {...divProps}>
@@ -88,7 +92,7 @@ const NavItem = (obj) => {
               <span>{item.closeText}</span>
               <span className="ma__utility-nav__close-icon" aria-hidden="true">+</span>
             </button>
-            <Icon name={item.icon} />
+            <Icon {...iconProps} />
             <span>{item.text}</span>
           </div>
           <div className="ma__utility-nav__content-body">

--- a/react/src/components/organisms/UtilityNav/index.js
+++ b/react/src/components/organisms/UtilityNav/index.js
@@ -77,7 +77,7 @@ const NavItem = (obj) => {
   };
   const iconProps = {
     name: item.icon,
-    ariaHidden: !item.ariaLabelText
+    ariaHidden: true
   };
   return(
     <li className="ma__utility-nav__item js-util-nav-toggle">
@@ -108,7 +108,7 @@ const NavItemLink = (obj) => {
   const item = obj.data;
   const iconProps = {
     name: item.icon,
-    ariaHidden: !item.ariaLabelText
+    ariaHidden: true
   };
   return(
     <li className="ma__utility-nav__item js-util-nav-toggle">


### PR DESCRIPTION
Minor
Fixed
- (React) [UtilityNav] DP-11663: set `ariaHidden` on decorative SVG icon. #827