### PR TITLE
React/ Add color option to comp heading

### DIFF
--- a/assets/scss/01-atoms/_comp-heading.scss
+++ b/assets/scss/01-atoms/_comp-heading.scss
@@ -56,4 +56,8 @@
   &--yellow {
     @include ma-border-decorative($c-highlight, 1);
   }
+
+  &--gray {
+    @include ma-border-decorative($c-gray, 1);
+  }
 }

--- a/changelogs/DP-16339.md
+++ b/changelogs/DP-16339.md
@@ -1,3 +1,3 @@
 Minor
-Fixed
+Added
 - (React) [CompHeading] DP-16339: Add `gray` color option. #834

--- a/changelogs/DP-16339.md
+++ b/changelogs/DP-16339.md
@@ -1,3 +1,3 @@
 Minor
 Fixed
-- (React) [CompHeading] DP-11663: Add `gray` color option. #834
+- (React) [CompHeading] DP-16339: Add `gray` color option. #834

--- a/changelogs/DP-16339.md
+++ b/changelogs/DP-16339.md
@@ -1,0 +1,3 @@
+Minor
+Fixed
+- (React) [CompHeading] DP-11663: Add `gray` color option. #834

--- a/react/src/components/atoms/headings/CompHeading/CompHeading.knob.options.js
+++ b/react/src/components/atoms/headings/CompHeading/CompHeading.knob.options.js
@@ -15,7 +15,7 @@ export default {
   id: (value) => text('CompHeading: id', value, 'CompHeading'),
   sub: (value) => boolean('CompHeading: sub', value, 'CompHeading'),
   level: (value) => select('CompHeading: level', levelOptions, value, 'CompHeading'),
-  color: (value) => select('CompHeading: color', { 'green (default)': '', yellow: 'yellow' }, value, 'CompHeading'),
+  color: (value) => select('CompHeading: color', { 'green (default)': '', yellow: 'yellow', gray: 'gray' }, value, 'CompHeading'),
   centered: (value) => boolean('CompHeading: centered', value, 'CompHeading'),
   sidebar: (value) => boolean('CompHeading: sidebar', value, 'CompHeading')
 };


### PR DESCRIPTION
Minor
Added
- (React) [CompHeading] DP-16339: Add `gray` color option. #834