### PR TITLE
React/dp 17417 fix proptype Element reference error in server side rendering

### DIFF
--- a/changelogs/DP-17417.yml
+++ b/changelogs/DP-17417.yml
@@ -4,3 +4,8 @@ Fixed:
     description: Move react-scripts into dev dependencies, and move react-html-parser into prod dependencies. (#927)
     issue: DP-17417
     impact: Patch
+  - project: React
+    component: Tab, FeedbackForm
+    description: Fix tab ref proptype for server side rendering. (#928)
+    issue: DP-17417
+    impact: Patch

--- a/react/src/components/base/Icon/Icon.stories.js
+++ b/react/src/components/base/Icon/Icon.stories.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withKnobs, select, text, array, boolean, color, number } from '@storybook/addon-knobs';
 import { assets, svgOptions } from './Icon.knob.options';

--- a/react/src/components/base/Icon/IconDisplay.js
+++ b/react/src/components/base/Icon/IconDisplay.js
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import Icon from './index';
 import './display.css';

--- a/react/src/components/forms/FeedbackForm/index.js
+++ b/react/src/components/forms/FeedbackForm/index.js
@@ -22,13 +22,6 @@ HiddenFields.propTypes = {
 };
 
 export default class FeedbackForm extends Component {
-  static defaultProps = {
-    formId: 2521317,
-    radioId: 47054416,
-    yesFeedbackId: 52940022,
-    noFeedbackId: 47054414,
-    refererId: 47056299
-  };
   static propTypes = {
     /** A ref object as created by React.createRef(). Will be applied to the form element. */
     formRef: PropTypes.oneOfType([
@@ -54,6 +47,13 @@ export default class FeedbackForm extends Component {
     /** A function whose return value is rendered under the no textarea. */
     noDisclaimer: PropTypes.func
   }
+  static defaultProps = {
+    formId: 2521317,
+    radioId: 47054416,
+    yesFeedbackId: 52940022,
+    noFeedbackId: 47054414,
+    refererId: 47056299
+  };
   state = {
     yesText: '',
     noText: '',

--- a/react/src/components/forms/FeedbackForm/index.js
+++ b/react/src/components/forms/FeedbackForm/index.js
@@ -33,7 +33,7 @@ export default class FeedbackForm extends Component {
     /** A ref object as created by React.createRef(). Will be applied to the form element. */
     formRef: PropTypes.oneOfType([
       PropTypes.func,
-      PropTypes.shape({ current: PropTypes.instanceOf(Element) })
+      PropTypes.shape({ current: PropTypes.any })
     ]),
     /** A function whose return value is displayed after a successful form submission. */
     successMessage: PropTypes.func.isRequired,

--- a/react/src/components/molecules/HeaderSearch/index.js
+++ b/react/src/components/molecules/HeaderSearch/index.js
@@ -90,7 +90,12 @@ HeaderSearch.propTypes = {
   /** @molecules/TypeAheadDropdown */
   orgDropdown: PropTypes.shape(PropTypes.TypeAheadDropdown),
   /** postInputFilter passable component */
-  postInputFilter: componentWithName('SelectBox')
+  postInputFilter: componentWithName('SelectBox'),
+  /** A ref object as created by React.createRef(). Will be applied to the input element. */
+  inputRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.any })
+  ])
 };
 
 HeaderSearch.defaultProps = {

--- a/react/src/components/molecules/ResultsHeading/index.js
+++ b/react/src/components/molecules/ResultsHeading/index.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import ButtonToggle from '../../atoms/buttons/ButtonToggle';
 import SelectBox from '../../forms/SelectBox';

--- a/react/src/components/organisms/TabContainer/tab.js
+++ b/react/src/components/organisms/TabContainer/tab.js
@@ -115,7 +115,7 @@ Tab.propTypes = {
   /** Children passed to tab container (tab content) */
   children: PropTypes.node,
   /** The tabs ref */
-  tabRef: PropTypes.oneOfType([PropTypes.object, PropTypes.instanceOf(Element)])
+  tabRef: PropTypes.oneOfType([PropTypes.object, PropTypes.any])
 };
 
 export default Tab;


### PR DESCRIPTION
Fixed:
  - project: React
    component: Tab, FeedbackForm
    description: Fix tab ref proptype for server side rendering. (#928)
    issue: DP-17417
    impact: Patch