### PR TITLE
All/dp 17532 publish mayflower tokens

### DIFF
--- a/assets/README.md
+++ b/assets/README.md
@@ -2,6 +2,15 @@
 [![npm package][npm-badge]][npm]
 
 Mayflower-tokens provides a bundled up library of design tokens and assets that you will need for theming your front end framework to look and feel like [Mass.gov](https://mass.gov) and other Commonwealth web properties that are in Mayflower ecosystem. Mayflower-tokens includes color token SCSS variables, fonts, icons and other imagery from Mayflower — the [enterprise design system for the Commonwealth of Massachusetts][mayflower-doc].
+```
+├── fonts                             Texta web fonts      
+├── images             
+│   ├── svg-icons                     SVG icon files
+│   ├── stateseal-color               stateseal png in color
+│   ├── stateseal-color               stateseal png grayscale
+├── colors         
+│   ├── _mayflower-color-tokens.scss  Color tokens
+```
 
 - **Codebase:** [Mayflower monorepo][mayflower-github] `assets` subdirectory
   >[Mayflower monorepo][mayflower-github] comprised of [Mayflower documentation][mayflower-doc], two component libraries — [Mayflower React][react-storybook] and [Mayflower PatternLab][patternLab], and their [shared assets][shared-assets].

--- a/assets/README.md
+++ b/assets/README.md
@@ -8,6 +8,21 @@ Mayflower-tokens provides a bundled up library of design tokens and assets that 
   > Refer to [Mayflower PatternLab Static Site][patternlab] for the set of UI components consumed in Mass.gov.
 - **Live demo:** [mayflower-react storybook][react-storybook]
 
+## Using Mayflower-Tokens in Your Project
+1. Install mayflower-tokens into your project as a dependency.
+`npm i @massds/mayflower-tokens --save`
+2. Import color tokens into your SASS/SCSS file
+`@import '[path to node_modules]/@massds/mayflower-tokens/colors/mayflower-color_tokens';`
+3. Refer to variables in `@massds/mayflower-tokens/colors/_mayflower-color_tokens.scss` to map the Mayflower color tokens in your theming SCSS.
+4. You can also find the web fonts Texta that are used in Mayflower (please)
+To import into your styles, refer to [mayflower Texta font imports](https://github.com/massgov/mayflower/blob/develop/assets/scss/00-base/_fonts.scss).
+
+## License
+Please note that the fonts and the svg-icons are licensed only for the usage on websites that are **owned by the Commonwealth of Massachusetts**. Mayflower is currently using a licensed web font Texta and purchased [Smashing Icons](https://smashicons.com/) for some icons.
+
+### Texta License
+Fontspring grants Licensee a perpetual, worldwide, non-exclusive and non-transferrable license to install the Texta as webfont on Websites that are owned by the Commonwealth of Massachusetts using the @font-face selector in CSS files. For other usage, you may have to acquire an additional license through Fontsprint.
+For more details about Texta's terms of use, please refer to our [web font license](https://www.fontspring.com/lic/htswufoczd).
 
 
 

--- a/assets/README.md
+++ b/assets/README.md
@@ -22,7 +22,7 @@ Mayflower-tokens provides a bundled up library of design tokens and assets that 
 `npm i @massds/mayflower-tokens --save`
 2. Import color tokens into your SASS/SCSS file
 `@import '[path to node_modules]/@massds/mayflower-tokens/colors/mayflower-color_tokens';`
-3. Refer to variables in `@massds/mayflower-tokens/colors/_mayflower-color_tokens.scss` to map the Mayflower color tokens in your theming SCSS.
+3. Refer to variables in `@massds/mayflower-tokens/colors/_mayflower-color_tokens.scss` or a [live demo for the colors](https://mayflower-react.digital.mass.gov/?path=/story/brand-colors--colors) to map the Mayflower color tokens in your theming SCSS.
 4. You can also find the web fonts Texta that are used in Mayflower (please)
 To import into your styles, refer to [mayflower Texta font imports](https://github.com/massgov/mayflower/blob/develop/assets/scss/00-base/_fonts.scss).
 

--- a/assets/README.md
+++ b/assets/README.md
@@ -1,0 +1,21 @@
+# Mayflower-Tokens
+[![npm package][npm-badge]][npm]
+
+Mayflower-tokens provides a bundled up library of design tokens and assets that you will need for theming your front end framework to look and feel like [Mass.gov](https://mass.gov) and other Commonwealth web properties that are in Mayflower ecosystem. Mayflower-tokens includes color token SCSS variables, fonts, icons and other imagery from Mayflower — the [enterprise design system for the Commonwealth of Massachusetts][mayflower-doc].
+
+- **Codebase:** [Mayflower monorepo][mayflower-github] `assets` subdirectory
+  >[Mayflower monorepo][mayflower-github] comprised of [Mayflower documentation][mayflower-doc], two component libraries — [Mayflower React][react-storybook] and [Mayflower PatternLab][patternLab], and their [shared assets][shared-assets].
+  > Refer to [Mayflower PatternLab Static Site][patternlab] for the set of UI components consumed in Mass.gov.
+- **Live demo:** [mayflower-react storybook][react-storybook]
+
+
+
+
+[npm-badge]: https://img.shields.io/npm/v/@massds/mayflower-react.png?style=flat-square
+[npm]: https://www.npmjs.com/package/@massds/mayflower-tokens
+[mayflower-github]: https://github.com/massgov/mayflower
+[mayflower-doc]: https://www.mass.gov/mayflower
+[react-storybook]: https://mayflower-react.digital.mass.gov
+[react-starter]: https://github.com/massgov/mayflower-react-starter
+[patternlab]: https://mayflower.digital.mass.gov
+[shared-assets]: https://github.com/massgov/mayflower/tree/develop/assets

--- a/assets/colors/_mayflower-color-tokens.scss
+++ b/assets/colors/_mayflower-color-tokens.scss
@@ -88,6 +88,15 @@ $c-atlantic-gray:                  #707070;
 $c-overcast-gray:                  #DCDCDC;
 $c-platinum-gray:                  #F2F2F2;
 
+// Gray Scale Spectrum Mapping
+$c-black:                          $c-revolution-gray;
+$c-gray-dark:                      $c-granite-gray;
+$c-gray:                           $c-atlantic-gray;
+$c-gray-light:                     $c-overcast-gray;
+$c-gray-lighter:                   #CCCCCC; // Followup needed: should be added as a base color or be replaced as a gradient color from granite gray
+$c-gray-lightest:                  $c-platinum-gray;
+$c-white:                          white;
+
 // Error Red (#CD0D0D)
 $c-error-red:                      #CD0D0D;
 $c-error-red-lighter:              #EEACAC; //Commonly used in outlines

--- a/assets/package.json
+++ b/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@massds/mayflower-tokens",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Mayflower design tokens — it includes color token SCSS variables, fonts, icons and other imagery",
   "style": "colors/_mayflower-color-tokens.scss",
   "files": [

--- a/assets/package.json
+++ b/assets/package.json
@@ -6,7 +6,9 @@
   "files": [
     "colors",
     "fonts",
-    "images"
+    "images/svg-icons",
+    "images/stateseal-color.png",
+    "images/stateseal.png"
   ],
   "scripts": {
     "test": "stylelint",

--- a/assets/package.json
+++ b/assets/package.json
@@ -1,8 +1,13 @@
 {
-  "name": "mayflower-theme",
+  "name": "@massds/mayflower-tokens",
   "version": "1.0.0",
-  "description": "Mayflower theming assets, including color variables, fonts, icons and other imagery, along with componentized scss used to style Mayflower markup",
-  "main": "index.js",
+  "description": "Mayflower design tokens — it includes color token SCSS variables, fonts, icons and other imagery",
+  "style": "colors/_mayflower-color-tokens.scss",
+  "files": [
+    "colors",
+    "fonts",
+    "images"
+  ],
   "scripts": {
     "test": "stylelint",
     "stylelint": "stylelint '**/*.scss' --syntax scss --formatter verbose",
@@ -13,8 +18,11 @@
     "url": "https://github.com/massgov/mayflower/tree/master/assets"
   },
   "keywords": [
-    "theme",
-    "scss"
+    "scss",
+    "colors",
+    "tokens",
+    "icons",
+    "fonts"
   ],
   "author": "Massachusetts Digital Services (MDS)",
   "license": "MIT",

--- a/assets/scss/00-base/_colors-tokens.scss
+++ b/assets/scss/00-base/_colors-tokens.scss
@@ -1,0 +1,69 @@
+/* Mayflower Color Tokens */
+
+// Bay Blue (#14558f)
+$c-bay-blue-90-tint:          #E8EEF4;
+$c-bay-blue-80-tint:          #D0DDE9;
+$c-bay-blue-70-tint:          #B9CCDD;
+$c-bay-blue-60-tint:          #A1BBD2;
+$c-bay-blue-50-tint:          #8AAAC7;
+$c-bay-blue-40-tint:          #7299BC;
+$c-bay-blue-30-tint:          #5B88B1;
+$c-bay-blue-20-tint:          #4377A5;
+$c-bay-blue-10-tint:          #2C669A;
+$c-bay-blue:                  #14558f;
+$c-bay-blue-10-shade:         #124D81;
+$c-bay-blue-20-shade:         #104472;
+$c-bay-blue-30-shade:         #0E3C64;
+$c-bay-blue-40-shade:         #0C3356;
+$c-bay-blue-50-shade:         #0A2B48;
+
+// Berkshires Green (#388557)
+$c-berkshires-green-90-tint:  #EBF3EE;
+$c-berkshires-green-80-tint:  #D7E7DD;
+$c-berkshires-green-70-tint:  #C3DACD;
+$c-berkshires-green-60-tint:  #AFCEBC;
+$c-berkshires-green-50-tint:  #9CC2AB;
+$c-berkshires-green-40-tint:  #88B69A;
+$c-berkshires-green-30-tint:  #74AA89;
+$c-berkshires-green-20-tint:  #609D79;
+$c-berkshires-green-10-tint:  #4C9168;
+$c-berkshires-green:          #388557;
+$c-berkshires-green-10-shade: #32784E;
+$c-berkshires-green-20-shade: #2D6A46;
+$c-berkshires-green-30-shade: #275D3D;
+$c-berkshires-green-40-shade: #225034;
+$c-berkshires-green-50-shade: #1C432C;
+
+
+// Duckling Yellow (#f6c51b)
+$c-duckling-yellow-90-tint:  #FEF9E8;
+$c-duckling-yellow-80-tint:  #FDF3D1;
+$c-duckling-yellow-70-tint:  #FCEEBB;
+$c-duckling-yellow-60-tint:  #FBE8A4;
+$c-duckling-yellow-50-tint:  #FBE28D;
+$c-duckling-yellow-40-tint:  #FADC76;
+$c-duckling-yellow-30-tint:  #F9D65F;
+$c-duckling-yellow-20-tint:  #F8D149;
+$c-duckling-yellow-10-tint:  #F7CB32;
+$c-duckling-yellow:                #f6c51b;
+$c-duckling-yellow-10-shade: #DDB118;
+$c-duckling-yellow-20-shade: #C59E16;
+$c-duckling-yellow-30-shade: #AC8A13;
+$c-duckling-yellow-40-shade: #947610;
+$c-duckling-yellow-50-shade: #7B630E;
+
+// Independence Cranberry (#680A1D)
+$c-independence-cranberry:         #680A1D;
+
+// Base Gray Scale Colors
+$c-revolution-gray:                #141414;
+$c-granite-gray:                   #535353;
+$c-overcast-gray:                  #DCDCDC;
+$c-platinum-gray:                  #F2F2F2;
+$c-atlantic-gray:                  #707070;
+$c-very-light-gray:                #CCCCCC;
+
+// Error Colors
+$c-error-red:                      #CD0D0D;
+$c-error-red-lighter:              #EEACAC;
+$c-error-red-lightest:             #FCF3F3;

--- a/assets/scss/00-base/_colors-tokens.scss
+++ b/assets/scss/00-base/_colors-tokens.scss
@@ -1,69 +1,97 @@
 /* Mayflower Color Tokens */
 
 // Bay Blue (#14558f)
-$c-bay-blue-90-tint:          #E8EEF4;
-$c-bay-blue-80-tint:          #D0DDE9;
-$c-bay-blue-70-tint:          #B9CCDD;
-$c-bay-blue-60-tint:          #A1BBD2;
-$c-bay-blue-50-tint:          #8AAAC7;
-$c-bay-blue-40-tint:          #7299BC;
-$c-bay-blue-30-tint:          #5B88B1;
-$c-bay-blue-20-tint:          #4377A5;
-$c-bay-blue-10-tint:          #2C669A;
-$c-bay-blue:                  #14558f;
-$c-bay-blue-10-shade:         #124D81;
-$c-bay-blue-20-shade:         #104472;
-$c-bay-blue-30-shade:         #0E3C64;
-$c-bay-blue-40-shade:         #0C3356;
-$c-bay-blue-50-shade:         #0A2B48;
+$c-bay-blue-90-tint:               #E8EEF4;
+$c-bay-blue-80-tint:               #D0DDE9;
+$c-bay-blue-70-tint:               #B9CCDD;
+$c-bay-blue-60-tint:               #A1BBD2;
+$c-bay-blue-50-tint:               #8AAAC7;
+$c-bay-blue-40-tint:               #7299BC;
+$c-bay-blue-30-tint:               #5B88B1;
+$c-bay-blue-20-tint:               #4377A5;
+$c-bay-blue-10-tint:               #2C669A;
+$c-bay-blue:                       #14558f;
+$c-bay-blue-10-shade:              #124D81;
+$c-bay-blue-20-shade:              #104472;
+$c-bay-blue-30-shade:              #0E3C64;
+$c-bay-blue-40-shade:              #0C3356;
+$c-bay-blue-50-shade:              #0A2B48;
+
+$c-bay-blue-lighter:               $c-bay-blue-50-tint; //Commonly used in outlines
+$c-bay-blue-lightest:              $c-bay-blue-90-tint; //Commonly used in background
 
 // Berkshires Green (#388557)
-$c-berkshires-green-90-tint:  #EBF3EE;
-$c-berkshires-green-80-tint:  #D7E7DD;
-$c-berkshires-green-70-tint:  #C3DACD;
-$c-berkshires-green-60-tint:  #AFCEBC;
-$c-berkshires-green-50-tint:  #9CC2AB;
-$c-berkshires-green-40-tint:  #88B69A;
-$c-berkshires-green-30-tint:  #74AA89;
-$c-berkshires-green-20-tint:  #609D79;
-$c-berkshires-green-10-tint:  #4C9168;
-$c-berkshires-green:          #388557;
-$c-berkshires-green-10-shade: #32784E;
-$c-berkshires-green-20-shade: #2D6A46;
-$c-berkshires-green-30-shade: #275D3D;
-$c-berkshires-green-40-shade: #225034;
-$c-berkshires-green-50-shade: #1C432C;
+$c-berkshires-green-90-tint:       #EBF3EE;
+$c-berkshires-green-80-tint:       #D7E7DD;
+$c-berkshires-green-70-tint:       #C3DACD;
+$c-berkshires-green-60-tint:       #AFCEBC;
+$c-berkshires-green-50-tint:       #9CC2AB;
+$c-berkshires-green-40-tint:       #88B69A;
+$c-berkshires-green-30-tint:       #74AA89;
+$c-berkshires-green-20-tint:       #609D79;
+$c-berkshires-green-10-tint:       #4C9168;
+$c-berkshires-green:               #388557;
+$c-berkshires-green-10-shade:      #32784E;
+$c-berkshires-green-20-shade:      #2D6A46;
+$c-berkshires-green-30-shade:      #275D3D;
+$c-berkshires-green-40-shade:      #225034;
+$c-berkshires-green-50-shade:      #1C432C;
+
+$c-berkshires-green-lighter:       $c-berkshires-green-50-tint; //Commonly used in outlines
+$c-berkshires-green-lightest:      $c-berkshires-green-80-tint; //Commonly used in background
+$c-berkshires-green-dark:          #214F34; // Followup needed: should be replaced with one of the gradient colors
 
 
 // Duckling Yellow (#f6c51b)
-$c-duckling-yellow-90-tint:  #FEF9E8;
-$c-duckling-yellow-80-tint:  #FDF3D1;
-$c-duckling-yellow-70-tint:  #FCEEBB;
-$c-duckling-yellow-60-tint:  #FBE8A4;
-$c-duckling-yellow-50-tint:  #FBE28D;
-$c-duckling-yellow-40-tint:  #FADC76;
-$c-duckling-yellow-30-tint:  #F9D65F;
-$c-duckling-yellow-20-tint:  #F8D149;
-$c-duckling-yellow-10-tint:  #F7CB32;
+$c-duckling-yellow-90-tint:        #FEF9E8;
+$c-duckling-yellow-80-tint:        #FDF3D1;
+$c-duckling-yellow-70-tint:        #FCEEBB;
+$c-duckling-yellow-60-tint:        #FBE8A4;
+$c-duckling-yellow-50-tint:        #FBE28D;
+$c-duckling-yellow-40-tint:        #FADC76;
+$c-duckling-yellow-30-tint:        #F9D65F;
+$c-duckling-yellow-20-tint:        #F8D149;
+$c-duckling-yellow-10-tint:        #F7CB32;
 $c-duckling-yellow:                #f6c51b;
-$c-duckling-yellow-10-shade: #DDB118;
-$c-duckling-yellow-20-shade: #C59E16;
-$c-duckling-yellow-30-shade: #AC8A13;
-$c-duckling-yellow-40-shade: #947610;
-$c-duckling-yellow-50-shade: #7B630E;
+$c-duckling-yellow-10-shade:       #DDB118;
+$c-duckling-yellow-20-shade:       #C59E16;
+$c-duckling-yellow-30-shade:       #AC8A13;
+$c-duckling-yellow-40-shade:       #947610;
+$c-duckling-yellow-50-shade:       #7B630E;
+
+$c-duckling-yellow-lighter:        $c-duckling-yellow-50-tint; //Commonly used in outlines
+$c-duckling-yellow-lightest:       $c-duckling-yellow-90-tint; //Commonly used in background
 
 // Independence Cranberry (#680A1D)
+$c-duckling-yellow-90-tint:        #F0E7E8;
+$c-duckling-yellow-80-tint:        #E1CED2;
+$c-duckling-yellow-70-tint:        #D2B6BB;
+$c-duckling-yellow-60-tint:        #C39DA5;
+$c-duckling-yellow-50-tint:        #B4858E;
+$c-duckling-yellow-40-tint:        #A46C77;
+$c-duckling-yellow-30-tint:        #955461;
+$c-duckling-yellow-20-tint:        #863B4A;
+$c-duckling-yellow-10-tint:        #772334;
 $c-independence-cranberry:         #680A1D;
+$c-duckling-yellow-10-shade:       #5E091A;
+$c-duckling-yellow-20-shade:       #530817;
+$c-duckling-yellow-30-shade:       #490714;
+$c-duckling-yellow-40-shade:       #3E0611;
+$c-duckling-yellow-50-shade:       #34050F;
+
+$c-independence-cranberry-lighter: $c-duckling-yellow-50-tint;  //Commonly used in outlines
 
 // Base Gray Scale Colors
 $c-revolution-gray:                #141414;
 $c-granite-gray:                   #535353;
+$c-atlantic-gray:                  #707070;
 $c-overcast-gray:                  #DCDCDC;
 $c-platinum-gray:                  #F2F2F2;
-$c-atlantic-gray:                  #707070;
-$c-very-light-gray:                #CCCCCC;
 
-// Error Colors
+// Error Red (#CD0D0D)
 $c-error-red:                      #CD0D0D;
-$c-error-red-lighter:              #EEACAC;
-$c-error-red-lightest:             #FCF3F3;
+$c-error-red-lighter:              #EEACAC; //Commonly used in outlines
+$c-error-red-lightest:             #FCF3F3; //Commonly used in background
+
+// Focus Highlight (#3e94cf)
+$c-focus-hightlight:               #3e94cf;

--- a/assets/scss/00-base/_colors.scss
+++ b/assets/scss/00-base/_colors.scss
@@ -1,43 +1,14 @@
 // Theme colors
 
-// Primary Color
-$c-bay-blue:                       #14558f;
-$c-bay-blue-lighter:               #8AAAC7;
-$c-bay-blue-lightest:              #E7EEF4;
+@import 'colors-tokens';
 
-// Primary Alt Color
-$c-berkshires-green:               #388557;
-$c-berkshires-green-lighter:       #97C2A9;
-$c-berkshires-green-lightest:      #D6E7DD;
-$c-berkshires-green-dark:          #214F34;
 
-// Highlight and Warning Color
-$c-duckling-yellow:                #f6c51b;
-$c-duckling-yellow-lighter:        #FBE28D;
-$c-duckling-yellow-lightest:       #FEF9E8;
-
-// Government to Government Color. Currently not in use.
-$c-independence-cranberry:         #680A1D;
-$c-independence-cranberry-lighter: #AD7E88;
-
-// Base Gray Scale Colors
-$c-revolution-gray:                #141414;
-$c-granite-gray:                   #535353;
-$c-overcast-gray:                  #DCDCDC;
-$c-platinum-gray:                  #F2F2F2;
-$c-atlantic-gray:                  #707070;
-$c-very-light-gray:                #CCCCCC;
-
-// Error Colors
-$c-error-red:                      #CD0D0D;
-$c-error-red-lighter:              #EEACAC;
-$c-error-red-lightest:             #FCF3F3;
-
-// Full Gray Scale
+// Gray Scale Spectrum
 $c-black:                $c-revolution-gray;
 $c-gray-dark:            $c-granite-gray;
 $c-gray:                 $c-atlantic-gray;
 $c-gray-light:           $c-overcast-gray;
+$c-gray-lighter:         #CCCCCC;
 $c-gray-lightest:        $c-platinum-gray;
 $c-white:                white;
 
@@ -47,7 +18,7 @@ $c-error-lighter:        $c-error-red-lighter;
 $c-error-lightest:       $c-error-red-lightest;
 $c-warning:              $c-duckling-yellow;
 $c-success:              $c-berkshires-green;
-$c-focus:                #3e94cf;
+$c-focus:                $c-focus-hightlight;
 // Need to add these colors to this listing new to add
 // $c-visited
 

--- a/assets/scss/00-base/_colors.scss
+++ b/assets/scss/00-base/_colors.scss
@@ -15,31 +15,31 @@ $c-highlight-lighter:    $c-duckling-yellow-lighter !default;
 $c-highlight-lightest:   $c-duckling-yellow-lightest !default;
 
 // Utility Colors Variables
-$c-error:                $c-error-red;
-$c-error-lighter:        $c-error-red-lighter;
-$c-error-lightest:       $c-error-red-lightest;
-$c-warning:              $c-duckling-yellow;
-$c-success:              $c-berkshires-green;
-$c-focus:                $c-focus-hightlight;
+$c-error:                $c-error-red !default;
+$c-error-lighter:        $c-error-red-lighter !default;
+$c-error-lightest:       $c-error-red-lightest !default;
+$c-warning:              $c-duckling-yellow !default;
+$c-success:              $c-berkshires-green !default;
+$c-focus:                $c-focus-hightlight !default;
 // Need to add these colors to this listing new to add
 // $c-visited
 
-$c-font-base:            $c-black;
-$c-font-detail:          $c-gray-dark;
-$c-font-dark:            $c-black;
-$c-font-medium:          $c-gray;
+$c-font-base:            $c-black !default;
+$c-font-detail:          $c-gray-dark !default;
+$c-font-dark:            $c-black !default;
+$c-font-medium:          $c-gray !default;
 
-$c-font-heading:         $c-black;
-$c-font-inverse:         $c-white;
-$c-font-link:            $c-bay-blue;
-$c-font-error:           $c-error;
+$c-font-heading:         $c-black !default;
+$c-font-inverse:         $c-white !default;
+$c-font-link:            $c-bay-blue !default;
+$c-font-error:           $c-error !default;
 
-$c-bg-comp-title:        $c-gray-dark;
-$c-bg-subtle:            $c-gray-lightest;
-$c-bg-section:           $c-gray-lightest;
+$c-bg-comp-title:        $c-gray-dark !default;
+$c-bg-subtle:            $c-gray-lightest !default;
+$c-bg-section:           $c-gray-lightest !default;
 
-$c-bd-divider:           $c-gray-light;
-$c-bd-divider-dark:      $c-gray-dark;
-$c-bd-error:             $c-error;
-$c-bd-input:             $c-gray-light;
-$c-bd-input-dark:        $c-gray;
+$c-bd-divider:           $c-gray-light !default;
+$c-bd-divider-dark:      $c-gray-dark !default;
+$c-bd-error:             $c-error !default;
+$c-bd-input:             $c-gray-light !default;
+$c-bd-input-dark:        $c-gray !default;

--- a/assets/scss/00-base/_colors.scss
+++ b/assets/scss/00-base/_colors.scss
@@ -1,29 +1,8 @@
-// Theme colors
+// Mayflower Color Theme and Usage Mapping
 
-@import 'colors-tokens';
+@import '../../colors/mayflower-color-tokens';
 
-
-// Gray Scale Spectrum
-$c-black:                $c-revolution-gray;
-$c-gray-dark:            $c-granite-gray;
-$c-gray:                 $c-atlantic-gray;
-$c-gray-light:           $c-overcast-gray;
-$c-gray-lighter:         #CCCCCC;
-$c-gray-lightest:        $c-platinum-gray;
-$c-white:                white;
-
-// Additional Global Colors Representing Special States
-$c-error:                $c-error-red;
-$c-error-lighter:        $c-error-red-lighter;
-$c-error-lightest:       $c-error-red-lightest;
-$c-warning:              $c-duckling-yellow;
-$c-success:              $c-berkshires-green;
-$c-focus:                $c-focus-hightlight;
-// Need to add these colors to this listing new to add
-// $c-visited
-
-
-// Theme Color Usage Variables
+// Theme Color Variables
 $c-primary:              $c-bay-blue !default;
 $c-primary-lighter:      $c-bay-blue-lighter !default;
 $c-primary-lightest:     $c-bay-blue-lightest !default;
@@ -34,6 +13,16 @@ $c-primary-alt-dark:     $c-berkshires-green-dark !default;
 $c-highlight:            $c-duckling-yellow !default;
 $c-highlight-lighter:    $c-duckling-yellow-lighter !default;
 $c-highlight-lightest:   $c-duckling-yellow-lightest !default;
+
+// Utility Colors Variables
+$c-error:                $c-error-red;
+$c-error-lighter:        $c-error-red-lighter;
+$c-error-lightest:       $c-error-red-lightest;
+$c-warning:              $c-duckling-yellow;
+$c-success:              $c-berkshires-green;
+$c-focus:                $c-focus-hightlight;
+// Need to add these colors to this listing new to add
+// $c-visited
 
 $c-font-base:            $c-black;
 $c-font-detail:          $c-gray-dark;

--- a/assets/scss/02-molecules/_section-links.scss
+++ b/assets/scss/02-molecules/_section-links.scss
@@ -109,7 +109,7 @@
       margin-bottom: .5em;
     }
     align-self: stretch;
-    
+
     a {
       border: none;
     }
@@ -225,7 +225,7 @@
 
     &:hover,
     &:focus {
-      background-color: $c-very-light-gray;
+      background-color: $c-gray-lighter;
     }
 
     .ma__decorative-link {

--- a/changelogs/DP-17532.yml
+++ b/changelogs/DP-17532.yml
@@ -1,0 +1,17 @@
+Changed:
+  - project: Assets
+    component: SCSS
+    description: Separated color token variable scss from the color usage mapping. (#947)
+    issue: DP-17532
+    impact: Minor
+Added:
+  - project: Assets
+    component: SCSS
+    description: Added and refactored mayflower color gradients into color token stylesheet. (#947)
+    issue: DP-17532
+    impact: Minor
+  - project: Assets
+    component: SCSS
+    description: Registered a new `mayflower-token` package in npm to include color tokens, fonts and images. (#947)
+    issue: DP-17532
+    impact: Minor


### PR DESCRIPTION
Created a color token variable scss stylesheet and separated it from the Mayflower usage mapping, to include into the Mayflower-tokens package
- Added new color gradient variables into color tokens
- Some refactoring was needed to structure the package

See published package --> [@massds/mayflower-tokens](https://www.npmjs.com/package/@massds/mayflower-tokens)

--- 

### Changed:
  - project: Assets
    component: SCSS
    description: Separated color token variable scss from the color usage mapping. (#947)
    issue: DP-17532
    impact: Minor

### Added:
  - project: Assets
    component: SCSS
    description: Added and refactored mayflower color gradients into color token stylesheet. (#947)
    issue: DP-17532
    impact: Minor
  - project: Assets
    component: SCSS
    description: Registered a new `mayflower-token` package in npm to include color tokens, fonts and images. (#947)
    issue: DP-17532
    impact: Minor

