### PR TITLE
DP-17258 Fix links not appearing in TOC

### DIFF
--- a/changelogs/DP-17258.yml
+++ b/changelogs/DP-17258.yml
@@ -1,0 +1,6 @@
+Changed:
+  - project: Patternlab
+    component: StickyTOC
+    description: Fix "see more" button not appearing after the TOC
+    issue: DP-17258
+    impact: Minor

--- a/patternlab/styleguide/source/assets/js/modules/stickyTOC.js
+++ b/patternlab/styleguide/source/assets/js/modules/stickyTOC.js
@@ -105,7 +105,7 @@ export default (function (window, document) {
       }
 
       // Show expander when more than 10 links.
-      if (tocSectionCount <= 10 && window.innerWidth > 480 ) {
+      if (tocSectionCount <= 9 && window.innerWidth > 480 ) {
         toc.querySelector(".ma__sticky-toc__footer").style.display = "none";
       }
     }


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/develop/docs/for-developers/changelog-instructions.md)


## Description
There were links not appearing in the table of contents (TOC) on certain pages like this one.
https://www.mass.gov/info-details/2020-dor-tax-due-dates-and-extensions

What should have been happening is that the "show more" button should have appeared after 10 links but it was counting them incorrectly. I adjusted this so the count is correct and the "show more" button appears when there is actually more than 10 links.

## Related Issue / Ticket

- https://jira.mass.gov/browse/DP-17258

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Pull down this branch locally and visit this page: http://mass.local/info-details/2020-dor-tax-due-dates-and-extensions
2. You should see the "show more" button and clicking it allows you to see the last link in the TOC

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

*

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
