### PR TITLE
DP-15035 Adjust location-listing pagination to output 10 items only

### DIFF
--- a/changelogs/DP-15035.yml
+++ b/changelogs/DP-15035.yml
@@ -1,0 +1,6 @@
+Fixed:
+  - project: Patternlab
+    component: Location-listing
+    description: Limit pagination output to 10 items
+    issue: DP-15035
+    impact: Minor

--- a/patternlab/styleguide/source/_patterns/03-organisms/by-author/location-listing.twig
+++ b/patternlab/styleguide/source/_patterns/03-organisms/by-author/location-listing.twig
@@ -27,7 +27,14 @@
         {% endblock %}
 
         {% set pagination = locationListing.pagination %}
-        {% include "@molecules/pagination.twig" %}
+
+        {% include "@molecules/pagination.twig" with {
+          pagination: {
+            prev: pagination.prev,
+            next: pagination.next,
+            pages: pagination.pages|slice(0, 10)
+          }
+        } %}
       </div>
     </div>
   </div>


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/develop/docs/for-developers/changelog-instructions.md)


## Description
On the initial page load of https://www.mass.gov/assisted-living/locations?_page=1 the pagination sometimes overflows its container and displays too many items. This is fixed for the user once a pagination link is clicked and the pagination is then handled by JS. We adjusted the initial output from the twig template to output a maximum of 10 items. 

A few other notes..

When working locally with a super-sanitized database you may hit fatal errors when loading http://mass.local/assisted-living/locations?_page=1 . I think some required fields are getting sanitized so you may have to adjust for that. Some better error handling in `MapController.php` and `MapLocationFetcher.php` might help this when using a sanitized database. 

## Related Issue / Ticket

- https://jira.mass.gov/browse/DP-15035

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Visit http://mass.local/assisted-living/locations?_page=1 in a chrome incognito page. You may have to clear browser caches for this page as well. You should see 10 items initially loaded

So you should intially see this:

![initial_load_pagaination](https://user-images.githubusercontent.com/11247942/75482625-2e3bbf00-5973-11ea-97b2-3314613ccae6.png)


Then after you click a pagination link you will see this:

![js_pagination](https://user-images.githubusercontent.com/11247942/75482634-3431a000-5973-11ea-8b64-47888dd7307e.png)



## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

*

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
