### PR TITLE
Hotfix: React/fix mayflower react 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,11 +180,6 @@ jobs:
       - run:
           name: Mayflower React Build Storybook
           command: cd react && npm run build-storybook
-      - run:
-          name: Cleanup Mayflower assets package
-          command: |
-            rm -rf react/es/assets/package.json react/es/assets/package-lock.json react/es/assets/dist react/es/assets/scripts
-            rm -rf react/lib/assets/package.json react/lib/assets/package-lock.json react/lib/assets/dist react/lib/assets/scripts
       - persist_to_workspace:
           root: ~/repo
           paths: ["*"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 # Mayflower Release Notes
 All notable changes to this project will be documented in this file.
 
+## 9.44.2 (3/20/2020)
+### Fixed
+- (React) [NPM Package] hotfix: Fix Mayflower-react by updating prepublish hook. Please note: 9.44.1 was not successful, due to the package was overwritten by prepublish build. (#990)
+
 ## 9.44.1 (3/19/2020)
-### Fixed 
+### Fixed
 - (React) [NPM Package] hotfix: Remove package.json from symlinked assets folder in package. (#986)
 
 ## 9.44.0 (3/16/2020)
-### Added 
+### Added
 - (React) [Icon] DP-17530: Added github and slack icons. (#970)
 - (React) [SectionLinks] DP-17530: Added SectionLinks component. (#970)
 - (React) [Tabs] DP-17530: Added anchor link option for Tabs. (#970)
@@ -14,11 +18,11 @@ All notable changes to this project will be documented in this file.
 - (React) [Image] DP-17530: Refactored and fixed `shape` and `classes` props. (#970)
 - (Patternlab) [InformationDetails] DP-17625: Visual Story sidebar template and styles adjust. (#969)
 
-### Changed 
+### Changed
 - (Site) [New] DP-17530: Added Mayflower site homepage built with Gatsby and Mayflower React. (#970)
 - (React, Patternlab, Assets) [CircleCI] DP-17800: Move release to Monday 1pm EST (#980)
 
-### Fixed 
+### Fixed
 - (Patternlab) [Listings] DP-17633: Fix geocoding for autocomplete results on location listings. (#972)
 
 ## 9.43.0 (3/10/2020)

--- a/react/package.json
+++ b/react/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@massds/mayflower-react-test",
+  "name": "@massds/mayflower-react",
   "description": "React versions of Mayflower design system UI components",
   "author": "Massachusetts Digital Services (MDS)",
-  "version": "9.44.2-test3",
+  "version": "9.44.2",
   "main": "lib/index.js",
   "module": "es/index.js",
   "files": [

--- a/react/package.json
+++ b/react/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@massds/mayflower-react",
+  "name": "@massds/mayflower-react-test",
   "description": "React versions of Mayflower design system UI components",
   "author": "Massachusetts Digital Services (MDS)",
-  "version": "9.3.0",
+  "version": "9.44.2-test3",
   "main": "lib/index.js",
   "module": "es/index.js",
   "files": [
@@ -25,7 +25,7 @@
     "test": "nwb test-react",
     "test:coverage": "nwb test-react --coverage",
     "test:watch": "nwb test-react --server",
-    "prepublishOnly": "npm run build",
+    "prepublishOnly": "npm run build && ./scripts/cleanup-package.sh",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"
   },

--- a/react/scripts/cleanup-package.sh
+++ b/react/scripts/cleanup-package.sh
@@ -1,0 +1,2 @@
+rm -rf es/assets/package.json es/assets/package-lock.json es/assets/dist es/assets/scripts
+rm -rf lib/assets/package.json lib/assets/package-lock.json lib/assets/dist lib/assets/scripts


### PR DESCRIPTION
- (React) [NPM Package] hotfix: Fix Mayflower-react by updating prepublish hook. Please note: 9.44.1 was not successful, due to the package was overwritten by prepublish build. (#990)