### PR TITLE
site/fix mayflower-react package

### DIFF
--- a/assets/scss/01-atoms/_button-with-icon.scss
+++ b/assets/scss/01-atoms/_button-with-icon.scss
@@ -19,7 +19,7 @@ $quaternary-colors: (
   display: inline-block;
   font-weight: 700;
   letter-spacing: $letter-spacing-large;
-  padding: 0 14px;
+  padding: 10px 14px;
   text-transform: uppercase;
   transition: background-color .4s, color .4s, border .4s, fill .4s;
   white-space: nowrap;
@@ -39,7 +39,7 @@ $quaternary-colors: (
     }
   }
 
-  &--small { 
+  &--small {
     font-size: 1rem;
     line-height: 1.2;
     padding-top: 5px;
@@ -47,7 +47,7 @@ $quaternary-colors: (
     min-height: 0px;
   }
 
-  &--large { 
+  &--large {
     font-size: 1.375rem;
     line-height: 1.61;
     padding-top: 10px;

--- a/changelogs/update-site.yml
+++ b/changelogs/update-site.yml
@@ -1,0 +1,18 @@
+Added:
+  - project: React
+    component: ButtonWithIcon
+    description: Add `href` prop and allow passing `text` as children, allow the ButtonWithIcon component to be rendered as a link. (#992)
+    issue: DP-17662
+    impact: Minor
+Fixed:
+  - project: Site
+    component: Dependency
+    description: Upgrade Mayflower-react to 9.44.2 to fix assets paths. (#992)
+    issue: DP-17662
+    impact: Patch
+Changed:
+  - project: Site
+    component: Homepage
+    description: Update data and fixed images. (#992)
+    issue: DP-17662
+    impact: Patch

--- a/react/src/components/atoms/buttons/ButtonWithIcon/index.js
+++ b/react/src/components/atoms/buttons/ButtonWithIcon/index.js
@@ -26,17 +26,22 @@ const ButtonWithIcon = (props) => {
     className: buttonClasses,
     tabIndex: 0
   };
+  const Element = props.href ? 'a' : 'button';
   return(
-    <button {...buttonProps} ref={setButtonRef} aria-expanded={expanded}>
-      <span>{text}</span>
-      {icon}
-    </button>
+    <Element {...buttonProps} ref={setButtonRef} aria-expanded={expanded}>
+      <span>{props.children ? props.children : props.text}</span>
+      {icon && icon}
+    </Element>
   );
 };
 
 ButtonWithIcon.propTypes = {
   /** id for the button */
   id: PropTypes.string,
+  /** button or link content rendered in a span */
+  children: PropTypes.element,
+  /** When populated with a url, this component renders a <a> vs a <button> */
+  href: PropTypes.string,
   // Function to run on click of the button.
   onClick: PropTypes.func,
   // Sets a reference to the button onto the passed node.

--- a/site/.env.development
+++ b/site/.env.development
@@ -1,0 +1,2 @@
+# This variable is referenced in gatsby-config.js and used during gatsby build --path-prefix and gatsby serve --path-prefix.
+GATSBY_PATH_PREFIX=""

--- a/site/.env.production
+++ b/site/.env.production
@@ -1,0 +1,2 @@
+# This variable is referenced in gatsby-config.js and used during gatsby build --path-prefix and gatsby serve --path-prefix.
+GATSBY_PATH_PREFIX="/home"

--- a/site/.gitignore
+++ b/site/.gitignore
@@ -52,7 +52,7 @@ typings/
 *.tgz
 
 # dotenv environment variable files
-.env*
+.env
 
 # gatsby files
 .cache/

--- a/site/gatsby-config.js
+++ b/site/gatsby-config.js
@@ -1,6 +1,7 @@
 const path = require('path');
 
 module.exports = {
+  pathPrefix: `/home`,
   siteMetadata: {
     title: `Mayflower`,
     description: `A design system for the Commonwealth of Massachusetts`,

--- a/site/gatsby-config.js
+++ b/site/gatsby-config.js
@@ -4,10 +4,8 @@ require('dotenv').config({
   path: `.env.${process.env.NODE_ENV}`
 });
 
-console.log(process.env.GATSBY_PATH_PREFIX)
-
 module.exports = {
-  pathPrefix: process.env.GATSBY_PATH_PREFIX || '',
+  pathPrefix: process.env.GATSBY_PATH_PREFIX,
   siteMetadata: {
     title: `Mayflower`,
     description: `A design system for the Commonwealth of Massachusetts`,

--- a/site/gatsby-config.js
+++ b/site/gatsby-config.js
@@ -13,7 +13,7 @@ module.exports = {
       resolve: `gatsby-source-filesystem`,
       options: {
         name: `images`,
-        path: `${__dirname}/src/images`,
+        path: path.resolve(__dirname, './src/images/'),
       },
     },
     {

--- a/site/gatsby-config.js
+++ b/site/gatsby-config.js
@@ -1,7 +1,13 @@
 const path = require('path');
 
+require('dotenv').config({
+  path: `.env.${process.env.NODE_ENV}`
+});
+
+console.log(process.env.GATSBY_PATH_PREFIX)
+
 module.exports = {
-  pathPrefix: `/home`,
+  pathPrefix: process.env.GATSBY_PATH_PREFIX || '',
   siteMetadata: {
     title: `Mayflower`,
     description: `A design system for the Commonwealth of Massachusetts`,

--- a/site/package.json
+++ b/site/package.json
@@ -39,11 +39,11 @@
   ],
   "license": "MIT",
   "scripts": {
-    "build": "gatsby build",
+    "build": "gatsby build --prefix-paths",
     "develop": "gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "start": "npm run develop",
-    "serve": "gatsby serve",
+    "serve": "gatsby serve --prefix-paths",
     "clean": "gatsby clean",
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\" && exit 1",
     "lint": "./node_modules/.bin/eslint . --config .eslintrc",

--- a/site/package.json
+++ b/site/package.json
@@ -5,7 +5,7 @@
   "version": "0.1.0",
   "author": "Minghua Sun <clairesunstudio@gmail.com>",
   "dependencies": {
-    "@massds/mayflower-react": "9.40.0",
+    "@massds/mayflower-react": "9.44.2",
     "bootstrap": "^4.4.1",
     "classname": "^0.0.0",
     "gatsby": "^2.19.7",

--- a/site/package.json
+++ b/site/package.json
@@ -24,6 +24,8 @@
     "react-helmet": "^5.2.1"
   },
   "devDependencies": {
+    "cross-env": "^7.0.2",
+    "dotenv": "^8.2.0",
     "eslint": "^5.16.0",
     "eslint-config-airbnb": "^17.1.0",
     "eslint-loader": "^3.0.2",
@@ -43,7 +45,7 @@
     "develop": "gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "start": "npm run develop",
-    "serve": "gatsby serve --prefix-paths",
+    "serve": "cross-env NODE_ENV=production gatsby serve --prefix-paths",
     "clean": "gatsby clean",
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\" && exit 1",
     "lint": "./node_modules/.bin/eslint . --config .eslintrc",

--- a/site/src/components/layout.js
+++ b/site/src/components/layout.js
@@ -42,13 +42,13 @@ const Layout = ({ children, pre }) => {
   const siteLogo = <SiteLogo {...siteLogoProps} />
 
   const footerProps = {
-    title: 'Massachusetts Executive Office of Technology Security and Services (EOTSS)',
+    title: 'Executive Office of Technology Security and Services (EOTSS)',
     contact: {
       address: '1 Ashburton Place, 8th Floor, Boston, MA 02108',
       phone: '(617) 626-4400',
       online: {
-        href: 'https://mass.gov/EOTSS',
-        title: 'EOTSS Official Website'
+        href: 'https://www.mass.gov/orgs/massachusetts-digital-service',
+        title: 'Massachusetts Digital Service official website'
       }
     },
     siteLogo

--- a/site/src/data/index.json
+++ b/site/src/data/index.json
@@ -43,30 +43,42 @@
     },
     "description": "Use these branding assets to create a cohesive look across Commonwealth web properties.",
     "items": [{
-      "text": "Colors",
-      "href": ""
+      "text": "Color Tokens",
+      "href": "https://mayflower.digital.mass.gov/react/index.html?path=/story/brand-colors--colors",
+      "description": "",
+      "theme": ""
     },{
       "text": "Typography",
-      "href": ""
+      "href": "https://mayflower.digital.mass.gov/react/index.html?path=/story/brand-typography--about",
+      "description": "",
+      "theme": ""
     },{
       "text": "Icons",
-      "href": ""
+      "href": "https://mayflower.digital.mass.gov/react/index.html?path=/story/brand-icons--all-icons",
+      "description": "",
+      "theme": ""
     },{
       "text": "Mayflower Tokens NPM Package",
-      "href": "https://www.npmjs.com/package/@massds/mayflower-tokens"
+      "href": "https://www.npmjs.com/package/@massds/mayflower-tokens",
+      "description": "Download the color token SCSS variables, fonts, icons and other imagery for a Mayflower theme.",
+      "theme": "white"
     }]
   },
   {
     "title": {
       "text": "2. Markup and CSS"
     },
-    "description": "Implement Mayflower HTML markup and its generated static assets.",
+    "description": "Implement Mayflower HTML markup and its generated static assets to .",
     "items": [{
       "text": "Mayflower CSS and JS NPM Package",
-      "href": ""
+      "href": "",
+      "description": "",
+      "theme": ""
     },{
       "text": "Mayflower HTML Starter",
-      "href": ""
+      "href": "",
+      "description": "",
+      "theme": ""
     }]
   },
   {
@@ -74,16 +86,22 @@
       "text": "3. Component Libraries",
       "href": ""
     },
-    "description": "Use Mayflower component libraries help you build fast, accessible, mobile-friendly, cross-browser compatible web products quickly and efficiently.",
+    "description": "Leverage Mayflower component libraries build fast, accessible, mobile-friendly, cross-browser compatible web products efficiently.",
     "items": [{
       "text": "React Component Library",
-      "href": ""
+      "href": "",
+      "description": "",
+      "theme": ""
     },{
       "text": "Mayflower React NPM Package",
-      "href": ""
+      "href": "",
+      "description": "",
+      "theme": ""
     },{
       "text": "Patternlab Component Library",
-      "href": "Mayflower React NPM Package"
+      "href": "Mayflower React NPM Package",
+      "description": "",
+      "theme": ""
     }]
   }],
   "projects": [

--- a/site/src/data/index.json
+++ b/site/src/data/index.json
@@ -153,7 +153,7 @@
       "title": {
         "info": "",
         "text": "Submit a Github issue",
-        "href": "https://www.mass.gov",
+        "href": "https://github.com/massgov/mayflower/issues/new/choose",
         "showFileIcon": false
       },
       "description": "Found a bug or have a feature request?",
@@ -166,7 +166,7 @@
       "title": {
         "info": "",
         "text": "Join Mayflower Slack",
-        "href": "https://www.mass.gov",
+        "href": "https://join.slack.com/t/mayflowerdesignsystem/shared_invite/zt-7bspvkb6-2CBqU8oxumJuikKpe4pZHA",
         "showFileIcon": false
       },
       "description": "Join the Mayflower community and stay updated with releases.",

--- a/site/src/data/index.json
+++ b/site/src/data/index.json
@@ -2,11 +2,11 @@
   "title": "Homepage",
   "header": {
     "pageHeader": {
-      "title": "A design system for the state government"
+      "title": "A design system for Massachusetts state government"
     },
     "category": "Commonwealth of Massachusetts",
     "inverted": true,
-    "paragraph": "We make it easier to build a accessible, mobile-friendly government websites with a consistent look and feel for the state of Massachusetts.",
+    "paragraph": "Mayflower makes it easier to build accessible, mobile-friendly websites with a consistent look and feel for the state of Massachusetts.",
     "bgInfo": "",
     "bgImage": "",
     "buttons": [
@@ -41,7 +41,7 @@
     "title": {
       "text": "1. Branding and Tokens"
     },
-    "description": "Use these branding assets to create a cohesive look across Commonwealth web properties.",
+    "description": "Use these tech agnostic branding assets to create a cohesive look across Commonwealth web properties.",
     "items": [{
       "text": "Color Tokens",
       "href": "https://mayflower.digital.mass.gov/react/index.html?path=/story/brand-colors--colors",

--- a/site/src/data/index.json
+++ b/site/src/data/index.json
@@ -94,14 +94,14 @@
     "description": "Leverage Mayflower component libraries to build fast, accessible, mobile-friendly, cross-browser compatible web products efficiently.",
     "items": [{
       "text": "React Component Library",
-      "href": "",
-      "description": "",
+      "href": "https://mayflower.digital.mass.gov/react",
+      "description": "Browse Mayflower components built with ReactJS.",
       "theme": ""
     },{
       "text": "Mayflower React NPM Package",
-      "href": "",
-      "description": "",
-      "theme": ""
+      "href": "https://www.npmjs.com/package/@massds/mayflower-react",
+      "description": "Install the package to use Mayflower components in your React APP.",
+      "theme": "white"
     }]
   }],
   "projects": [

--- a/site/src/data/index.json
+++ b/site/src/data/index.json
@@ -68,17 +68,22 @@
     "title": {
       "text": "2. Markup and CSS"
     },
-    "description": "Implement Mayflower HTML markup and its generated static assets to .",
+    "description": "Implement Mayflower HTML markup and link to the CDN for compiled static assets.",
     "items": [{
-      "text": "Mayflower CSS and JS NPM Package",
-      "href": "",
-      "description": "",
-      "theme": ""
-    },{
       "text": "Mayflower HTML Starter",
-      "href": "",
-      "description": "",
+      "href": "https://github.com/massgov/mayflower-starters",
+      "description": "Use the Mayflower starters to kick-start builidng a simple webpage.",
       "theme": ""
+    }, {
+      "text": "Mayflower Patternlab",
+      "href": "https://mayflower.digital.mass.gov/patternlab",
+      "description": "Explore the Mayflower components and their HTML markup.",
+      "theme": ""
+    }, {
+      "text": "Mayflower static assets CDN",
+      "href": "https://unpkg.com/browse/@massds/mayflower/",
+      "description": "Webfonts, images, compiled CSS and JS are served over the UNPKG CDN. Point to a specific version to go with the markup.",
+      "theme": "white"
     }]
   },
   {
@@ -86,7 +91,7 @@
       "text": "3. Component Libraries",
       "href": ""
     },
-    "description": "Leverage Mayflower component libraries build fast, accessible, mobile-friendly, cross-browser compatible web products efficiently.",
+    "description": "Leverage Mayflower component libraries to build fast, accessible, mobile-friendly, cross-browser compatible web products efficiently.",
     "items": [{
       "text": "React Component Library",
       "href": "",
@@ -95,11 +100,6 @@
     },{
       "text": "Mayflower React NPM Package",
       "href": "",
-      "description": "",
-      "theme": ""
-    },{
-      "text": "Patternlab Component Library",
-      "href": "Mayflower React NPM Package",
       "description": "",
       "theme": ""
     }]
@@ -123,7 +123,7 @@
       "title": {
         "info": "FY20 summary budget site homepage",
         "text": "Massachusetts budget sites",
-        "href": "https://www.mass.gov",
+        "href": "http://budget.digital.mass.gov/summary/fy20/",
         "showFileIcon": false
       },
       "description": "",
@@ -137,7 +137,7 @@
       "title": {
         "info": "PFML Contribution Calculator",
         "text": "Paid Family Medical Leave Contribution Calculator",
-        "href": "https://www.mass.gov",
+        "href": "https://calculator.digital.mass.gov/pfml/contribution",
         "showFileIcon": false
       },
       "description": "",
@@ -152,7 +152,7 @@
     {
       "title": {
         "info": "",
-        "text": "Github",
+        "text": "Submit a Github issue",
         "href": "https://www.mass.gov",
         "showFileIcon": false
       },
@@ -164,12 +164,12 @@
     },
     {
       "title": {
-        "info": "FY20 summary budget site homepage",
-        "text": "Slack",
+        "info": "",
+        "text": "Join Mayflower Slack",
         "href": "https://www.mass.gov",
         "showFileIcon": false
       },
-      "description": "Join the discussion and stay updated",
+      "description": "Join the Mayflower community and stay updated with releases.",
       "icon": {
         "name": "slack",
         "fill": "#388557"
@@ -177,12 +177,12 @@
     },
     {
       "title": {
-        "info": "mass.gov homepage",
-        "text": "Email",
-        "href": "https://www.mass.gov",
+        "info": "",
+        "text": "Email Us",
+        "href": "mailto:Digitalservices@mass.gov",
         "showFileIcon": false
       },
-      "description": "Get in touch with the team",
+      "description": "Get in touch with the team for other purposes.",
       "icon": {
         "name": "mail",
         "fill": "#388557"

--- a/site/src/pages/index.js
+++ b/site/src/pages/index.js
@@ -1,11 +1,11 @@
-import React from "react"
+import React from "react";
 import { graphql } from "gatsby";
 import Img from 'gatsby-image';
 import Layout from "../components/layout"
 import Image from "../components/image"
 import SEO from "../components/seo"
 import Section from "../components/section"
-import { IllustratedHeader, ButtonWithIcon, GenTeaser, Tabs, Icon, SectionLinks, DecorativeLink } from "@massds/mayflower-react";
+import { IllustratedHeader, ButtonWithIcon, GenTeaser, Tabs, Icon, SectionLinks, DecorativeLink, CalloutLink } from "@massds/mayflower-react";
 import BannerImage from '../images/massgov.png';
 
 import './index.scss';
@@ -45,7 +45,7 @@ const IndexPage = ({ data: { content } }) => {
               <div class="col-md">
                 <SectionLinks {...sectionLinksProps}>
                   {
-                    items.map((item) => <DecorativeLink {...item} />)
+                    items.map((item) => <CalloutLink {...item} />)
                   }
                 </SectionLinks>
               </div>
@@ -133,6 +133,8 @@ export const query = graphql`
         items {
           text
           href
+          description
+          theme
         }
       }
       projects {

--- a/site/src/pages/index.js
+++ b/site/src/pages/index.js
@@ -60,7 +60,7 @@ const IndexPage = ({ data: { content } }) => {
             projects.map(({ title, description, img }) => (
               <div class="col-md">
                 <GenTeaser stacked>
-                  <GenTeaser.Image style={{ height: 200, borderWidth: '1px', borderStyle: 'solid' }}>
+                  <GenTeaser.Image style={{ maxHeight: 200, borderWidth: '1px', borderStyle: 'solid' }}>
                     <Img fluid={img.src.childImageSharp.fluid} alt={img.alt}  />
                   </GenTeaser.Image>
                   <GenTeaser.Details>

--- a/site/src/pages/index.js
+++ b/site/src/pages/index.js
@@ -39,7 +39,7 @@ const IndexPage = ({ data: { content } }) => {
       </IllustratedHeader>
       <Tabs tabs={tabs} />
       <Section>
-        <div class="row">
+        <div class="row ma__row--three-up">
           {
             links.map(({ items, ...sectionLinksProps }) => (
               <div class="col-md">

--- a/site/src/pages/index.scss
+++ b/site/src/pages/index.scss
@@ -19,3 +19,48 @@
   overflow: hidden;
   border-color: $c-gray-lighter;
 }
+
+h2.ma__section-links__title {
+  margin-bottom: 0;
+}
+
+.ma__callout-link{
+    line-height: 1.3;
+    @media ($bp-medium-min) {
+        width: 33%;
+    }
+    @media ($bp-large-min) {
+        width: 100%;
+    }
+    @media ($bp-x-large-min) {
+        width: 33%;
+    }
+    @media ($bp-small-min) {
+      padding: 15px 20px;
+    }
+
+    a {
+      display: contents;
+    }
+
+    &__container {
+      font-size: 1.3rem;
+      padding-right: 0;
+    }
+
+    &__description {
+        font-size: 1rem;
+        @media ($bp-x-large-max) {
+            display: none;
+        }
+    }
+}
+
+// Bootstrap overrides
+.row {
+  align-items: stretch;
+  
+  .col-md {
+    height: 100%;
+  }
+}

--- a/site/src/pages/index.scss
+++ b/site/src/pages/index.scss
@@ -56,11 +56,11 @@ h2.ma__section-links__title {
     }
 }
 
-// Bootstrap overrides
-.row {
+// Match row height
+.ma__row--three-up {
   align-items: stretch;
 
-  .col-md {
+  .ma__section-links {
     height: 100%;
   }
 }

--- a/site/src/pages/index.scss
+++ b/site/src/pages/index.scss
@@ -59,7 +59,7 @@ h2.ma__section-links__title {
 // Bootstrap overrides
 .row {
   align-items: stretch;
-  
+
   .col-md {
     height: 100%;
   }

--- a/site/yarn.lock
+++ b/site/yarn.lock
@@ -1118,10 +1118,10 @@
   dependencies:
     core-js "^2.5.7"
 
-"@massds/mayflower-react@9.40.0":
-  version "9.40.0"
-  resolved "https://registry.yarnpkg.com/@massds/mayflower-react/-/mayflower-react-9.40.0.tgz#16e79241edd723ebcb665afd5c66a912e6052bfd"
-  integrity sha512-YL2uX4R86UzCRibnC0jtgsckr/Gxov2h1cy6ly5LDwcTl6va5Tp3VCEnVE7uck8E1HL7VruIIKM7IkDoIGtBZw==
+"@massds/mayflower-react@9.44.2":
+  version "9.44.2"
+  resolved "https://registry.yarnpkg.com/@massds/mayflower-react/-/mayflower-react-9.44.2.tgz#a6ba65a317b85e56fa86ff11402ebf4dcd181b04"
+  integrity sha512-307scmUBeInooik++v16nvgqum6RgSstYQmif7Ahm9noeyejjggVlcoDi0sMngmyK9L1/UuBXTQOX+qVLeLmPw==
   dependencies:
     airbnb-prop-types "^2.13.2"
     autosuggest-highlight "^3.1.1"

--- a/site/yarn.lock
+++ b/site/yarn.lock
@@ -3471,6 +3471,13 @@ create-react-context@^0.2.1:
     fbjs "^0.8.0"
     gud "^1.0.0"
 
+cross-env@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.2.tgz#bd5ed31339a93a3418ac4f3ca9ca3403082ae5f9"
+  integrity sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
 cross-fetch@2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-2.2.2.tgz#a47ff4f7fc712daba8f6a695a11c948440d45723"
@@ -3507,7 +3514,7 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.0:
+cross-spawn@^7.0.0, cross-spawn@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.1.tgz#0ab56286e0f7c24e153d04cc2aa027e43a9a5d14"
   integrity sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==


### PR DESCRIPTION
Added:
  - project: React
    component: ButtonWithIcon
    description: Add `href` prop and allow passing `text` as children, allow the ButtonWithIcon component to be rendered as a link. (#992)
    issue: DP-17662
    impact: Minor
Fixed:
  - project: Site
    component: Dependency
    description: Upgrade Mayflower-react to 9.44.2 to fix assets paths. (#992)
    issue: DP-17662
    impact: Patch
Changed:
  - project: Site
    component: Homepage
    description: Update data and fixed images. (#992)
    issue: DP-17662
    impact: Patch


--- 

To see the homepage built from `/site`
Go to mayflower.digital.mass.gov