### PR TITLE
DP-18000 make top level items in main nav clickable

### DIFF
--- a/assets/scss/02-molecules/_main-nav.scss
+++ b/assets/scss/02-molecules/_main-nav.scss
@@ -277,6 +277,9 @@
     letter-spacing: letter-spacing-medium;
     text-transform: uppercase;
   }
+  a {
+    color: #141414;
+  }
 }
 
 //theme

--- a/assets/scss/02-molecules/_main-nav.scss
+++ b/assets/scss/02-molecules/_main-nav.scss
@@ -277,6 +277,7 @@
     letter-spacing: letter-spacing-medium;
     text-transform: uppercase;
   }
+
   a {
     color: #141414;
   }

--- a/changelogs/DP-18000.yml
+++ b/changelogs/DP-18000.yml
@@ -1,0 +1,58 @@
+# Every PR must have a changelog. To create a changelog:
+# 1. Make a copy of this file and name it with the ticket number.
+# 2. Keep the original format of one of the examples at the bottom, and override each element of it using ___TEMPLATE___ for reference
+# 3. Remove all comments from the copied file
+
+#___CHANGE TYPES___
+# - Added for new features.
+# - Changed for changes in existing functionality.
+# - Deprecated for soon-to-be removed features.
+# - Removed for now removed features.
+# - Fixed for any bug fixes.
+# - Security in case of vulnerabilities.
+# e.g. Added
+
+#___PROJECT___
+# - Patternlab
+# - React
+# - Docs
+# e.g. React
+# e.g. React, Patternlab
+
+#___COMPONENT___
+# Component name(s) in `PascalCase`
+# e.g. Header
+# e.g. Form, InputSlider, InputTextTypeAhead
+
+#___DESCRIPTION___
+# PR description and PR number (append PR number with # to create a link to the PR in Github)
+# If you need multiple lines, start the first line with the following "|-" characters.
+# For any breaking changes, add a comment in the PR describing the necessary changes on the consumer side and link that comment in the description.
+#e.g. Adds apples to apple trees for admin apple pickers (#PR)
+
+#___ISSUE___
+# A Jira ticket or a Github issue number (append Github issue number with # to create a link to the issue in Github)
+# e.g. DP-12345 or #123
+
+#___IMPACT___
+# - Major impact when you make incompatible API changes,
+# - Minor impact when you add functionality in a backwards compatible manner, and
+# - Patch impact when you make backwards compatible bug fixes.
+# e.g. Minor
+# See https://semver.org/ for more info.
+
+
+#___TEMPLATE___
+# ChangeType [enter a valid option, see __CHANGE TYPES___ e.g. Added]:
+#  - project: Enter one or multiple (comma separated) valid project prefix(es) - see ___PROJECT___ e.g. React, Patternlab
+#    component: Enter one or multiple (comma separated) valid component name(s) - see ___COMPONENT___ e.g. Color
+#    description: Describe the change and add the PR number. see ___DESCRIPTION___ e.g. Adds apples to apple trees for admin apple pickers (#PR)
+#    issue: Add a Jira ticket or issue number, e.g. DP-12345 or 124
+#    impact: Enter a valid impact, e.g. Minor
+
+Changed:
+  - project: Patternlab
+    component: main-nav
+    description: Make top-level nav items clickable
+    issue: DP-18000
+    impact: Minor

--- a/patternlab/styleguide/source/_patterns/02-molecules/main-nav.twig
+++ b/patternlab/styleguide/source/_patterns/02-molecules/main-nav.twig
@@ -24,9 +24,7 @@
             </ul>
           </div>
         {% elseif nav.href %}
-          <a href="{{ nav.href }}" class="ma__main-nav__top-link" tabindex="0">
-              <span class="visually-hidden show-label">See all topics under </span>{{ nav.text }}
-          </a>
+          <a href="{{ nav.href }}" class="ma__main-nav__top-link" tabindex="0">{{ nav.text }}</a>
         {% else %}
           <button id="{{ buttonId }}" class="ma__main-nav__top-link" tabindex="{{ loop.first? 0 : -1 }}">{{ nav.text }}</button>
         {% endif %}

--- a/patternlab/styleguide/source/_patterns/02-molecules/main-nav.twig
+++ b/patternlab/styleguide/source/_patterns/02-molecules/main-nav.twig
@@ -24,11 +24,9 @@
             </ul>
           </div>
         {% elseif nav.href %}
-          <button id="{{ buttonId }}" class="ma__main-nav__top-link" aria-haspopup="true" aria-expanded="false" tabindex="0">
-            <a href="{{ nav.href }}">
+          <a href="{{ nav.href }}" class="ma__main-nav__top-link" aria-haspopup="true" aria-expanded="false" tabindex="0">
               <span class="visually-hidden show-label">See all topics under </span>{{ nav.text }}
-            </a>
-          </button>
+          </a>
         {% else %}
           <button id="{{ buttonId }}" class="ma__main-nav__top-link" tabindex="{{ loop.first? 0 : -1 }}">{{ nav.text }}</button>
         {% endif %}

--- a/patternlab/styleguide/source/_patterns/02-molecules/main-nav.twig
+++ b/patternlab/styleguide/source/_patterns/02-molecules/main-nav.twig
@@ -23,6 +23,12 @@
               </li>
             </ul>
           </div>
+        {% elseif nav.href %}
+          <button id="{{ buttonId }}" class="ma__main-nav__top-link" aria-haspopup="true" aria-expanded="false" tabindex="0">
+            <a href="{{ nav.href }}">
+              <span class="visually-hidden show-label">See all topics under </span>{{ nav.text }}
+            </a>
+          </button>
         {% else %}
           <button id="{{ buttonId }}" class="ma__main-nav__top-link" tabindex="{{ loop.first? 0 : -1 }}">{{ nav.text }}</button>
         {% endif %}

--- a/patternlab/styleguide/source/_patterns/02-molecules/main-nav.twig
+++ b/patternlab/styleguide/source/_patterns/02-molecules/main-nav.twig
@@ -24,7 +24,7 @@
             </ul>
           </div>
         {% elseif nav.href %}
-          <a href="{{ nav.href }}" class="ma__main-nav__top-link" aria-haspopup="true" aria-expanded="false" tabindex="0">
+          <a href="{{ nav.href }}" class="ma__main-nav__top-link" tabindex="0">
               <span class="visually-hidden show-label">See all topics under </span>{{ nav.text }}
           </a>
         {% else %}


### PR DESCRIPTION
## Description
Adds logic to the main nav molecule to allow top level menu items to be clicked.

## Related Issue / Ticket

- [JIRA issue](https://jira.mass.gov/browse/DP-18000)

## Steps to Test
1. Go to http://mass.local/admin/structure/menu/manage/main/add?destination=/admin/structure/menu
2. Add a menu link and ensure the "Show as expanded" checkbox in unchecked
3. Save the menu link and return to the homepage.
4. Find your new menu link in the main navigation
5. Click the link and verify it takes you to the page your specified
6. Verify existing links behave as expected

## Screenshots
![2020-03-31_452x174](https://user-images.githubusercontent.com/4932789/78050588-740cee00-734a-11ea-91f5-025f3273341a.png)


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

*

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
