### PR TITLE
DP-18018 Style clickable main nav link

### DIFF
--- a/assets/scss/02-molecules/_main-nav.scss
+++ b/assets/scss/02-molecules/_main-nav.scss
@@ -133,6 +133,7 @@
 
     &.cv-alternate-style {
       background-color: #f7c600;
+
       &:hover {
         background-color: #fce387;
       }

--- a/assets/scss/02-molecules/_main-nav.scss
+++ b/assets/scss/02-molecules/_main-nav.scss
@@ -131,6 +131,12 @@
       }
     }
 
+    &.cv-alternate-style {
+      background-color: #f7c600;
+      &:hover {
+        background-color: #fce387;
+      }
+    }
   }
 
   &__back {
@@ -277,6 +283,7 @@
     letter-spacing: letter-spacing-medium;
     text-transform: uppercase;
   }
+
   a {
     color: #141414;
   }

--- a/changelogs/DP-18018.yml
+++ b/changelogs/DP-18018.yml
@@ -1,0 +1,59 @@
+# Every PR must have a changelog. To create a changelog:
+# 1. Make a copy of this file and name it with the ticket number.
+# 2. Keep the original format of one of the examples at the bottom, and override each element of it using ___TEMPLATE___ for reference
+# 3. Remove all comments from the copied file
+
+#___CHANGE TYPES___
+# - Added for new features.
+# - Changed for changes in existing functionality.
+# - Deprecated for soon-to-be removed features.
+# - Removed for now removed features.
+# - Fixed for any bug fixes.
+# - Security in case of vulnerabilities.
+# e.g. Added
+
+#___PROJECT___
+# - Patternlab
+# - React
+# - Docs
+# e.g. React
+# e.g. React, Patternlab
+
+#___COMPONENT___
+# Component name(s) in `PascalCase`
+# e.g. Header
+# e.g. Form, InputSlider, InputTextTypeAhead
+
+#___DESCRIPTION___
+# PR description and PR number (append PR number with # to create a link to the PR in Github)
+# If you need multiple lines, start the first line with the following "|-" characters.
+# For any breaking changes, add a comment in the PR describing the necessary changes on the consumer side and link that comment in the description.
+#e.g. Adds apples to apple trees for admin apple pickers (#PR)
+
+#___ISSUE___
+# A Jira ticket or a Github issue number (append Github issue number with # to create a link to the issue in Github)
+# e.g. DP-12345 or #123
+
+#___IMPACT___
+# - Major impact when you make incompatible API changes,
+# - Minor impact when you add functionality in a backwards compatible manner, and
+# - Patch impact when you make backwards compatible bug fixes.
+# e.g. Minor
+# See https://semver.org/ for more info.
+
+
+#___TEMPLATE___
+# ChangeType [enter a valid option, see __CHANGE TYPES___ e.g. Added]:
+#  - project: Enter one or multiple (comma separated) valid project prefix(es) - see ___PROJECT___ e.g. React, Patternlab
+#    component: Enter one or multiple (comma separated) valid component name(s) - see ___COMPONENT___ e.g. Color
+#    description: Describe the change and add the PR number. see ___DESCRIPTION___ e.g. Adds apples to apple trees for admin apple pickers (#PR)
+#    issue: Add a Jira ticket or issue number, e.g. DP-12345 or 124
+#    impact: Enter a valid impact, e.g. Minor
+
+#___EXAMPLE___
+Changed:
+  - project: Patternlab
+    component: main-nav
+    description: add alternate style for COVID-19 link
+    issue: DP-18018
+    impact: Minor

--- a/patternlab/styleguide/source/_patterns/02-molecules/main-nav.twig
+++ b/patternlab/styleguide/source/_patterns/02-molecules/main-nav.twig
@@ -24,7 +24,12 @@
             </ul>
           </div>
         {% elseif nav.href %}
-          <button id="{{ buttonId }}" class="ma__main-nav__top-link" aria-haspopup="true" aria-expanded="false" tabindex="0">
+          {# This is temporary. We want to provide visual context for the COVID-19 menu link. #}
+          {% set altClass = '' %}
+          {% if 'covid' in nav.text|lower %}
+            {% set altClass = 'cv-alternate-style' %}
+          {% endif %}
+          <button id="{{ buttonId }}" class="ma__main-nav__top-link {{ altClass }}" aria-haspopup="true" aria-expanded="false" tabindex="0">
             <a href="{{ nav.href }}">
               <span class="visually-hidden show-label">See all topics under </span>{{ nav.text }}
             </a>


### PR DESCRIPTION
## Description
Adds temporary styles based on the text in a main nav link

## Related Issue / Ticket

- [JIRA issue](https://jira.mass.gov/browse/DP-18018)

## Steps to Test
1. See steps from [this PR](https://github.com/massgov/mayflower/pull/1004) for adding a link to the main nav. Ensure the name contains "covid" (case insensitive)
2. Save the link and go to the home page. Verify the styles match the designs
3. Edit the menu link and change the name to anything not containing "covid" - save the menu link
4. Go to the home page and verify the styles are not applied to the link

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

*

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
