### PR TITLE
DP-17792 Point button arrow to up when accordion is open

### DIFF
--- a/assets/scss/02-molecules/_button-alert.scss
+++ b/assets/scss/02-molecules/_button-alert.scss
@@ -28,6 +28,13 @@
     border-color: rgba($c-font-inverse,.5);
   }
 
+  // If the parent of the button-alert is an open accordion, then flip the arrow up.
+  .js-accordion.is-open & {
+    &:after {
+      transform: translateY(-50%) rotate(-135deg);
+    }
+  }
+
   // This is used in mayflower-react specifically, `is-open` class is moved down a level from patternlab
 
   &.is-open {

--- a/assets/scss/02-molecules/_button-alert.scss
+++ b/assets/scss/02-molecules/_button-alert.scss
@@ -29,7 +29,9 @@
   }
 
   // If the parent of the button-alert is an open accordion, then flip the arrow up.
+
   .js-accordion.is-open & {
+
     &:after {
       transform: translateY(-50%) rotate(-135deg);
     }

--- a/changelogs/DP-17792.yml
+++ b/changelogs/DP-17792.yml
@@ -1,0 +1,6 @@
+Changed:
+  - project: Patternlab
+    component: Button alert
+    description: Adjusted scss to rotate button arrow up when accordion opens
+    issue: DP-17792
+    impact: Minor


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/develop/docs/for-developers/changelog-instructions.md)


## Description
This ticket addresses the alert button arrow icon that was not pointing up when the accordion was opened.


## Related Issue / Ticket
- https://jira.mass.gov/browse/DP-17792

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Visit this pattern and verify the arrow correctly points up when the accordion is opened: http://localhost:3000/?p=organisms-emergency-alerts
2. Pull this change into the Drupal site and verify this is working correctly with the emergency alert at the top of the page

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

![Screen Shot 2020-04-10 at 9 18 56 AM](https://user-images.githubusercontent.com/11247942/78993762-71f61c80-7b0c-11ea-891c-072f77016ac6.png)

![Screen Shot 2020-04-10 at 9 19 30 AM](https://user-images.githubusercontent.com/11247942/78993770-76223a00-7b0c-11ea-93fa-a43c1ec05dfa.png)




## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

*

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
