### PR TITLE
[Text replacement] import mayflower replacement google fonts

### DIFF
--- a/assets/scss/00-base/_fonts-fallback.scss
+++ b/assets/scss/00-base/_fonts-fallback.scss
@@ -6,3 +6,13 @@
 @import url('https://fonts.googleapis.com/css?family=Source+Code+Pro');
 
 @import url('https://fonts.googleapis.com/css2?family=Hanuman');
+
+/* Import Texta replacement font
+*/
+@import url('https://fonts.googleapis.com/css2?family=Muli:ital,wght@0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap&subset=latin-ext,vietnamese');
+
+// @import url('https://fonts.googleapis.com/css2?family=Raleway:ital,wght@0,300;0,400;0,500;0,700;0,800;1,300;1,400;1,500;1,700;1,800&display=swap');
+// 
+// @import url('https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap');
+// 
+// @import url('https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,300;0,400;0,500;0,700;0,800;1,300;1,400;1,500;1,700;1,800&display=swap');

--- a/assets/scss/00-base/_variables.scss
+++ b/assets/scss/00-base/_variables.scss
@@ -35,6 +35,6 @@ $close-icon: '\00d7';
 
 
 // font families
-$fonts:      "Texta", "Helvetica", "Arial", sans-serif;
+$fonts:      "Muli", "Helvetica", "Arial", sans-serif;
 $fonts-mono: "Source Code Pro", "Monaco", monospace;
 $fonts-khmer: "Hanuman";


### PR DESCRIPTION
<img width="867" alt="Screen Shot 2020-04-22 at 1 03 44 PM" src="https://user-images.githubusercontent.com/5789411/80011359-c51b8800-8499-11ea-8f92-70050073472e.png">

Muli: https://mayflower.digital.mass.gov/patternlab/b/all/DP-17833-replace-texta-muli/?p=pages-detail-for-service-howto-location
Monserrat: https://mayflower.digital.mass.gov/patternlab/b/all/DP-17833-replace-texta-monserrat/?p=pages-detail-for-service-howto-location
Noto Sans: https://mayflower.digital.mass.gov/patternlab/b/all/DP-17833-replace-texta-noto/?p=pages-detail-for-service-howto-location
Raleway: https://mayflower.digital.mass.gov/patternlab/b/all/DP-17833-replace-texta-raleway/?p=pages-detail-for-service-howto-location
Public Sans: https://mayflower.digital.mass.gov/patternlab/b/all/DP-17833-replace-texta-publicsans/?p=pages-detail-for-service-howto-location