### PR TITLE
Revert "add fonts for vietnamese"

### DIFF
--- a/assets/scss/00-base/_fonts-fallback.scss
+++ b/assets/scss/00-base/_fonts-fallback.scss
@@ -6,5 +6,3 @@
 @import url('https://fonts.googleapis.com/css?family=Source+Code+Pro');
 
 @import url('https://fonts.googleapis.com/css2?family=Hanuman');
-
-@import url('https://fonts.googleapis.com/css2?family=Muli:ital,wght@0,300;0,400;0,500;0,600;0,700;0,800;1,300;1,400;1,500;1,600;1,700;1,800&display=swap');

--- a/assets/scss/00-base/_variables.scss
+++ b/assets/scss/00-base/_variables.scss
@@ -38,7 +38,6 @@ $close-icon: '\00d7';
 $fonts:      "Texta", "Helvetica", "Arial", sans-serif;
 $fonts-mono: "Source Code Pro", "Monaco", monospace;
 $fonts-khmer: "Hanuman";
-$fonts-vietnamese: "Muli";
 
 
 // font weights

--- a/assets/scss/01-atoms/global/_elements.scss
+++ b/assets/scss/01-atoms/global/_elements.scss
@@ -23,12 +23,6 @@ html {
 
   &:lang(km) {
     font-family: $fonts-khmer, $fonts;
-    font-size: 14px;
-  }
-
-  &:lang(vi) {
-    font-family: $fonts-vietnamese, sans-serif;
-    font-size: 14px;
   }
 
   font-size: 14.5px;


### PR DESCRIPTION
Reverts massgov/mayflower#1068.

It looks like Drupal CSS aggregation is having issues with this font. Rolling back until we can implement a fix.