### PR TITLE
Use node for HelperText message property

### DIFF
--- a/changelogs/helpertext_proptype.yml
+++ b/changelogs/helpertext_proptype.yml
@@ -1,0 +1,7 @@
+Changed:
+  - project: React
+    component: HelperText
+    description: Use node instead of string for `message` proptype
+    issue:
+    impact: Minor
+

--- a/changelogs/helpertext_proptype.yml
+++ b/changelogs/helpertext_proptype.yml
@@ -3,5 +3,4 @@ Changed:
     component: HelperText
     description: Use node instead of string for `message` proptype
     issue:
-    impact: Minor
-
+    impact: Patch

--- a/react/src/components/forms/HelperText/index.js
+++ b/react/src/components/forms/HelperText/index.js
@@ -16,7 +16,7 @@ HelperText.propTypes = {
   /** The ID of the corresponding input field */
   inputId: PropTypes.string.isRequired,
   /** The help text for the corresponding input field */
-  message: PropTypes.string.isRequired
+  message: PropTypes.node.isRequired
 };
 
 export default HelperText;


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/develop/docs/for-developers/changelog-instructions.md)


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
The HelperText component is specifying its `message` property as a string.  In reality, it accepts anything renderable by React in there, which includes strings, React nodes, etc. This PR just converts the propType to `node`, which is defined as:
> Anything that can be rendered: numbers, strings, elements or an array (or fragment) containing these types.

This avoids a propType warning where there doesn't really need to be one. 

## Related Issue / Ticket

- [JIRA issue]()
- [Github issue]()

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1.

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

*

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
