### PR TITLE
DP-19085 google map

### DIFF
--- a/changelogs/DP-19085.yml
+++ b/changelogs/DP-19085.yml
@@ -1,0 +1,6 @@
+Changed:
+  - project: Mayflower
+    component: GoogleMap
+    description: Modify google-map.twig to print googleMap.link.info value and set it visualy hidden as context info for screen reader users. (#1089)
+    issue: DP-19085
+    impact: Patch

--- a/patternlab/styleguide/source/_patterns/02-molecules/google-map.twig
+++ b/patternlab/styleguide/source/_patterns/02-molecules/google-map.twig
@@ -7,11 +7,11 @@
   {# for static maps #}
   {% if googleMap.static %}
   <div class="ma__google-map__map static-image">
-    <a href="{{ googleMap.link.href }}" title="Get Directions">
+    <a href="{{ googleMap.link.href }}">
       {% set picture = googleMap.picture %}
       {% include "@atoms/09-media/picture-element.twig" %}
       <div class="ma__google-maps__directions-link">
-        <span>Get Directions&nbsp;{{ icon('arrow') }}</span>
+        <span>Get Directions<span class="ma__visually-hidden"> to {{ googleMap.link.info }}</span>&nbsp;{{ icon('arrow') }}</span>
       </div>
     </a>
   </div>

--- a/patternlab/styleguide/source/_patterns/02-molecules/google-map.twig
+++ b/patternlab/styleguide/source/_patterns/02-molecules/google-map.twig
@@ -2,8 +2,7 @@
 {% set  maxItems = maxItems ? maxItems : googleMap.markers|length %}
 <div
   class="ma__google-map"
-  aria-hidden="true"
-  role="presentation">
+  {{ googleMap.static ? "" : 'aria-hidden="true" role="presentation"' }}>
   {# for static maps #}
   {% if googleMap.static %}
   <div class="ma__google-map__map static-image">

--- a/patternlab/styleguide/source/_patterns/02-molecules/google-map~static-image.json
+++ b/patternlab/styleguide/source/_patterns/02-molecules/google-map~static-image.json
@@ -4,7 +4,7 @@
     "link": {
       "href": "https://www.google.com/maps/place/251+Causeway+St+Boston+MA+02114",
       "text": "Get Directions",
-      "info": "Get Directions"
+      "info": "Department of Conservation and Recreation"
     },
     "picture": {
       "defaultImage": "https://maps.googleapis.com/maps/api/staticmap?center=42.366565,-71.05894&zoom=16&size=400x400&markers=label:A%7C42.366565,-71.05894&markers=label:B%7C42.358795,-71.063858&client=gme-commonwealthofmassachusetts&channel=massgov&signature=NtPVeSVJQHMeHEnnJaBxQGz8WHw",

--- a/patternlab/styleguide/source/_patterns/05-pages/location-general-content.json
+++ b/patternlab/styleguide/source/_patterns/05-pages/location-general-content.json
@@ -117,7 +117,7 @@
       "link": {
         "href": "https://www.google.com/maps/place/251+Causeway+St+Boston+MA+02114",
         "text": "See a larger map",
-        "info": "Get Directions"
+        "info": "Mt Greylock State Park"
       },
       "picture": {
         "defaultImage": "https://maps.googleapis.com/maps/api/staticmap?center=42.366565,-71.05894&zoom=16&size=600x400&markers=label:A%7C42.366565,-71.05894&markers=label:B%7C42.358795,-71.063858&client=gme-commonwealthofmassachusetts&channel=massgov&signature=ZfVgzAGuHDGCUTdazkS3WBiiOWY",

--- a/patternlab/styleguide/source/_patterns/05-pages/location-park-content.json
+++ b/patternlab/styleguide/source/_patterns/05-pages/location-park-content.json
@@ -137,7 +137,7 @@
       "link": {
         "href": "https://www.google.com/maps/place/251+Causeway+St+Boston+MA+02114",
         "text": "Get Directions",
-        "info": "Get Directions"
+        "info": "Mt Greylock State Park"
       },
       "picture": {
         "defaultImage": "https://maps.googleapis.com/maps/api/staticmap?center=42.366565,-71.05894&zoom=16&size=400x400&markers=label:A%7C42.366565,-71.05894&markers=label:B%7C42.358795,-71.063858&client=gme-commonwealthofmassachusetts&channel=massgov&signature=NtPVeSVJQHMeHEnnJaBxQGz8WHw",


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/develop/docs/for-developers/changelog-instructions.md)


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
**google-map.twig**
- Modify the template to print `googleMap.static.link.info`.
- Set the data visually hidden for screen reader users only use.
- Remove `title` attribute which is not necessary in this context from the link.
- Add a condition to remove `aria-hidden` and `role` attributes when it's statc.

**patternlab/styleguide/source/_patterns/02-molecules/google-map~static-image.json**
**patternlab/styleguide/source/_patterns/05-pages/location-general-content.json**
**patternlab/styleguide/source/_patterns/05-pages/location-park-content.json**
- Adjust the json files to reflect the changes for google-map.twig.

## Related Issue / Ticket

- [JIRA issue](https://jira.mass.gov/browse/DP-19085)
- [Github issue](https://github.com/massgov/openmass/pull/372)

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Go to **/patterns/02-molecules-google-map-static-image/02-molecules-google-map-static-image.html**, and check the source of the template to see:
       - no `aria-hidden` and `role` attributes on `div.ma__google-map` (enable screen readers to recognize the component)
       - no `title` attribute in `a`
       - `span.ma__visually-hidden` with its content of "to a location name" after the "Get Directions" in the `span`
```
<div class="ma__google-map">
  <div class="ma__google-map__map static-image">
    <a href="https://www.google.com/maps/place/251+Causeway+St+Boston+MA+02114">
      <picture class="ma__picture">
      ...
      </picture>
      <div class="ma__google-maps__directions-link">
        <span>Get Directions
          <span class="ma__visually-hidden"> to Department of Conservation and Recreation</span>
          &nbsp;<svg aria-hidden="true" focusable="false">...
        </span>
      </div>
    </a>
  </div>
</div>
```

2. Go to **/patterns/02-molecules-google-map/02-molecules-google-map.html**, and check the source of the template to see:
       - `div.ma__google-map` has `aria-hidden` and `role` attributes (make screen readers to ignore the component)
```
<div class="ma__google-map" aria-hidden="true" role="presentation">
```

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

*

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
