### PR TITLE
Assets integration: Fix React ES6 Exports

### DIFF
--- a/react/gulpfile.js
+++ b/react/gulpfile.js
@@ -68,6 +68,31 @@ function resolvePath(sourcePath, currentFile, opts) {
     if (check.test(sourcePath)) {
       const matches = check.exec(sourcePath);
       resolvedPath = `${rootPath}${matches[1]}`;
+      // ES Modules need to list out the extension on the end of the path,
+      // otherwise index.js will be used instead of index.mjs.
+      if (opts.hasOwnProperty('isES5') && opts.isES5 === false) {
+        // List of exports that are files and not directories.
+        const excludes = [
+          'Input/error',
+          'Input/context',
+          'Input/utility',
+          'Input/validate',
+          'TabContainer/tab',
+          'TabContainer/tab-body',
+          'TabContainer/context',
+          'utilities/componentPropTypeCheck',
+          'Breadcrumb/item',
+          'GenTeaser/utils'
+        ];
+        // If the current path is a file and not a directory...
+        if (excludes.some((rule) => sourcePath.includes(rule))) {
+          // Add the .mjs extension.
+          resolvedPath = `${resolvedPath}.mjs`;
+        } else {
+          // Else, add the path to the index.mjs file the ES module needs.
+          resolvedPath = `${resolvedPath}/index.mjs`;
+        }
+      }
     }
   });
   return resolvedPath || sourcePath;
@@ -112,7 +137,8 @@ function transpileES5() {
           'module-resolver',
           {
             resolvePath,
-            alias: aliases
+            alias: aliases,
+            isES5: true
           }
         ],
         '@babel/plugin-proposal-optional-chaining',
@@ -170,7 +196,8 @@ function transpileES6() {
           'module-resolver',
           {
             resolvePath,
-            alias: aliases
+            alias: aliases,
+            isES5: false
           }
         ],
         '@babel/plugin-proposal-optional-chaining',

--- a/react/gulpfile.js
+++ b/react/gulpfile.js
@@ -1,13 +1,11 @@
-import gulp from 'gulp';
-import babel from 'gulp-babel';
-import rename from 'gulp-rename';
-import del from 'del';
-import path from 'path';
-import { fileURLToPath } from 'url';
-
 const {
   src, dest, series, parallel
-} = gulp;
+} = require('gulp');
+const babel = require('gulp-babel');
+const rename = require('gulp-rename');
+const del = require('del');
+const path = require('path');
+
 function clean() {
   return del(['dist']);
 }
@@ -62,7 +60,7 @@ const sources = [
 ];
 
 function resolvePath(sourcePath, currentFile, opts) {
-  const entryPoint = path.resolve(path.dirname(fileURLToPath(import.meta.url)), './src/index.js');
+  const entryPoint = path.resolve(__dirname, './src/index.js');
   const rootPath = currentFile === entryPoint ? './' : '../';
   let resolvedPath = null;
   Object.keys(opts.alias).forEach((alias) => {
@@ -72,7 +70,7 @@ function resolvePath(sourcePath, currentFile, opts) {
       resolvedPath = `${rootPath}${matches[1]}`;
       // ES Modules need to list out the extension on the end of the path,
       // otherwise index.js will be used instead of index.mjs.
-      if (opts.hasOwnProperty('isES5') && opts.isES5 === true) {
+      if (opts.hasOwnProperty('isES5') && opts.isES5 === false) {
         // List of exports that are files and not directories.
         const excludes = [
           'Input/error',
@@ -89,10 +87,10 @@ function resolvePath(sourcePath, currentFile, opts) {
         // If the current path is a file and not a directory...
         if (excludes.some((rule) => sourcePath.includes(rule))) {
           // Add the .mjs extension.
-          resolvedPath = `${resolvedPath}.cjs`;
+          resolvedPath = `${resolvedPath}.mjs`;
         } else {
           // Else, add the path to the index.mjs file the ES module needs.
-          resolvedPath = `${resolvedPath}/index.cjs`;
+          resolvedPath = `${resolvedPath}/index.mjs`;
         }
       }
     }
@@ -102,7 +100,11 @@ function resolvePath(sourcePath, currentFile, opts) {
 
 function transpileES5() {
   return src(sources)
-    
+    .pipe(rename((p) => {
+      const splitPath = p.dirname.split('/');
+      // eslint-disable-next-line no-param-reassign
+      p.dirname = splitPath[splitPath.length - 1];
+    }))
     .pipe(babel({
       presets: [
         [
@@ -158,22 +160,10 @@ function transpileES5() {
         'babel-plugin-add-module-exports'
       ]
     }))
-    .pipe(rename((p) => {
-      const splitPath = p.dirname.split('/');
-      // eslint-disable-next-line no-param-reassign
-      p.dirname = splitPath[splitPath.length - 1];
-      // eslint-disable-next-line no-param-reassign
-      p.extname = '.cjs';
-    }))
     .pipe(dest('dist'));
 }
 function transpileES6() {
   return src(sources)
-  .pipe(rename((p) => {
-    const splitPath = p.dirname.split('/');
-    // eslint-disable-next-line no-param-reassign
-    p.dirname = splitPath[splitPath.length - 1];
-  }))
     .pipe(babel({
       presets: [
         [
@@ -228,7 +218,13 @@ function transpileES6() {
         ]
       ]
     }))
-    
+    .pipe(rename((p) => {
+      const splitPath = p.dirname.split('/');
+      // eslint-disable-next-line no-param-reassign
+      p.dirname = splitPath[splitPath.length - 1];
+      // eslint-disable-next-line no-param-reassign
+      p.extname = '.mjs';
+    }))
     .pipe(dest('dist'));
 }
-export default series(clean, parallel(transpileES5, transpileES6, styles, icons));
+exports.default = series(clean, parallel(transpileES5, transpileES6, styles, icons));

--- a/react/package.json
+++ b/react/package.json
@@ -3,9 +3,8 @@
   "description": "React versions of Mayflower design system UI components",
   "author": "Massachusetts Digital Services (MDS)",
   "version": "10.0.0",
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
-  "type": "module",
+  "main": "./dist/index.mjs",
+  "module": "./dist/index.mjs",
   "sideEffects": [
     "**/*.css",
     "**/*.scss"
@@ -14,9 +13,9 @@
     "dist"
   ],
   "exports": {
-    "import": "./dist/index.js",
-    "require": "./dist/index.cjs",
-    "default": "./dist/index.js"
+    "import": "./dist/index.mjs",
+    "require": "./dist/index.js",
+    "default": "./dist/index.mjs"
   },
   "scripts": {
     "backstop:test": "docker-compose run backstop test --rm",

--- a/react/package.json
+++ b/react/package.json
@@ -3,8 +3,8 @@
   "description": "React versions of Mayflower design system UI components",
   "author": "Massachusetts Digital Services (MDS)",
   "version": "10.0.0",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "main": "./dist/index.mjs",
+  "module": "./dist/index.mjs",
   "sideEffects": [
     "**/*.css",
     "**/*.scss"
@@ -13,6 +13,7 @@
     "dist"
   ],
   "exports": {
+    "import": "./dist/index.mjs",
     "require": "./dist/index.js",
     "default": "./dist/index.mjs"
   },

--- a/react/package.json
+++ b/react/package.json
@@ -3,8 +3,9 @@
   "description": "React versions of Mayflower design system UI components",
   "author": "Massachusetts Digital Services (MDS)",
   "version": "10.0.0",
-  "main": "./dist/index.mjs",
-  "module": "./dist/index.mjs",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "type": "module",
   "sideEffects": [
     "**/*.css",
     "**/*.scss"
@@ -13,9 +14,9 @@
     "dist"
   ],
   "exports": {
-    "import": "./dist/index.mjs",
-    "require": "./dist/index.js",
-    "default": "./dist/index.mjs"
+    "import": "./dist/index.js",
+    "require": "./dist/index.cjs",
+    "default": "./dist/index.js"
   },
   "scripts": {
     "backstop:test": "docker-compose run backstop test --rm",

--- a/react/src/components/forms/Form/index.js
+++ b/react/src/components/forms/Form/index.js
@@ -6,7 +6,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormContext } from '../Input/context';
+import { FormContext } from 'MayflowerReactForms/Input/context';
 
 /* eslint-disable react/no-unused-state */
 

--- a/react/src/components/forms/Input/error.js
+++ b/react/src/components/forms/Input/error.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ErrorMessage from 'MayflowerReactForms/ErrorMessage';
-import { InputContext } from './context';
+import { InputContext } from 'MayflowerReactForms/Input/context';
 
 class Error extends React.Component {
   displayErrorMessage = (inputContext) => {

--- a/react/src/components/forms/Input/index.js
+++ b/react/src/components/forms/Input/index.js
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import Label from 'MayflowerReactForms/Label';
-import { InputContext, FormContext } from './context';
+import { InputContext, FormContext } from 'MayflowerReactForms/Input/context';
 
 /* eslint-disable react/no-unused-state */
 

--- a/react/src/components/organisms/GenTeaser/index.js
+++ b/react/src/components/organisms/GenTeaser/index.js
@@ -30,7 +30,7 @@ import PhoneNumber from 'MayflowerReactContact/PhoneNumber';
 import Address from 'MayflowerReactContact/Address';
 import TeaserSearch from 'MayflowerReactGenTeaser/TeaserSearch';
 import TeaserOrgs from 'MayflowerReactGenTeaser/TeaserOrgs';
-import { buildUrl } from './utils';
+import { buildUrl } from 'MayflowerReactOrganisms/GenTeaser/utils';
 
 const GenTeaser = (props) => {
   const {


### PR DESCRIPTION
This updates the ES6 exports to use the full extension in their import/export paths so that importing a component doesn't fall back to the commonjs index.js file. Instead, the ES6 paths should be using the component's index.mjs file.