### PR TITLE
Removes logo import from SiteLogo component.

### DIFF
--- a/react/src/components/atoms/media/SiteLogo/index.js
+++ b/react/src/components/atoms/media/SiteLogo/index.js
@@ -11,7 +11,7 @@ import Image from '../Image';
 const SiteLogo = (siteLogo) => (
   <div className="ma__site-logo">
     <a href={siteLogo.url.domain ? siteLogo.url.domain : '/'} title={siteLogo.title}>
-      <Image {...siteLogo.image} />
+      {siteLogo?.image?.src && <Image {...siteLogo.image} />}
       <span>{siteLogo.siteName}</span>
     </a>
   </div>

--- a/react/src/components/atoms/media/SiteLogo/index.js
+++ b/react/src/components/atoms/media/SiteLogo/index.js
@@ -6,7 +6,6 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import logo from '@massds/mayflower-assets/static/images/stateseal.png';
 import Image from '../Image';
 
 const SiteLogo = (siteLogo) => (
@@ -34,7 +33,6 @@ SiteLogo.defaultProps = {
     domain: '/'
   },
   image: {
-    src: logo,
     alt: '',
     width: 45,
     height: 45

--- a/react/src/components/organisms/Footer/Footer.stories.js
+++ b/react/src/components/organisms/Footer/Footer.stories.js
@@ -42,6 +42,9 @@ storiesOf('organisms/Footer', module)
         footerLinks: object('footerLinks', FooterLinksLiveData),
         showNavHeading: boolean('showNavHeading', false),
         socialLinks: object('socialLinks', SocialLinksLiveData),
+        footerLogo: {
+          src: text('footer.footerLogo.src', stateSeal)
+        },
         footerText: object('footerText', {
           copyright: '2018 Commonwealth of Massachusetts.',
           description: 'Mass.gov® is a registered service mark of the Commonwealth of Massachusetts.',

--- a/react/src/components/organisms/Footer/index.js
+++ b/react/src/components/organisms/Footer/index.js
@@ -12,7 +12,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 
-import logo from '@massds/mayflower-assets/static/images/stateseal.png';
 import FooterLinks from 'MayflowerReactMolecules/FooterLinks';
 import SocialLinks from 'MayflowerReactMolecules/SocialLinks';
 import Icon from 'MayflowerReactBase/Icon';
@@ -92,7 +91,6 @@ Footer.defaultProps = {
   backToTopButton: false,
   footerLogo: {
     domain: '/',
-    src: logo,
     title: 'Mass.gov homepage'
   },
   footerText: {

--- a/react/src/components/organisms/Header/index.js
+++ b/react/src/components/organisms/Header/index.js
@@ -18,7 +18,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import is from 'is';
 import classNames from 'classnames';
-import logo from '@massds/mayflower-assets/static/images/stateseal.png';
 import UtilityNav from 'MayflowerReactOrganisms/UtilityNav';
 import MainNav from 'MayflowerReactMolecules/MainNav';
 import HeaderSearch from 'MayflowerReactMolecules/HeaderSearch';
@@ -295,7 +294,6 @@ Header.defaultProps = {
       domain: 'https://www.mass.gov/'
     },
     image: {
-      src: logo,
       alt: 'Massachusetts state seal',
       width: 45,
       height: 45

--- a/react/src/components/organisms/Header/index.js
+++ b/react/src/components/organisms/Header/index.js
@@ -294,7 +294,6 @@ Header.defaultProps = {
       domain: 'https://www.mass.gov/'
     },
     image: {
-      alt: 'Massachusetts state seal',
       width: 45,
       height: 45
     },

--- a/react/src/components/templates/NarrowTemplate/NarrowTemplate.stories.js
+++ b/react/src/components/templates/NarrowTemplate/NarrowTemplate.stories.js
@@ -16,7 +16,8 @@ storiesOf('templates', module)
           domain: text('NarrowTemplate siteLogoDomain: url domain', 'https://www.mass.gov/')
         },
         image: {
-          src: logo
+          src: logo,
+          alt: 'Massachusetts state seal'
         }
       };
       const props = {

--- a/react/src/components/templates/NarrowTemplate/NarrowTemplate.stories.js
+++ b/react/src/components/templates/NarrowTemplate/NarrowTemplate.stories.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withKnobs, select, text } from '@storybook/addon-knobs';
+import logo from '@massds/mayflower-assets/static/images/stateseal.png';
 
 import NarrowTemplate from '.';
 import NarrowTemplateDocs from './NarrowTemplate.md';
@@ -13,6 +14,9 @@ storiesOf('templates', module)
       const siteLogoDomainProps = {
         url: {
           domain: text('NarrowTemplate siteLogoDomain: url domain', 'https://www.mass.gov/')
+        },
+        image: {
+          src: logo
         }
       };
       const props = {


### PR DESCRIPTION
Only NarrowTemplate is affected by this change. I added the logo back to NarrowTemplate's story.