### PR TITLE
use relative links to avoid error withouth sass include path

### DIFF
--- a/assets/scss/01-atoms/_address.scss
+++ b/assets/scss/01-atoms/_address.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__address {
 

--- a/assets/scss/01-atoms/_arrow-button.scss
+++ b/assets/scss/01-atoms/_arrow-button.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__arrow-button {
 

--- a/assets/scss/01-atoms/_button-search.scss
+++ b/assets/scss/01-atoms/_button-search.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 @mixin ma-button-search ($background-color, $color) {
   border: 2px solid;

--- a/assets/scss/01-atoms/_button-sort.scss
+++ b/assets/scss/01-atoms/_button-sort.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__button-sort {
 

--- a/assets/scss/01-atoms/_button-tag.scss
+++ b/assets/scss/01-atoms/_button-tag.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 @use "sass:color" as *;
 

--- a/assets/scss/01-atoms/_button-toggle.scss
+++ b/assets/scss/01-atoms/_button-toggle.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__button-toggle {
 

--- a/assets/scss/01-atoms/_button-with-icon.scss
+++ b/assets/scss/01-atoms/_button-with-icon.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 $colors: (
   "c-highlight": $c-highlight,

--- a/assets/scss/01-atoms/_buttons.scss
+++ b/assets/scss/01-atoms/_buttons.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 $primarycolors: (
   "c-primary-alt": $c-primary-alt,

--- a/assets/scss/01-atoms/_category-icon.scss
+++ b/assets/scss/01-atoms/_category-icon.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__category-icon {
 

--- a/assets/scss/01-atoms/_checklist.scss
+++ b/assets/scss/01-atoms/_checklist.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__checklist {
 

--- a/assets/scss/01-atoms/_colored-heading.scss
+++ b/assets/scss/01-atoms/_colored-heading.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__colored-heading {
 

--- a/assets/scss/01-atoms/_column-heading.scss
+++ b/assets/scss/01-atoms/_column-heading.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__column-heading {
 

--- a/assets/scss/01-atoms/_comp-heading.scss
+++ b/assets/scss/01-atoms/_comp-heading.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__comp-heading {
 

--- a/assets/scss/01-atoms/_content-link.scss
+++ b/assets/scss/01-atoms/_content-link.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__content-link {
 

--- a/assets/scss/01-atoms/_decorative-link.scss
+++ b/assets/scss/01-atoms/_decorative-link.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__decorative-link {
 

--- a/assets/scss/01-atoms/_divider.scss
+++ b/assets/scss/01-atoms/_divider.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__divider {
 

--- a/assets/scss/01-atoms/_email.scss
+++ b/assets/scss/01-atoms/_email.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__email {
 

--- a/assets/scss/01-atoms/_error-msg.scss
+++ b/assets/scss/01-atoms/_error-msg.scss
@@ -1,6 +1,6 @@
 // error message
 
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__error-msg {
   display: none;

--- a/assets/scss/01-atoms/_event-time.scss
+++ b/assets/scss/01-atoms/_event-time.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__event-time {
 

--- a/assets/scss/01-atoms/_figure.scss
+++ b/assets/scss/01-atoms/_figure.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__figure {
 

--- a/assets/scss/01-atoms/_fixed-feedback-button.scss
+++ b/assets/scss/01-atoms/_fixed-feedback-button.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__fixed-feedback-button {
   bottom: 0;

--- a/assets/scss/01-atoms/_footnote-link.scss
+++ b/assets/scss/01-atoms/_footnote-link.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__footnote-link {
 

--- a/assets/scss/01-atoms/_footnote.scss
+++ b/assets/scss/01-atoms/_footnote.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__footnote-item {
   transition: all 0.4s ease;

--- a/assets/scss/01-atoms/_forms.scss
+++ b/assets/scss/01-atoms/_forms.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 input {
 

--- a/assets/scss/01-atoms/_helper-text.scss
+++ b/assets/scss/01-atoms/_helper-text.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__helper-text {
   font-size: 1rem;

--- a/assets/scss/01-atoms/_icon-list.scss
+++ b/assets/scss/01-atoms/_icon-list.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__rich-text .ma__icon-list,
 .ma__icon-list {

--- a/assets/scss/01-atoms/_iframe.scss
+++ b/assets/scss/01-atoms/_iframe.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__iframe {
 

--- a/assets/scss/01-atoms/_image.scss
+++ b/assets/scss/01-atoms/_image.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__image {
 

--- a/assets/scss/01-atoms/_input--button.scss
+++ b/assets/scss/01-atoms/_input--button.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 @mixin ma__input--button($type) {
   .ma__input-#{$type} {

--- a/assets/scss/01-atoms/_input-checkbox.scss
+++ b/assets/scss/01-atoms/_input-checkbox.scss
@@ -1,6 +1,6 @@
 // Custom Checkboxes
 
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__input-checkbox {
   display: inline-block;

--- a/assets/scss/01-atoms/_input-date.scss
+++ b/assets/scss/01-atoms/_input-date.scss
@@ -1,6 +1,6 @@
 // Custom Date input
 
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__input-date[type=text] {
   background-image: url("#{$assets-path}/images/svg-icons/date-picker.svg");

--- a/assets/scss/01-atoms/_input-fuzzy.scss
+++ b/assets/scss/01-atoms/_input-fuzzy.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .react-autowhatever__container {
   position: relative;

--- a/assets/scss/01-atoms/_input-group.scss
+++ b/assets/scss/01-atoms/_input-group.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__input-group {
 

--- a/assets/scss/01-atoms/_input-number.scss
+++ b/assets/scss/01-atoms/_input-number.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__input-number {
   display: inline-block;

--- a/assets/scss/01-atoms/_input-radio.scss
+++ b/assets/scss/01-atoms/_input-radio.scss
@@ -1,6 +1,6 @@
 // Custom Radio Buttons
 
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__input-radio {
   display: inline-block;

--- a/assets/scss/01-atoms/_input-typeahead.scss
+++ b/assets/scss/01-atoms/_input-typeahead.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__input-typeahead {
   font-size: 1.25rem;

--- a/assets/scss/01-atoms/_label.scss
+++ b/assets/scss/01-atoms/_label.scss
@@ -1,6 +1,6 @@
 // Special label handling
 
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__legend,
 .ma__label {

--- a/assets/scss/01-atoms/_operational-hours.scss
+++ b/assets/scss/01-atoms/_operational-hours.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__operational-hours {
 

--- a/assets/scss/01-atoms/_page-title.scss
+++ b/assets/scss/01-atoms/_page-title.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__page-title {
   margin-bottom: .4em;

--- a/assets/scss/01-atoms/_phone-number.scss
+++ b/assets/scss/01-atoms/_phone-number.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__phone-number {
 

--- a/assets/scss/01-atoms/_publish-state.scss
+++ b/assets/scss/01-atoms/_publish-state.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__publish-state {
   font-size: 2rem;

--- a/assets/scss/01-atoms/_select-box.scss
+++ b/assets/scss/01-atoms/_select-box.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__select-box {
   display: inline-block;

--- a/assets/scss/01-atoms/_sidebar-heading.scss
+++ b/assets/scss/01-atoms/_sidebar-heading.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__sidebar-heading {
 

--- a/assets/scss/01-atoms/_site-logo.scss
+++ b/assets/scss/01-atoms/_site-logo.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__site-logo {
 

--- a/assets/scss/01-atoms/_svg-icons.scss
+++ b/assets/scss/01-atoms/_svg-icons.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .svg-alert {
   height: 48px;

--- a/assets/scss/01-atoms/_svg-loc-icons.scss
+++ b/assets/scss/01-atoms/_svg-loc-icons.scss
@@ -1,7 +1,7 @@
 // heights should all be 40px tall
 // add top padding to compensate
 
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .svg-loc-dogs-allowed {
   height: 35px;

--- a/assets/scss/01-atoms/_table-responsive.scss
+++ b/assets/scss/01-atoms/_table-responsive.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__table--responsive {
   position: relative;

--- a/assets/scss/01-atoms/_table.scss
+++ b/assets/scss/01-atoms/_table.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__rich-text table,
 .ma__table {

--- a/assets/scss/01-atoms/_textarea.scss
+++ b/assets/scss/01-atoms/_textarea.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__textarea {
 

--- a/assets/scss/01-atoms/_unordered-list.scss
+++ b/assets/scss/01-atoms/_unordered-list.scss
@@ -1,6 +1,6 @@
 // Override :last-child bottom margin.
 
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__horizontal-list:nth-child(n) {
     padding: 0;

--- a/assets/scss/01-atoms/_video.scss
+++ b/assets/scss/01-atoms/_video.scss
@@ -2,7 +2,7 @@
 
 @use "sass:meta";
 
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__video {
 

--- a/assets/scss/02-molecules/_accordion-item.scss
+++ b/assets/scss/02-molecules/_accordion-item.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__accordion {
 

--- a/assets/scss/02-molecules/_action-event.scss
+++ b/assets/scss/02-molecules/_action-event.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__action-event {
 

--- a/assets/scss/02-molecules/_action-gallery.scss
+++ b/assets/scss/02-molecules/_action-gallery.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__action-gallery {
 

--- a/assets/scss/02-molecules/_action-image.scss
+++ b/assets/scss/02-molecules/_action-image.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__action-image {
 

--- a/assets/scss/02-molecules/_action-step.scss
+++ b/assets/scss/02-molecules/_action-step.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__action-step {
   

--- a/assets/scss/02-molecules/_arrow-nav.scss
+++ b/assets/scss/02-molecules/_arrow-nav.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__arrow-nav {
   min-height: 45px;

--- a/assets/scss/02-molecules/_back-button.scss
+++ b/assets/scss/02-molecules/_back-button.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__back-button {
 

--- a/assets/scss/02-molecules/_banner-credit.scss
+++ b/assets/scss/02-molecules/_banner-credit.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__banner-credit {
   position: relative;

--- a/assets/scss/02-molecules/_breadcrumb.scss
+++ b/assets/scss/02-molecules/_breadcrumb.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__breadcrumb {
   display: block;

--- a/assets/scss/02-molecules/_button-alert.scss
+++ b/assets/scss/02-molecules/_button-alert.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__button-alert {
 

--- a/assets/scss/02-molecules/_callout-link.scss
+++ b/assets/scss/02-molecules/_callout-link.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 @use "sass:color" as *;
 

--- a/assets/scss/02-molecules/_callout-stats.scss
+++ b/assets/scss/02-molecules/_callout-stats.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__callout-stats {
   margin-bottom: 1em;

--- a/assets/scss/02-molecules/_campaign-feature-2up.scss
+++ b/assets/scss/02-molecules/_campaign-feature-2up.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__campaign-feature-2up {
 

--- a/assets/scss/02-molecules/_card.scss
+++ b/assets/scss/02-molecules/_card.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__card {
   background-color: $c-gray-light;  

--- a/assets/scss/02-molecules/_collapsible-header.scss
+++ b/assets/scss/02-molecules/_collapsible-header.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__collapsible-header {
   

--- a/assets/scss/02-molecules/_contact-group.scss
+++ b/assets/scss/02-molecules/_contact-group.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__contact-group {
 

--- a/assets/scss/02-molecules/_contact-us.scss
+++ b/assets/scss/02-molecules/_contact-us.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__contact-us {
 

--- a/assets/scss/02-molecules/_date-range.scss
+++ b/assets/scss/02-molecules/_date-range.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__date-range {
 

--- a/assets/scss/02-molecules/_divided-inputs.scss
+++ b/assets/scss/02-molecules/_divided-inputs.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__divided-inputs {
 

--- a/assets/scss/02-molecules/_download-link.scss
+++ b/assets/scss/02-molecules/_download-link.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__download-link {
 

--- a/assets/scss/02-molecules/_emergency-alert.scss
+++ b/assets/scss/02-molecules/_emergency-alert.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 @use "sass:color" as *;
 

--- a/assets/scss/02-molecules/_emergency-header.scss
+++ b/assets/scss/02-molecules/_emergency-header.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__emergency-header {
 

--- a/assets/scss/02-molecules/_error-list.scss
+++ b/assets/scss/02-molecules/_error-list.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 @use "sass:color" as *;
 

--- a/assets/scss/02-molecules/_event-filters.scss
+++ b/assets/scss/02-molecules/_event-filters.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__event-filters {
   padding-top: 30px;

--- a/assets/scss/02-molecules/_event-teaser.scss
+++ b/assets/scss/02-molecules/_event-teaser.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 @use "sass:color" as *;
 

--- a/assets/scss/02-molecules/_featured-item.scss
+++ b/assets/scss/02-molecules/_featured-item.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__featured-item {
 

--- a/assets/scss/02-molecules/_field-submit.scss
+++ b/assets/scss/02-molecules/_field-submit.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__field-submit {
   border: none;

--- a/assets/scss/02-molecules/_floating-action.scss
+++ b/assets/scss/02-molecules/_floating-action.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__floating-action {
   position: fixed;

--- a/assets/scss/02-molecules/_footer-links.scss
+++ b/assets/scss/02-molecules/_footer-links.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__footer-links {
 

--- a/assets/scss/02-molecules/_footnote.scss
+++ b/assets/scss/02-molecules/_footnote.scss
@@ -1,6 +1,6 @@
 // toggle JS to adjust for mobile elements, like the header, sticky-nav, jump-links.
 
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .js-footnote {
   

--- a/assets/scss/02-molecules/_general-teaser.scss
+++ b/assets/scss/02-molecules/_general-teaser.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__general-teaser {
 

--- a/assets/scss/02-molecules/_google-map.scss
+++ b/assets/scss/02-molecules/_google-map.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__google-map {
 

--- a/assets/scss/02-molecules/_header-contact.scss
+++ b/assets/scss/02-molecules/_header-contact.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__header-contact {
 

--- a/assets/scss/02-molecules/_header-search.scss
+++ b/assets/scss/02-molecules/_header-search.scss
@@ -1,7 +1,7 @@
 $header-search-height: 46px;
 $bp-header-search-reduce-button: "max-width: 700px";
 
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__header-search {
   display: inline-block;

--- a/assets/scss/02-molecules/_header-tags.scss
+++ b/assets/scss/02-molecules/_header-tags.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__header-tags {
   font-size: 16px;

--- a/assets/scss/02-molecules/_icon-link.scss
+++ b/assets/scss/02-molecules/_icon-link.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__icon-link {
   position: relative;

--- a/assets/scss/02-molecules/_icon-links.scss
+++ b/assets/scss/02-molecules/_icon-links.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__icon-links {
 

--- a/assets/scss/02-molecules/_illustrated-link.scss
+++ b/assets/scss/02-molecules/_illustrated-link.scss
@@ -1,6 +1,6 @@
 $illustrated-link-image-width: 130px;
 
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 @use "sass:color" as *;
 

--- a/assets/scss/02-molecules/_image-link.scss
+++ b/assets/scss/02-molecules/_image-link.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__image-link {
     display: flex;

--- a/assets/scss/02-molecules/_image-promo.scss
+++ b/assets/scss/02-molecules/_image-promo.scss
@@ -1,6 +1,6 @@
 $image-promo-bp-x-large-min: "min-width: 1160px";
 
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__image-promo {
 

--- a/assets/scss/02-molecules/_info-window.scss
+++ b/assets/scss/02-molecules/_info-window.scss
@@ -1,7 +1,7 @@
 // // use in the Action Map component info window
 // // Handle bar template
 
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__info-window {
   font-size: 1.25rem;

--- a/assets/scss/02-molecules/_input-radio-group.scss
+++ b/assets/scss/02-molecules/_input-radio-group.scss
@@ -1,7 +1,7 @@
 $margin: 5px;
 $total-margin: $margin * 2;
 
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 @mixin group-responsive-custom($bp, $col) {
 

--- a/assets/scss/02-molecules/_keyword-search.scss
+++ b/assets/scss/02-molecules/_keyword-search.scss
@@ -1,6 +1,6 @@
 $header-search-height: 46px;
 
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__keyword-search {
   display: inline-block;

--- a/assets/scss/02-molecules/_labelled-list.scss
+++ b/assets/scss/02-molecules/_labelled-list.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__labelled-list {
   margin-top: 1.875rem !important;

--- a/assets/scss/02-molecules/_link-dropdown.scss
+++ b/assets/scss/02-molecules/_link-dropdown.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__link-dropdown {
 

--- a/assets/scss/02-molecules/_listing-table.scss
+++ b/assets/scss/02-molecules/_listing-table.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__listing-table {
 

--- a/assets/scss/02-molecules/_location-filters.scss
+++ b/assets/scss/02-molecules/_location-filters.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__location-filters {
   padding-top: 30px;

--- a/assets/scss/02-molecules/_location-icons.scss
+++ b/assets/scss/02-molecules/_location-icons.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__location-icons {
   margin-bottom: -30px;

--- a/assets/scss/02-molecules/_main-nav.scss
+++ b/assets/scss/02-molecules/_main-nav.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__main-nav {
 

--- a/assets/scss/02-molecules/_multiselect-dropdown.scss
+++ b/assets/scss/02-molecules/_multiselect-dropdown.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__multiselect-dropdown {
 

--- a/assets/scss/02-molecules/_org-info.scss
+++ b/assets/scss/02-molecules/_org-info.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__org-info {
 

--- a/assets/scss/02-molecules/_org-selector.scss
+++ b/assets/scss/02-molecules/_org-selector.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__org-selector {
 

--- a/assets/scss/02-molecules/_page-intro.scss
+++ b/assets/scss/02-molecules/_page-intro.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__page-intro {
 

--- a/assets/scss/02-molecules/_pagination.scss
+++ b/assets/scss/02-molecules/_pagination.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__pagination {
 

--- a/assets/scss/02-molecules/_press-status.scss
+++ b/assets/scss/02-molecules/_press-status.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__press-status {
   padding: 30px;

--- a/assets/scss/02-molecules/_press-teaser.scss
+++ b/assets/scss/02-molecules/_press-teaser.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__press-teaser {
 

--- a/assets/scss/02-molecules/_radio-scale.scss
+++ b/assets/scss/02-molecules/_radio-scale.scss
@@ -2,7 +2,7 @@
 //
 // Custom radio set that displays the otions in a block'd scale.
 
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__radio-scale {
 

--- a/assets/scss/02-molecules/_related-action.scss
+++ b/assets/scss/02-molecules/_related-action.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .paragraph--type--related-link, // mass gov drupal instance
 .ma__related-action {

--- a/assets/scss/02-molecules/_relationship-indicators.scss
+++ b/assets/scss/02-molecules/_relationship-indicators.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__relationship-indicators {
 

--- a/assets/scss/02-molecules/_results-heading.scss
+++ b/assets/scss/02-molecules/_results-heading.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__results-heading {
 

--- a/assets/scss/02-molecules/_section-links.scss
+++ b/assets/scss/02-molecules/_section-links.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__section-links {
   position: relative;

--- a/assets/scss/02-molecules/_social-links.scss
+++ b/assets/scss/02-molecules/_social-links.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__social-links {
 

--- a/assets/scss/02-molecules/_sort-results.scss
+++ b/assets/scss/02-molecules/_sort-results.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__sort-results {
   font-size: 0;

--- a/assets/scss/02-molecules/_sticky-nav.scss
+++ b/assets/scss/02-molecules/_sticky-nav.scss
@@ -2,7 +2,7 @@
 // $column: 85px;
 // $gutter: 20px;
 
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__sticky-nav {
 

--- a/assets/scss/02-molecules/_tabs.scss
+++ b/assets/scss/02-molecules/_tabs.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__tabs {
   overflow: auto;

--- a/assets/scss/02-molecules/_tags.scss
+++ b/assets/scss/02-molecules/_tags.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__tags {
   margin-bottom: 10px;

--- a/assets/scss/02-molecules/_tooltip-popup.scss
+++ b/assets/scss/02-molecules/_tooltip-popup.scss
@@ -14,7 +14,7 @@ $font: Helvetica, sans-serif;
 $dropdown-background-color: $background-color;
 $dropdown-border-color: $border-color;
 
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 // "top", "bottom", "left", "right"
 

--- a/assets/scss/02-molecules/_tooltip.scss
+++ b/assets/scss/02-molecules/_tooltip.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 @use "sass:color" as *;
 

--- a/assets/scss/02-molecules/_wait-time.scss
+++ b/assets/scss/02-molecules/_wait-time.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__wait-time {
 

--- a/assets/scss/03-organisms/_about-section.scss
+++ b/assets/scss/03-organisms/_about-section.scss
@@ -1,7 +1,7 @@
 
 //theme
 
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__about-section {
 

--- a/assets/scss/03-organisms/_accordion-wrapper.scss
+++ b/assets/scss/03-organisms/_accordion-wrapper.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__accordion-wrapper {
 

--- a/assets/scss/03-organisms/_action-card.scss
+++ b/assets/scss/03-organisms/_action-card.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__action-card {
 

--- a/assets/scss/03-organisms/_action-details.scss
+++ b/assets/scss/03-organisms/_action-details.scss
@@ -2,7 +2,7 @@
 // $column: 85px;
 // $gutter: 20px;
 
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__action-details {
 

--- a/assets/scss/03-organisms/_action-finder.scss
+++ b/assets/scss/03-organisms/_action-finder.scss
@@ -1,6 +1,6 @@
 $action-finder-bp: 900px;
 
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 @use "sass:color" as *;
 

--- a/assets/scss/03-organisms/_ajax-pattern.scss
+++ b/assets/scss/03-organisms/_ajax-pattern.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__ajax-pattern {
   margin: 0;

--- a/assets/scss/03-organisms/_banner-carousel.scss
+++ b/assets/scss/03-organisms/_banner-carousel.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__banner-carousel {
   margin-bottom: 45px;

--- a/assets/scss/03-organisms/_blog-feed.scss
+++ b/assets/scss/03-organisms/_blog-feed.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__blog-feed {
 

--- a/assets/scss/03-organisms/_breadcrumbs.scss
+++ b/assets/scss/03-organisms/_breadcrumbs.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__breadcrumbs {
 

--- a/assets/scss/03-organisms/_callout-alert.scss
+++ b/assets/scss/03-organisms/_callout-alert.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 @use "sass:color" as *;
 

--- a/assets/scss/03-organisms/_callout-message.scss
+++ b/assets/scss/03-organisms/_callout-message.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 @use "sass:color" as *;
 

--- a/assets/scss/03-organisms/_callout-time.scss
+++ b/assets/scss/03-organisms/_callout-time.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__callout-time {
   position: relative;

--- a/assets/scss/03-organisms/_callout.scss
+++ b/assets/scss/03-organisms/_callout.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__callout {
   border-left: 2px solid;

--- a/assets/scss/03-organisms/_campaign-feature.scss
+++ b/assets/scss/03-organisms/_campaign-feature.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__campaign-feature {
 

--- a/assets/scss/03-organisms/_campaign-video.scss
+++ b/assets/scss/03-organisms/_campaign-video.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 $colors: (
   "c-primary": $c-primary,

--- a/assets/scss/03-organisms/_change-log.scss
+++ b/assets/scss/03-organisms/_change-log.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__change-log {
 

--- a/assets/scss/03-organisms/_collage-header.scss
+++ b/assets/scss/03-organisms/_collage-header.scss
@@ -1,6 +1,6 @@
 $collage-header-bp-min: "min-width: 701px";
 
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__collage-header {
   overflow: hidden;

--- a/assets/scss/03-organisms/_collapsible-content.scss
+++ b/assets/scss/03-organisms/_collapsible-content.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__collapsible-content {
 

--- a/assets/scss/03-organisms/_contact-list.scss
+++ b/assets/scss/03-organisms/_contact-list.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__contact-list {
 

--- a/assets/scss/03-organisms/_contact-row.scss
+++ b/assets/scss/03-organisms/_contact-row.scss
@@ -1,7 +1,7 @@
 //Custom breakpoint for contact row
 $accordion-break: 720px;
 
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__contact-row {
   position: relative;

--- a/assets/scss/03-organisms/_content-eyebrow.scss
+++ b/assets/scss/03-organisms/_content-eyebrow.scss
@@ -1,5 +1,5 @@
 
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__content-eyebrow {
 

--- a/assets/scss/03-organisms/_curated-person.scss
+++ b/assets/scss/03-organisms/_curated-person.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__curated-person {
 

--- a/assets/scss/03-organisms/_descriptive-links.scss
+++ b/assets/scss/03-organisms/_descriptive-links.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__descriptive-links {
 

--- a/assets/scss/03-organisms/_emergency-alerts.scss
+++ b/assets/scss/03-organisms/_emergency-alerts.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 @use "sass:color" as *;
 

--- a/assets/scss/03-organisms/_error-page.scss
+++ b/assets/scss/03-organisms/_error-page.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__error-page {
   margin-bottom: 40px;

--- a/assets/scss/03-organisms/_event-listing-interactive.scss
+++ b/assets/scss/03-organisms/_event-listing-interactive.scss
@@ -1,5 +1,5 @@
 
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__event-listing-interactive {
   position: relative;

--- a/assets/scss/03-organisms/_event-listing.scss
+++ b/assets/scss/03-organisms/_event-listing.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 $event-listing-bp-show-grid: $bp-medium-min;
 

--- a/assets/scss/03-organisms/_featured-item-mosaic.scss
+++ b/assets/scss/03-organisms/_featured-item-mosaic.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__featured-item-mosaic {
 

--- a/assets/scss/03-organisms/_feedback-form.scss
+++ b/assets/scss/03-organisms/_feedback-form.scss
@@ -2,7 +2,7 @@ $feedback-form-spacing: 50px;
 $feedback-form-spacing-mobile: 20px;
 $feedback-form-bp-min: "min-width: 751px";
 
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__feedback-form {
   background-size: cover;

--- a/assets/scss/03-organisms/_footer-slim.scss
+++ b/assets/scss/03-organisms/_footer-slim.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__footer_slim {
   background-color: $c-platinum-gray;

--- a/assets/scss/03-organisms/_footer.scss
+++ b/assets/scss/03-organisms/_footer.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__footer {
   padding: 20px 0 30px;

--- a/assets/scss/03-organisms/_footnote-list.scss
+++ b/assets/scss/03-organisms/_footnote-list.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__footnote-list {
 

--- a/assets/scss/03-organisms/_form-downloads.scss
+++ b/assets/scss/03-organisms/_form-downloads.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__form-downloads {
 

--- a/assets/scss/03-organisms/_form-requirements.scss
+++ b/assets/scss/03-organisms/_form-requirements.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__form-requirements {
   position: relative;

--- a/assets/scss/03-organisms/_gen-teaser.scss
+++ b/assets/scss/03-organisms/_gen-teaser.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__gen-teaser {
 

--- a/assets/scss/03-organisms/_header-alert.scss
+++ b/assets/scss/03-organisms/_header-alert.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__header-alert {
   display: none;

--- a/assets/scss/03-organisms/_header-slim.scss
+++ b/assets/scss/03-organisms/_header-slim.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__header_slim {
 

--- a/assets/scss/03-organisms/_header.scss
+++ b/assets/scss/03-organisms/_header.scss
@@ -2,7 +2,7 @@ $header-mobile-menu-width: 300px;
 $header-logo-width: 150px;
 $bp-header-logo-min: "min-width: 1000px";
 
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 @use "sass:color" as *;
 

--- a/assets/scss/03-organisms/_help-tip.scss
+++ b/assets/scss/03-organisms/_help-tip.scss
@@ -2,7 +2,7 @@ $spacing: 1rem;
 $border-radius: 4px;
 $border-width: 1px;
 
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 @use "sass:color" as *;
 

--- a/assets/scss/03-organisms/_helpful-links.scss
+++ b/assets/scss/03-organisms/_helpful-links.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__helpful-links {
 

--- a/assets/scss/03-organisms/_illustrated-header.scss
+++ b/assets/scss/03-organisms/_illustrated-header.scss
@@ -2,7 +2,7 @@ $bp-illustrated-header-columns-min: "min-width: 1001px";
 $bp-illustrated-header-columns-max: "max-width: 1000px";
 $bp-illustrated-header-image-width: 360px;
 
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__illustrated-header {
   margin-bottom: 40px;

--- a/assets/scss/03-organisms/_image-credit.scss
+++ b/assets/scss/03-organisms/_image-credit.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__image-credit {
   font-size: 16px;

--- a/assets/scss/03-organisms/_image-link-list.scss
+++ b/assets/scss/03-organisms/_image-link-list.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__link-list--image-blocks {
   // grid stuff

--- a/assets/scss/03-organisms/_image-promos.scss
+++ b/assets/scss/03-organisms/_image-promos.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__image-promos {
 

--- a/assets/scss/03-organisms/_in-page-alert.scss
+++ b/assets/scss/03-organisms/_in-page-alert.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__in-page-alert {
   background-color: $c-warning;

--- a/assets/scss/03-organisms/_jump-links.scss
+++ b/assets/scss/03-organisms/_jump-links.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__jump-links {
   margin-bottom: 30px;

--- a/assets/scss/03-organisms/_key-actions.scss
+++ b/assets/scss/03-organisms/_key-actions.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__key-actions {
   clear: both;

--- a/assets/scss/03-organisms/_key-message.scss
+++ b/assets/scss/03-organisms/_key-message.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 $colors: (
   "c-primary": $c-primary,

--- a/assets/scss/03-organisms/_link-list.scss
+++ b/assets/scss/03-organisms/_link-list.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__link-list {
 

--- a/assets/scss/03-organisms/_location-banner.scss
+++ b/assets/scss/03-organisms/_location-banner.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__location-banner {
 

--- a/assets/scss/03-organisms/_location-listing.scss
+++ b/assets/scss/03-organisms/_location-listing.scss
@@ -2,7 +2,7 @@ $location-listing--gutter-width: 30px;
 $location-listing--tags-size: 25px;
 $location-listin--map-min-width: 315px;
 
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__location-listing {
   position: relative;

--- a/assets/scss/03-organisms/_mapped-locations.scss
+++ b/assets/scss/03-organisms/_mapped-locations.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__mapped-locations {
 

--- a/assets/scss/03-organisms/_mass-feedback-form.scss
+++ b/assets/scss/03-organisms/_mass-feedback-form.scss
@@ -1,7 +1,7 @@
 $formTransitions: max-height 0.6s linear, margin 0.1s linear;
 $formQuickTransitions: max-height 0.3s linear;
 
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__mass-feedback-form {
 

--- a/assets/scss/03-organisms/_organization-navigation-item.scss
+++ b/assets/scss/03-organisms/_organization-navigation-item.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__organization-navigation {
 

--- a/assets/scss/03-organisms/_organization-navigation.scss
+++ b/assets/scss/03-organisms/_organization-navigation.scss
@@ -1,6 +1,6 @@
 $menu-transition-time: 0.3s;
 
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__organization-navigation {
   background-color: $c-gray-lightest;

--- a/assets/scss/03-organisms/_page-banner.scss
+++ b/assets/scss/03-organisms/_page-banner.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 $page-banner-icon-width: $column + $gutter;
 $page-banner-height: 330px;

--- a/assets/scss/03-organisms/_page-discourse.scss
+++ b/assets/scss/03-organisms/_page-discourse.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__page-discourse {
   padding-bottom: 45px;

--- a/assets/scss/03-organisms/_page-flipper.scss
+++ b/assets/scss/03-organisms/_page-flipper.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__page-flipper {
 

--- a/assets/scss/03-organisms/_page-header.scss
+++ b/assets/scss/03-organisms/_page-header.scss
@@ -1,6 +1,6 @@
 $page-header-widget-width: 350px;
 
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__page-header {
 

--- a/assets/scss/03-organisms/_page-overview.scss
+++ b/assets/scss/03-organisms/_page-overview.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__page-overview {
 

--- a/assets/scss/03-organisms/_person-card.scss
+++ b/assets/scss/03-organisms/_person-card.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__person-card {
   text-align: center;

--- a/assets/scss/03-organisms/_personal-message.scss
+++ b/assets/scss/03-organisms/_personal-message.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__personal-message {
   padding: 30px;

--- a/assets/scss/03-organisms/_press-filters.scss
+++ b/assets/scss/03-organisms/_press-filters.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__press-filters {
 

--- a/assets/scss/03-organisms/_press-listing.scss
+++ b/assets/scss/03-organisms/_press-listing.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__press-listing {
 

--- a/assets/scss/03-organisms/_pullquote.scss
+++ b/assets/scss/03-organisms/_pullquote.scss
@@ -1,6 +1,6 @@
  //theme
 
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__pullquote {
   position: relative;

--- a/assets/scss/03-organisms/_quick-actions.scss
+++ b/assets/scss/03-organisms/_quick-actions.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__quick-actions {
 

--- a/assets/scss/03-organisms/_related-locations.scss
+++ b/assets/scss/03-organisms/_related-locations.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__related-locations {
   background-color: $c-bg-section;

--- a/assets/scss/03-organisms/_related-orgs-and-topics.scss
+++ b/assets/scss/03-organisms/_related-orgs-and-topics.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__related-orgs-and-topics {
 

--- a/assets/scss/03-organisms/_rich-text.scss
+++ b/assets/scss/03-organisms/_rich-text.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 $rich-text-spacing: 1.75rem;
 $rich-text-spacing-mobile: 1.5rem;

--- a/assets/scss/03-organisms/_search-banner.scss
+++ b/assets/scss/03-organisms/_search-banner.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__search-banner {
   background-position: center center;

--- a/assets/scss/03-organisms/_sections-three-up.scss
+++ b/assets/scss/03-organisms/_sections-three-up.scss
@@ -1,7 +1,7 @@
 $bp-section-3up-large-min: "min-width:951px";
 $bp-section-3up-large-max: "max-width:950px";
 
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__sections-3up {
   

--- a/assets/scss/03-organisms/_short-description.scss
+++ b/assets/scss/03-organisms/_short-description.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__short-description {
 

--- a/assets/scss/03-organisms/_sidebar-promo.scss
+++ b/assets/scss/03-organisms/_sidebar-promo.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__sidebar-promo {
   margin-bottom: 40px;

--- a/assets/scss/03-organisms/_sidebar-widget.scss
+++ b/assets/scss/03-organisms/_sidebar-widget.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__sidebar-widget {
   

--- a/assets/scss/03-organisms/_split-columns.scss
+++ b/assets/scss/03-organisms/_split-columns.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__split-columns {
 

--- a/assets/scss/03-organisms/_split50.scss
+++ b/assets/scss/03-organisms/_split50.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__split50 {
 

--- a/assets/scss/03-organisms/_stacked-row-section.scss
+++ b/assets/scss/03-organisms/_stacked-row-section.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__stacked-row {
   position: relative;

--- a/assets/scss/03-organisms/_steps-ordered.scss
+++ b/assets/scss/03-organisms/_steps-ordered.scss
@@ -1,6 +1,6 @@
 $steps-ordered-icon-border: 3px;
 
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__steps-ordered {
 

--- a/assets/scss/03-organisms/_steps-unordered.scss
+++ b/assets/scss/03-organisms/_steps-unordered.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__steps-unordered {
 

--- a/assets/scss/03-organisms/_sticky-toc.scss
+++ b/assets/scss/03-organisms/_sticky-toc.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__sticky-toc {
   margin-bottom: 30px;

--- a/assets/scss/03-organisms/_suggested-pages.scss
+++ b/assets/scss/03-organisms/_suggested-pages.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__suggested-pages {
 

--- a/assets/scss/03-organisms/_tab-container.scss
+++ b/assets/scss/03-organisms/_tab-container.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 @mixin tabscroll {
   flex-wrap: nowrap;

--- a/assets/scss/03-organisms/_table-of-contents-hierarchy.scss
+++ b/assets/scss/03-organisms/_table-of-contents-hierarchy.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__toc--hierarchy {
 

--- a/assets/scss/03-organisms/_table-of-contents-overlay.scss
+++ b/assets/scss/03-organisms/_table-of-contents-overlay.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__toc--overlay {
 

--- a/assets/scss/03-organisms/_tabular-data.scss
+++ b/assets/scss/03-organisms/_tabular-data.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__tabular-data {
 

--- a/assets/scss/03-organisms/_teaser-listing-group.scss
+++ b/assets/scss/03-organisms/_teaser-listing-group.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__teaser-listing-group {
 

--- a/assets/scss/03-organisms/_teaser-listing.scss
+++ b/assets/scss/03-organisms/_teaser-listing.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__teaser-listing {
 

--- a/assets/scss/03-organisms/_teaser-text.scss
+++ b/assets/scss/03-organisms/_teaser-text.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__teaser-text {
 

--- a/assets/scss/03-organisms/_teaser.scss
+++ b/assets/scss/03-organisms/_teaser.scss
@@ -1,7 +1,7 @@
 $c-gray-dcdcdc: #dcdcdc;
 $c-theme-green: #43956f;
 
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__results-list-container {
 

--- a/assets/scss/03-organisms/_test-feed.scss
+++ b/assets/scss/03-organisms/_test-feed.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__test-feed {
 

--- a/assets/scss/03-organisms/_top-actions.scss
+++ b/assets/scss/03-organisms/_top-actions.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__top-actions {
 

--- a/assets/scss/03-organisms/_transition-page.scss
+++ b/assets/scss/03-organisms/_transition-page.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__transition-page {
   margin-bottom: 40px;

--- a/assets/scss/03-organisms/_utility-nav.scss
+++ b/assets/scss/03-organisms/_utility-nav.scss
@@ -1,6 +1,6 @@
 $utility-nav-height: 43px;
 
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__utility-nav {
   position: relative;

--- a/assets/scss/03-organisms/_utility-panel.scss
+++ b/assets/scss/03-organisms/_utility-panel.scss
@@ -1,7 +1,7 @@
 $bp-utility-panel-medium-min: "min-width:1121px";
 $bp-utility-panel-reduce-links-max: "max-width:1120px";
 
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__utility-panel {
   background-color: $c-primary; 

--- a/assets/scss/04-templates/_binder-page.scss
+++ b/assets/scss/04-templates/_binder-page.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__binder-page {
 

--- a/assets/scss/04-templates/_bio.scss
+++ b/assets/scss/04-templates/_bio.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__bio {
 

--- a/assets/scss/04-templates/_court-rules.scss
+++ b/assets/scss/04-templates/_court-rules.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__court-rules {
 

--- a/assets/scss/04-templates/_details.scss
+++ b/assets/scss/04-templates/_details.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__details {
 

--- a/assets/scss/04-templates/_form-page.scss
+++ b/assets/scss/04-templates/_form-page.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__form-page {
 

--- a/assets/scss/04-templates/_general.scss
+++ b/assets/scss/04-templates/_general.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .pre-content,
 .main-content,

--- a/assets/scss/04-templates/_information-details.scss
+++ b/assets/scss/04-templates/_information-details.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__information-details {
 

--- a/assets/scss/04-templates/_marketing-campaign.scss
+++ b/assets/scss/04-templates/_marketing-campaign.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__campaign-landing {
 

--- a/assets/scss/04-templates/_narrow-template.scss
+++ b/assets/scss/04-templates/_narrow-template.scss
@@ -4,7 +4,7 @@ $narrow-template-bg-offset-narrow: calc(50% - 125px);
 $narrow-template-max-width: 670px;
 $narrow-template-header-height: 170px;
 
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 @keyframes narrow-template-bg-full-left {
 

--- a/assets/scss/04-templates/_organization-details.scss
+++ b/assets/scss/04-templates/_organization-details.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__organization-detail {
 

--- a/assets/scss/04-templates/_policy-advisory.scss
+++ b/assets/scss/04-templates/_policy-advisory.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__policy-advisory {
  

--- a/assets/scss/04-templates/_press.scss
+++ b/assets/scss/04-templates/_press.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__press {
 

--- a/assets/scss/04-templates/_services.scss
+++ b/assets/scss/04-templates/_services.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma__services {
 

--- a/assets/scss/04-templates/_stacked-row-section-external-sidebar.scss
+++ b/assets/scss/04-templates/_stacked-row-section-external-sidebar.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ma_stacked-row-external-sidebar {
 

--- a/assets/scss/05-dataviz/_datatable.scss
+++ b/assets/scss/05-dataviz/_datatable.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 .ReactTable {
 

--- a/assets/scss/08-print/_print.scss
+++ b/assets/scss/08-print/_print.scss
@@ -1,4 +1,4 @@
-@use "00-base/global" as *;
+@use "../00-base/global" as *;
 
 @media print {
 


### PR DESCRIPTION
Currently in mayflower-v10, scss in mayflower-assets package assumes the include paths exist when importing other scss files.
e.g. 
```
@use "00-base/global" as *;
```
This requires the mayflower-assets consuming projects to always have to configure the sass include paths `node_modules/@massds/mayflower-assets/scss`:
e..g 
```
  sassOptions: {
    // It is required to include path @massds/mayflower-assets/scss when referencing a mayflower-assets SCSS file that imports 00-base/global.
    includePaths: [
      path.join(__dirname, "./node_modules/@massds/mayflower-assets/scss"),
    ],
  }
```
See the thread in pfml --> https://github.com/EOLWD/pfml/pull/587#discussion_r455841997

--- 

Requiring include path `node_modules/@massds/mayflower-assets/scss` VS. using the direct relative paths
**Pros:**
- In mayflower-assets package when importing other scss files, don't have to spell out the relative paths based on nested directories
- anything else missing?

**Cons**
- Requires consuming project to configure include path, otherwise will error out

Weighing the current pros and cons, I think it's more important to prioritize consumers and internal development shortcuts. Unless there are other things missing we should include in our considerations.