### PR TITLE
DP-19425 Fix formatting of COVID global nav link on search.mass.gov

### DIFF
--- a/react/src/components/molecules/MainNav/index.js
+++ b/react/src/components/molecules/MainNav/index.js
@@ -119,11 +119,16 @@ class MainNav extends Component {
             const liId = `li${index}`;
             const isExpanded = navSelected === liId;
             const itemBody = [];
+            const covidTopLink = item.text.toLowerCase().includes('covid') || false;
+            const topLevelButtonClasses = classNames({
+              'ma__main-nav__top-link': true,
+              'cv-alternative-style': covidTopLink
+            });
             if (item.subNav) {
               const buttonProps = {
                 id: buttonId,
                 index,
-                className: 'ma__main-nav__top-link',
+                className: topLevelButtonClasses,
                 'aria-expanded': `${isExpanded}`,
                 'aria-haspopup': 'true',
                 role: 'menuitem',


### PR DESCRIPTION
## Description
This PR includes some conditional logic to look for the keyword "covid" in the top-level menu item text, and add the class cv-alternative-style when detected. This ticket was created to address the missing COVID-19 styling in massgov-search, which pulls in its templates and styles from Mayflower React.

## Related Issue / Ticket

- [DP-19425](https://jira.mass.gov/browse/DP-19425)

## Steps to Test
1. Assuming other general setup steps are completed (see react/README.md), run `npm run start` from the react directory.

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

*

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
