### PR TITLE
move focus from the menu button to the menu container(=flyout) with tab

### DIFF
--- a/assets/scss/03-organisms/_header-hamburger.scss
+++ b/assets/scss/03-organisms/_header-hamburger.scss
@@ -786,3 +786,27 @@ body.show-menu {
     position: absolute;
   }
 }
+
+*:focus {
+  background-color: yellowgreen;
+}
+*:focus {
+  background-color: yellowgreen !important;
+}
+.ma__header__hamburger__skip-nav {
+  width: 240px !important;
+  height: 100px !important;
+  margin: 0 !important;
+  display: block !important;
+  clip: auto !important;
+  position: relative !important;
+}
+
+.ma__header__hamburger__skip-nav, .ma__header__hamburger__skip-nav:not(:focus) {
+  width: 240px;
+  height: 100px;
+  margin: 0;
+  display: block;
+  clip: auto;
+  position: relative !important;
+}

--- a/assets/scss/03-organisms/_header-hamburger.scss
+++ b/assets/scss/03-organisms/_header-hamburger.scss
@@ -786,29 +786,3 @@ body.show-menu {
     position: absolute;
   }
 }
-
-*:focus {
-  background-color: yellowgreen;
-}
-
-*:focus {
-  background-color: yellowgreen !important;
-}
-
-// .ma__header__hamburger__skip-nav {
-//   width: 240px !important;
-//   height: 100px !important;
-//   margin: 0 !important;
-//   display: block !important;
-//   clip: auto !important;
-//   position: relative !important;
-// }
-
-// .ma__header__hamburger__skip-nav, .ma__header__hamburger__skip-nav:not(:focus) {
-//   width: 240px;
-//   height: 100px;
-//   margin: 0;
-//   display: block;
-//   clip: auto;
-//   position: relative !important;
-// }

--- a/assets/scss/03-organisms/_header-hamburger.scss
+++ b/assets/scss/03-organisms/_header-hamburger.scss
@@ -790,9 +790,11 @@ body.show-menu {
 *:focus {
   background-color: yellowgreen;
 }
+
 *:focus {
   background-color: yellowgreen !important;
 }
+
 .ma__header__hamburger__skip-nav {
   width: 240px !important;
   height: 100px !important;

--- a/assets/scss/03-organisms/_header-hamburger.scss
+++ b/assets/scss/03-organisms/_header-hamburger.scss
@@ -795,20 +795,20 @@ body.show-menu {
   background-color: yellowgreen !important;
 }
 
-.ma__header__hamburger__skip-nav {
-  width: 240px !important;
-  height: 100px !important;
-  margin: 0 !important;
-  display: block !important;
-  clip: auto !important;
-  position: relative !important;
-}
+// .ma__header__hamburger__skip-nav {
+//   width: 240px !important;
+//   height: 100px !important;
+//   margin: 0 !important;
+//   display: block !important;
+//   clip: auto !important;
+//   position: relative !important;
+// }
 
-.ma__header__hamburger__skip-nav, .ma__header__hamburger__skip-nav:not(:focus) {
-  width: 240px;
-  height: 100px;
-  margin: 0;
-  display: block;
-  clip: auto;
-  position: relative !important;
-}
+// .ma__header__hamburger__skip-nav, .ma__header__hamburger__skip-nav:not(:focus) {
+//   width: 240px;
+//   height: 100px;
+//   margin: 0;
+//   display: block;
+//   clip: auto;
+//   position: relative !important;
+// }

--- a/changelogs/DP-19783.yml
+++ b/changelogs/DP-19783.yml
@@ -1,0 +1,6 @@
+Fixed:
+  - project: Patternlab
+    component: Header
+    description: Set focus on the menu container from the menu button while the container is open with tab. (#1159)
+    issue: DP-19783
+    impact: Patch

--- a/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
+++ b/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
@@ -1,3 +1,4 @@
+const osInfo = navigator.appVersion;
 const body = document.querySelector("body");
 let width = body.clientWidth;
 const feedbackButton = document.querySelector(".ma__fixed-feedback-button");
@@ -108,9 +109,36 @@ if (menuButton !== null) {
 
   menuButton.addEventListener("keydown", function (e) {
     if (e.key === "Tab" || e.code === "Tab") {
+      e.preventDefault();
+
+// alert(navigator.appVersion);
+// "5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1.2 Safari/605.1.15"
+      if (osInfo.indexOf("Mac OS X 10_15_6") !== -1 && osInfo.indexOf("Version/13.1.2 Safari/605.1.15") !== -1) {
+        document.querySelector(".ma__header__hamburger__nav-container .ma__header-search__input").style.display = "none";
+      }
+
+      let focusable = hamburgerMenuContainer.querySelectorAll("button, [href], input, [tabindex]:not([tabindex='-1'])");
+
+      console.log(focusable[0]);
+
+      // focusable[0].style.background = "yellowgreen";
+
       if (width < 621) {
-        hamburgerMenuContainer.setAttribute("tabindex", "0");
-        hamburgerMenuContainer.focus();
+
+        // hamburgerMenuContainer.setAttribute("tabindex", "0");
+        // hamburgerMenuContainer.focus();
+
+        // const hamburgerMenuContainer = document.querySelector(".ma__header__hamburger__nav-container");
+
+
+        // if (focusable[0] !== hamburgerMenuContainer.querySelector(".ma__header-search__input")) {
+          // document.querySelector(".ma__header__hamburger__nav-container .ma__header-search__input").style.display = "none";
+          // hamburgerMenuContainer.querySelector(".ma__header-search__input").setAttribute("tabindex", "-1");
+
+        // }
+
+        focusable[0].focus();
+
       }
     }
   });
@@ -502,9 +530,9 @@ function commonCloseMenuTasks() {
   menuButton.setAttribute("aria-expanded", "false");
   menuButton.setAttribute("aria-label", "Open the main menu for mass.gov");
 
-  if (hamburgerMenuContainer.hasAttribute("tabindex")) {
-    hamburgerMenuContainer.removeAttribute("tabindex");
-  }
+  // if (hamburgerMenuContainer.hasAttribute("tabindex")) {
+  //   hamburgerMenuContainer.removeAttribute("tabindex");
+  // }
 
   if(searchInput.hasAttribute("autofocus")) {
     searchInput.removeAttribute("autofocus");
@@ -558,7 +586,6 @@ function jumpToSearch(e) {
     commonOpenMenuTasks();
     jumpToSearchButton.setAttribute("aria-pressed", "true");
     // Set focus on the search input field.
-    const osInfo = navigator.appVersion;
     if (osInfo.indexOf("iPhone") !== -1) {
       // Set up a temp input to display onscreen keyboard.
       const __tempEl = document.createElement("input");

--- a/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
+++ b/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
@@ -19,6 +19,17 @@ const utilNarrowButton = document.querySelector(".ma__header__hamburger__utility
 let utilNarrowContent = utilNarrowButton ? utilNarrowButton.nextElementSibling : null;
 let utilNarrowContainer = utilNarrowContent ? utilNarrowContent.querySelector(".ma__utility-nav__container") : null;
 
+
+if (osInfo.indexOf("Mac OS X 10_15_6") !== -1 && osInfo.indexOf("Version/13.1.2 Safari/605.1.15") !== -1) {
+
+  document.addEventListener("keydown", function (e) {
+    if (e.key === "Tab" || e.code === "Tab") {
+      e.preventDefault();
+    }
+  });
+
+}
+
 // Check whether the wide utility nav is open.
 const utilNavWideCheck = function() {
   return utilNavWide ? (utilNavWide.offsetWidth > 0 && utilNavWide.offsetHeight > 0) : null;
@@ -111,20 +122,19 @@ if (menuButton !== null) {
     if (e.key === "Tab" || e.code === "Tab") {
       e.preventDefault();
 
-// alert(navigator.appVersion);
-// "5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1.2 Safari/605.1.15"
-      if (osInfo.indexOf("Mac OS X 10_15_6") !== -1 && osInfo.indexOf("Version/13.1.2 Safari/605.1.15") !== -1) {
-        document.querySelector(".ma__header__hamburger__nav-container .ma__header-search__input").style.display = "none";
-      }
-
+      // const hamburgerMenuContainer = document.querySelector(".ma__header__hamburger__nav-container");
       let focusable = hamburgerMenuContainer.querySelectorAll("button, [href], input, [tabindex]:not([tabindex='-1'])");
 
-      console.log(focusable[0]);
-
-      // focusable[0].style.background = "yellowgreen";
+      focusable[0].style.background = "pink";
 
       if (width < 621) {
 
+
+        if (osInfo.indexOf("Mac OS X 10_15_6") !== -1 && osInfo.indexOf("Version/13.1.2 Safari/605.1.15") !== -1) {
+
+          document.querySelector(".ma__header__hamburger__nav-container .ma__header-search__input").setAttribute("tabindex", "-1");
+
+        }
         // hamburgerMenuContainer.setAttribute("tabindex", "0");
         // hamburgerMenuContainer.focus();
 

--- a/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
+++ b/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
@@ -20,21 +20,13 @@ let utilNarrowContent = utilNarrowButton ? utilNarrowButton.nextElementSibling :
 let utilNarrowContainer = utilNarrowContent ? utilNarrowContent.querySelector(".ma__utility-nav__container") : null;
 
 
-// if (osInfo.indexOf("Version/13.1.2 Safari/605.1.15") !== -1) {
-
-//   // document.body.firstElementChild.tabIndex = 1;
-
-//   // hamburgerMenuContainer.firstElementChild.tabIndex = 1;
-
-//   hamburgerMenuContainer.querySelector("a").style.background = "green";
-
-//   // document.addEventListener("keydown", function (e) {
-//   //   if (e.key === "Tab" || e.code === "Tab") {
-//   //     e.preventDefault();
-//   //   }
-//   // });
-
-// }
+if (osInfo.indexOf("Version/13.1.2 Safari/605.1.15") !== -1) {
+  document.addEventListener("keydown", function (e) {
+    if (e.key === "Tab" || e.code === "Tab") {
+      body.querySelector("a:first-of-type").focus();
+    }
+  });
+}
 
 // Check whether the wide utility nav is open.
 const utilNavWideCheck = function() {
@@ -114,7 +106,10 @@ if (menuButton !== null) {
   menuButton.addEventListener("click", function (event) {
     event.preventDefault();
 
-    // e.target.focus();
+    // For Safari, this ensures to move focus to the menu content.
+    if (osInfo.indexOf("Safari") !== -1) {
+      menuButton.focus();
+    }
 
     toggleMenu();
   });
@@ -128,37 +123,13 @@ if (menuButton !== null) {
 
   menuButton.addEventListener("keydown", function (e) {
     if (e.key === "Tab" || e.code === "Tab") {
-      e.preventDefault();
-
-      // const hamburgerMenuContainer = document.querySelector(".ma__header__hamburger__nav-container");
-      let focusable = hamburgerMenuContainer.querySelectorAll("button, [href], input, [tabindex]:not([tabindex='-1'])");
-
-      // focusable[0].style.background = "pink";
-
       if (width < 621) {
+        e.preventDefault();
 
-
-        // if (osInfo.indexOf("Mac OS X 10_15_6") !== -1 && osInfo.indexOf("Version/13.1.2 Safari/605.1.15") !== -1) {
-
-        //   focusable[0].style.background = "pink";
-
-        //   // document.querySelector(".ma__header__hamburger__nav-container .ma__header-search__input").setAttribute("tabindex", "-1");
-
-        // }
-        // hamburgerMenuContainer.setAttribute("tabindex", "0");
-        // hamburgerMenuContainer.focus();
-
-        // const hamburgerMenuContainer = document.querySelector(".ma__header__hamburger__nav-container");
-
-
-        // if (focusable[0] !== hamburgerMenuContainer.querySelector(".ma__header-search__input")) {
-          // document.querySelector(".ma__header__hamburger__nav-container .ma__header-search__input").style.display = "none";
-          // hamburgerMenuContainer.querySelector(".ma__header-search__input").setAttribute("tabindex", "-1");
-
-        // }
+        const hamburgerMenuContainer = document.querySelector(".ma__header__hamburger__nav-container");
+        let focusable = hamburgerMenuContainer.querySelectorAll("button, [href], input, [tabindex]:not([tabindex='-1'])");
 
         focusable[0].focus();
-
       }
     }
   });

--- a/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
+++ b/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
@@ -106,6 +106,15 @@ if (menuButton !== null) {
     toggleMenu();
   });
 
+  menuButton.addEventListener("keydown", function (e) {
+    if (e.key === "Tab" || e.code === "Tab") {
+      if (width < 621) {
+        hamburgerMenuContainer.setAttribute("tabindex", "0");
+        hamburgerMenuContainer.focus();
+      }
+    }
+  });
+
   const firstTopMenuItem = document.querySelector(".ma__header__hamburger__nav .ma__main__hamburger-nav__item:first-of-type .js-main-nav-hamburger__top-link");
   // To accomodate both button and link as the last top menu item, use 'ma__' classes instead of 'js-'.
   const lastTopMenuItem = document.querySelector(".ma__main__hamburger-nav__item:last-of-type .ma__main__hamburger-nav__top-link");
@@ -472,7 +481,7 @@ function closeMenu() {
   commonCloseMenuTasks();
   menuButton.setAttribute("aria-pressed", "false");
 
-  // Set focusn on the menu button.
+  // Set focus on the menu button.
   setTimeout(function timeoutFunction() {
     document.querySelector(".js-header-menu-button").focus();
   }, 100);
@@ -490,6 +499,10 @@ function commonCloseMenuTasks() {
 
   menuButton.setAttribute("aria-expanded", "false");
   menuButton.setAttribute("aria-label", "Open the main menu for mass.gov");
+
+  if (hamburgerMenuContainer.hasAttribute("tabindex")) {
+    hamburgerMenuContainer.removeAttribute("tabindex");
+  }
 
   if(searchInput.hasAttribute("autofocus")) {
     searchInput.removeAttribute("autofocus");

--- a/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
+++ b/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
@@ -20,15 +20,21 @@ let utilNarrowContent = utilNarrowButton ? utilNarrowButton.nextElementSibling :
 let utilNarrowContainer = utilNarrowContent ? utilNarrowContent.querySelector(".ma__utility-nav__container") : null;
 
 
-if (osInfo.indexOf("Mac OS X 10_15_6") !== -1 && osInfo.indexOf("Version/13.1.2 Safari/605.1.15") !== -1) {
+// if (osInfo.indexOf("Version/13.1.2 Safari/605.1.15") !== -1) {
 
-  document.addEventListener("keydown", function (e) {
-    if (e.key === "Tab" || e.code === "Tab") {
-      e.preventDefault();
-    }
-  });
+//   // document.body.firstElementChild.tabIndex = 1;
 
-}
+//   // hamburgerMenuContainer.firstElementChild.tabIndex = 1;
+
+//   hamburgerMenuContainer.querySelector("a").style.background = "green";
+
+//   // document.addEventListener("keydown", function (e) {
+//   //   if (e.key === "Tab" || e.code === "Tab") {
+//   //     e.preventDefault();
+//   //   }
+//   // });
+
+// }
 
 // Check whether the wide utility nav is open.
 const utilNavWideCheck = function() {
@@ -108,6 +114,8 @@ if (menuButton !== null) {
   menuButton.addEventListener("click", function (event) {
     event.preventDefault();
 
+    // e.target.focus();
+
     toggleMenu();
   });
 
@@ -125,16 +133,18 @@ if (menuButton !== null) {
       // const hamburgerMenuContainer = document.querySelector(".ma__header__hamburger__nav-container");
       let focusable = hamburgerMenuContainer.querySelectorAll("button, [href], input, [tabindex]:not([tabindex='-1'])");
 
-      focusable[0].style.background = "pink";
+      // focusable[0].style.background = "pink";
 
       if (width < 621) {
 
 
-        if (osInfo.indexOf("Mac OS X 10_15_6") !== -1 && osInfo.indexOf("Version/13.1.2 Safari/605.1.15") !== -1) {
+        // if (osInfo.indexOf("Mac OS X 10_15_6") !== -1 && osInfo.indexOf("Version/13.1.2 Safari/605.1.15") !== -1) {
 
-          document.querySelector(".ma__header__hamburger__nav-container .ma__header-search__input").setAttribute("tabindex", "-1");
+        //   focusable[0].style.background = "pink";
 
-        }
+        //   // document.querySelector(".ma__header__hamburger__nav-container .ma__header-search__input").setAttribute("tabindex", "-1");
+
+        // }
         // hamburgerMenuContainer.setAttribute("tabindex", "0");
         // hamburgerMenuContainer.focus();
 


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/develop/docs/for-developers/changelog-instructions.md)


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
Issue:  When the menu button is clicked and the flyout is open(= the menu button has focus), hitting tab sets focus on the jump to search button on the blue nav bar, instead of the flyout.  

Solution:  With tabbing in above condition, set focus on the flyout container with `tabindex="0"`.  Then, the first focusable element in the flyout gets focus.

## Related Issue / Ticket

- [JIRA issue](https://jira.mass.gov/browse/DP-19783)
- [Github issue]()

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

**Note:**

When you test in Safari, please make sure it has the correct set up.  By default, macOS has limited keyboard tabbing to only ‘text boxes and lists’ as a system preference.  This has been recognized in Firefox and Safari specifically.

Please configure your Mac before start testing:  https://www.a11yproject.com/posts/2017-12-29-macos-browser-keyboard-navigation/

This setting change cannot be done in Browserstack.


1. Go to http://localhost:3000/patterns/05-pages-Homepage-hamburger/05-pages-Homepage-hamburger.html and set the screen width less than 620px.  Make sure you see the menu button and the jump to search button.

2. Click the menu button to open the menu, then hit TAB.  Find the focus is set on the first focusable element in the flyout. In this case, the mass.gov link.

<img width="590" alt="open" src="https://user-images.githubusercontent.com/9633303/91355025-94d35580-e7bb-11ea-8150-3742a79773b2.png">

4.  Close the menu and hit TAB. Find the focus is set on the jump to search button.

<img width="531" alt="close" src="https://user-images.githubusercontent.com/9633303/91355139-c0eed680-e7bb-11ea-9d46-5ccb919e8d5f.png">


## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

*

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
