### PR TITLE
Allow value 0 to be returned in onBlur callback

### DIFF
--- a/changelogs/react-fix-inputCurrency-bug.yml
+++ b/changelogs/react-fix-inputCurrency-bug.yml
@@ -1,0 +1,5 @@
+Added:
+  - project: React
+    component: InputCurrency
+    description: Fix onBlur bug to allow value 0 to be returned in onBlur callback. (#1161)
+    impact: Patch

--- a/react/src/components/forms/InputCurrency/index.js
+++ b/react/src/components/forms/InputCurrency/index.js
@@ -140,7 +140,7 @@ const Currency = (props) => {
           const handleBlur = (e) => {
             const { type } = e;
             const inputEl = ref.current;
-            const { value } = inputEl;
+            const value = inputEl && inputEl.value;
             const numberValue = Number(numbro.unformat(value));
             // isNotNumber returns true if value is null, undefined or NaN vs Number.isNaN only checks if value is NaN
             /* eslint-disable-next-line   no-restricted-globals */

--- a/react/src/components/forms/InputCurrency/index.js
+++ b/react/src/components/forms/InputCurrency/index.js
@@ -148,7 +148,7 @@ const Currency = (props) => {
             if (isNotNumber) {
               inputEl.setAttribute('placeholder', props.placeholder);
             } else {
-              let newValue = isNotNumber || numberValue;
+              let newValue = numberValue;
               if (hasNumberProperty(props, 'max') && newValue > props.max) {
                 newValue = props.max;
               }

--- a/react/src/components/forms/InputCurrency/index.js
+++ b/react/src/components/forms/InputCurrency/index.js
@@ -140,15 +140,15 @@ const Currency = (props) => {
           const handleBlur = (e) => {
             const { type } = e;
             const inputEl = ref.current;
-            const stringValue = inputEl.value;
-            // isNotNumber returns true if stringValue is null, undefined or 'NaN'
+            const { value } = inputEl;
+            const numberValue = Number(numbro.unformat(value));
+            // isNotNumber returns true if value is null, undefined or NaN vs Number.isNaN only checks if value is NaN
             /* eslint-disable-next-line   no-restricted-globals */
-            const isNotNumber = !stringValue || isNaN(Number(numbro.unformat(stringValue)));
+            const isNotNumber = isNaN(value);
             if (isNotNumber) {
               inputEl.setAttribute('placeholder', props.placeholder);
-            }
-            let newValue = isNotNumber ? '' : Number(numbro.unformat(stringValue));
-            if (!is.empty(newValue)) {
+            } else {
+              let newValue = isNotNumber || numberValue;
               if (hasNumberProperty(props, 'max') && newValue > props.max) {
                 newValue = props.max;
               }


### PR DESCRIPTION
Added:
  - project: React
    component: InputCurrency
    description: Fix onBlur bug to allow value 0 to be returned in onBlur callback. (#916)
    impact: Patch


To test:
http://localhost:6006/?path=/story/forms-atoms--inputcurrency
- type in '0' and click outside of the input, onBlur is triggered
<img width="428" alt="Screen Shot 2020-09-01 at 1 31 08 AM" src="https://user-images.githubusercontent.com/5789411/91798517-0dd71080-ebf3-11ea-9c0a-227531d7d487.png">
- type in a non-number input and click outside of the input, onBlur is not triggered
<img width="515" alt="Screen Shot 2020-09-01 at 1 31 35 AM" src="https://user-images.githubusercontent.com/5789411/91798566-3101c000-ebf3-11ea-8e6c-1e46d74d538d.png">
