### PR TITLE
(react)[InputCurrency]allow onBlur callback to fire on input with $

### DIFF
--- a/changelogs/react-fix-inputCurrency-bug.yml
+++ b/changelogs/react-fix-inputCurrency-bug.yml
@@ -1,5 +1,9 @@
-Added:
+Fixed:
   - project: React
     component: InputCurrency
     description: Fix onBlur bug to allow value 0 to be returned in onBlur callback. (#1161)
+    impact: Patch
+  - project: React
+    component: InputCurrency
+    description: Fix onBlur bug to allow onBlur callback to fire on input with `$`. (#1163)
     impact: Patch

--- a/react/src/components/forms/InputCurrency/index.js
+++ b/react/src/components/forms/InputCurrency/index.js
@@ -141,10 +141,11 @@ const Currency = (props) => {
             const { type } = e;
             const inputEl = ref.current;
             const value = inputEl && inputEl.value;
-            const numberValue = Number(numbro.unformat(value));
+            const numberValue = value && Number(numbro.unformat(value.replace('$', '')));
+
             // isNotNumber returns true if value is null, undefined or NaN vs Number.isNaN only checks if value is NaN
             /* eslint-disable-next-line   no-restricted-globals */
-            const isNotNumber = isNaN(value);
+            const isNotNumber = isNaN(numberValue);
             if (isNotNumber) {
               inputEl.setAttribute('placeholder', props.placeholder);
             } else {


### PR DESCRIPTION
  - project: React
    component: InputCurrency
    description: Fix onBlur bug to allow onBlur callback to fire on input with `$`. (#1163)
    impact: Patch