### PR TITLE
Release 9.55.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Mayflower Release Notes
 All notable changes to this project will be documented in this file.
 
+## 9.55.2 (9/7/2020)
+### Fixed 
+- (React) [InputCurrency] Fix onBlur bug to allow value 0 to be returned in onBlur callback. (#1161)
+- (React) [InputCurrency] Fix onBlur bug to allow onBlur callback to fire on input with `$`. (#1163)
+
 ## 9.55.0 (8/24/2020)
 ### Changed 
 - (React) [MainNav] DP-19425: Fix formatting of COVID global nav link on search.mass.gov (#1143)

--- a/changelogs/react-fix-inputCurrency-bug.yml
+++ b/changelogs/react-fix-inputCurrency-bug.yml
@@ -1,5 +1,9 @@
-Added:
+Fixed:
   - project: React
     component: InputCurrency
     description: Fix onBlur bug to allow value 0 to be returned in onBlur callback. (#1161)
+    impact: Patch
+  - project: React
+    component: InputCurrency
+    description: Fix onBlur bug to allow onBlur callback to fire on input with `$`. (#1163)
     impact: Patch

--- a/changelogs/react-fix-inputCurrency-bug.yml
+++ b/changelogs/react-fix-inputCurrency-bug.yml
@@ -1,9 +1,0 @@
-Fixed:
-  - project: React
-    component: InputCurrency
-    description: Fix onBlur bug to allow value 0 to be returned in onBlur callback. (#1161)
-    impact: Patch
-  - project: React
-    component: InputCurrency
-    description: Fix onBlur bug to allow onBlur callback to fire on input with `$`. (#1163)
-    impact: Patch

--- a/react/src/components/forms/InputCurrency/index.js
+++ b/react/src/components/forms/InputCurrency/index.js
@@ -141,10 +141,11 @@ const Currency = (props) => {
             const { type } = e;
             const inputEl = ref.current;
             const value = inputEl && inputEl.value;
-            const numberValue = Number(numbro.unformat(value));
+            const numberValue = value && Number(numbro.unformat(value.replace('$', '')));
+
             // isNotNumber returns true if value is null, undefined or NaN vs Number.isNaN only checks if value is NaN
             /* eslint-disable-next-line   no-restricted-globals */
-            const isNotNumber = isNaN(value);
+            const isNotNumber = isNaN(numberValue);
             if (isNotNumber) {
               inputEl.setAttribute('placeholder', props.placeholder);
             } else {


### PR DESCRIPTION
## 9.55.2 (9/7/2020)
### Fixed 
- (React) [InputCurrency] Fix onBlur bug to allow value 0 to be returned in onBlur callback. (#1161)
- (React) [InputCurrency] Fix onBlur bug to allow onBlur callback to fire on input with `$`. (#1163)
