### PR TITLE
DP-19889 the menu scroll issue in iphone

### DIFF
--- a/changelogs/DP-19889.yml
+++ b/changelogs/DP-19889.yml
@@ -1,0 +1,6 @@
+Fixed:
+  - project: Patternlab
+    component: Header
+    description: Make the menu container stay open and scrollable. (#1183)
+    issue: DP-19889
+    impact: Patch

--- a/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
+++ b/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
@@ -596,6 +596,10 @@ function commonCloseMenuTasks() {
   menuButton.setAttribute("aria-expanded", "false");
   menuButton.setAttribute("aria-label", "Open the main menu for mass.gov");
 
+  if (hamburgerMenuContainer.hasAttribute("style")) {
+    hamburgerMenuContainer.removeAttribute("style");
+  }
+
   // if (hamburgerMenuContainer.hasAttribute("tabindex")) {
   //   hamburgerMenuContainer.removeAttribute("tabindex");
   // }
@@ -635,6 +639,19 @@ function openMenu() {
 
 function commonOpenMenuTasks() {
   body.classList.add("show-menu");
+
+  if (osInfo.indexOf("iPhone") !== -1) {
+    let heightAboveNavContainer = document.querySelector(".ma__header__hamburger__nav-container").getBoundingClientRect().top;
+
+    if (heightAboveNavContainer > 0) {
+      if (osInfo.indexOf("Version/12.") !== -1 || osInfo.indexOf("Version/11.") !== -1 || osInfo.indexOf("Version/12.") !== -1 || osInfo.indexOf("Version/10.") !== -1)  {
+        let bodyOffset = document.querySelector(".ma__header__hamburger").getBoundingClientRect().top - 80;
+        document.querySelector(".show-menu").style.top = `-${bodyOffset}px`;
+        document.querySelector(".show-menu").style.position = "fixed";
+      }
+    }
+    hamburgerMenuContainer.style.height = "calc(100vh - 150px)";
+  }
 
   if (document.querySelector("html.stickyTOC")) {
     document.querySelector("html.stickyTOC").classList.add("stickyTOCtmp");

--- a/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
+++ b/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
@@ -588,6 +588,12 @@ function closeMenu() {
 
 function commonCloseMenuTasks() {
   body.classList.remove("show-menu");
+  if (body.style.position === "fixed") {
+    body.style.position = "relative";
+  }
+  if (body.style.top !== 0) {
+    body.style.top = 0;
+  }
 
   if (document.querySelector("html.stickyTOCtmp")) {
     document.querySelector("html.stickyTOCtmp").classList.add("stickyTOC");
@@ -650,6 +656,7 @@ function commonOpenMenuTasks() {
         document.querySelector(".show-menu").style.position = "fixed";
       }
     }
+    // The height setting makes the menu container scroll.
     hamburgerMenuContainer.style.height = "calc(100vh - 150px)";
   }
 

--- a/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
+++ b/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
@@ -22,7 +22,7 @@ let utilNarrowContainer = utilNarrowContent ? utilNarrowContent.querySelector(".
 // Check whether the narrow utility nav is open.
 const utilNavNarrowCheck = function() {
   return utilNarrowNav ? (utilNarrowNav.offsetWidth > 0 && utilNarrowNav.offsetHeight > 0) : false;
-}
+};
 
 /** DP-19336 begin: add padding to hamburger menu to allow scrolling when alerts are loaded */
 const hamburgerMainNav = document.querySelector(".ma__header__hamburger__main-nav");
@@ -360,7 +360,6 @@ if (menuButton !== null) {
             let targetIndex;
             for (let index = lastIndex; index > -1; index--) {
               if (e.target === narrowUtilContentLinks[index]) {
-                console.log(index);
                 targetIndex = index;
               }
             }
@@ -413,7 +412,6 @@ if (menuButton !== null) {
   const itemButton = item.querySelector(".js-main-nav-hamburger__top-link");
   const subMenu = item.querySelector(".js-main-nav-hamburger-content");
   const subItems = subMenu.querySelector(".js-main-nav-hamburger__container");
-  let subMenuItems = subMenu.querySelectorAll(".js-main-nav-hamburger__subitem");
 
   subItems.style.opacity = "0";
 
@@ -504,30 +502,6 @@ if (menuButton !== null) {
       }
     }
   });
-
-  // Replacing this with submenuLinks.forEach() since this doesn't work with Voiceover.
-  // [].forEach.call(subMenuItems, function (subItem) {
-  //   const prevSib = subItem.previousElementSibling;
-  //   const nextSib = subItem.nextElementSibling;
-
-  //   subItem.addEventListener("keydown", function (e) {
-
-  //     switch (e.code) {
-  //       case "ArrowUp":
-  //       case "ArrowLeft":
-  //         if (subItem === prevSib) {
-  //           prevSib.querySelector(".js-main-nav-hamburger__link").focus();
-  //         }
-  //         break;
-  //       case "ArrowDown":
-  //       case "ArrowRight":
-  //         if (subItem === nextSib) {
-  //           nextSib.querySelector(".js-main-nav-hamburger__link").focus();
-  //         }
-  //         break;
-  //     }
-  //   });
-  // });
 });
 
 if (jumpToSearchButton !== null) {
@@ -545,7 +519,7 @@ if (jumpToSearchButton !== null) {
 
 // Adjust the overlay position as the alert accordion opens/closes while the menu is open.
 setTimeout(function timeoutFunction() {
-  if (document.querySelector(".js-ajax-pattern")) {
+  if (document.querySelector(".ma__button-alert")) {
     document.querySelector(".ma__button-alert").addEventListener("click", function () {
       if (body.classList.contains("show-menu")) {
         let openAboveNavBar = document.querySelector(".js-accordion-content").getBoundingClientRect().top;
@@ -615,9 +589,9 @@ function closeMenu() {
 function commonCloseMenuTasks() {
   body.classList.remove("show-menu");
 
-  if (document.querySelector('html.stickyTOCtmp')) {
-    document.querySelector('html.stickyTOCtmp').classList.add('stickyTOC');
-    document.querySelector('html.stickyTOCtmp').classList.remove('stickyTOCtmp');
+  if (document.querySelector("html.stickyTOCtmp")) {
+    document.querySelector("html.stickyTOCtmp").classList.add("stickyTOC");
+    document.querySelector("html.stickyTOCtmp").classList.remove("stickyTOCtmp");
   }
   menuButton.setAttribute("aria-expanded", "false");
   menuButton.setAttribute("aria-label", "Open the main menu for mass.gov");
@@ -642,7 +616,7 @@ function commonCloseMenuTasks() {
 function openMenu() {
   commonOpenMenuTasks();
   menuButton.setAttribute("aria-pressed", "true");
-  let alertsHeader = document.querySelector('.ma__emergency-alerts__header');
+  let alertsHeader = document.querySelector(".ma__emergency-alerts__header");
   if (alertsHeader !== null) {
     let emergencyAlerts = document.querySelector(".ma__emergency-alerts");
     let scrollOffset = emergencyAlerts.offsetHeight - (alertsHeader.offsetHeight/2);
@@ -662,9 +636,9 @@ function openMenu() {
 function commonOpenMenuTasks() {
   body.classList.add("show-menu");
 
-  if (document.querySelector('html.stickyTOC')) {
-    document.querySelector('html.stickyTOC').classList.add('stickyTOCtmp');
-    document.querySelector('html.stickyTOC').classList.remove('stickyTOC');
+  if (document.querySelector("html.stickyTOC")) {
+    document.querySelector("html.stickyTOC").classList.add("stickyTOCtmp");
+    document.querySelector("html.stickyTOC").classList.remove("stickyTOC");
   }
 
   menuButton.setAttribute("aria-expanded", "true");
@@ -697,7 +671,6 @@ function jumpToSearch(e) {
     hamburgerMenuContainer.removeAttribute("aria-hidden");
     openMenu();
     setTimeout(function timeoutFunction() {
-      console.log('search timeout clicked');
       jumpToSearchButton.setAttribute("aria-pressed", "true");
       searchInput.setAttribute("autofocus", "");
       searchInput.focus();


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/develop/docs/for-developers/changelog-instructions.md)


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
- Make the menu stay open as scroll in ios 12, 11 and 10.
- Make the menu scroll in ios 14, 13, 12, 11 and 10.
- Fix a JS error.

## Related Issue / Ticket

- [JIRA issue](https://jira.mass.gov/browse/DP-19889)
- [Github issue]()

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Go to http://localhost:3000/patterns/05-pages-Homepage-hamburger/05-pages-Homepage-hamburger.html in ios 10, 11, 12, 13 and 14.

2. Open the menu and scroll the menu container and find
 - The alert doesn't scroll as scrolling the menu.
 - The menu container doesn't close as scroll.
 - The menu container can be scrolled to the bottom. 

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

*

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
