### PR TITLE
Removed touchend events to prevent observed open on scroll - DP-19878

### DIFF
--- a/changelogs/DP-19878.yml
+++ b/changelogs/DP-19878.yml
@@ -1,0 +1,6 @@
+Added:
+  - project: Patternlab
+    component: Header
+    description: Removed touchend events from the menu and search buttons. (#1185)
+    issue: DP-19878
+    impact: Patch

--- a/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
+++ b/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
@@ -123,13 +123,6 @@ if (menuButton !== null) {
     toggleMenu();
   });
 
-  // for touch devices
-  menuButton.addEventListener("touchend", function (event) {
-    event.preventDefault();
-
-    toggleMenu();
-  });
-
   menuButton.addEventListener("keydown", function (e) {
     if (e.key === "Tab" || e.code === "Tab") {
       if (width < 621) {
@@ -510,12 +503,6 @@ if (jumpToSearchButton !== null) {
     e.preventDefault();
     jumpToSearch();
   });
-
-  jumpToSearchButton.addEventListener("touchend", (e) => {
-    e.preventDefault();
-
-    jumpToSearch();
-  }, false);
 }
 
 // Adjust the overlay position as the alert accordion opens/closes while the menu is open.


### PR DESCRIPTION
## Description
This PR removes touchend events attached to the menu and search buttons, which were triggering an observed issue on mobile devices when scrolling.

## Related Issue / Ticket

- [DP-19878](https://jira.mass.gov/browse/DP-19878)

## Steps to Test

1. Scroll on a mobile device and touch on the menu button or search button while scrolling. The menu should not open.

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

*

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
