### PR TITLE
DP-19987: log in to menu width

### DIFF
--- a/assets/scss/03-organisms/_header-hamburger.scss
+++ b/assets/scss/03-organisms/_header-hamburger.scss
@@ -799,5 +799,6 @@ body.show-menu {
   .util-nav-content-open .ma__header__hamburger__utility-nav--wide {
     width: 100%;
     position: absolute;
+    left: 0;
   }
 }

--- a/changelogs/DP-19987.yml
+++ b/changelogs/DP-19987.yml
@@ -1,0 +1,6 @@
+Fixed:
+  - project: Patternlab
+    component: Header
+    description: Fixed log in to menu width. (#1186)
+    issue: DP-19783
+    impact: Patch


### PR DESCRIPTION
## Description
Adjusted CSS to make log in to menu full width again.

## Related Issue / Ticket

- [DP-19987](https://jira.mass.gov/browse/DP-19987)

## Steps to Test

1. Open up menu link. The menu should be full width. NOTE: the menu animation pulls down from the top of the screen, which looks odd when alerts are in place. This is an issue for production as well, so I considered this issue out of scope here.

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

*

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
