### PR TITLE
DP-20029: Fixed search button behavior caused by resize events on phones

### DIFF
--- a/changelogs/DP-20029.yml
+++ b/changelogs/DP-20029.yml
@@ -1,0 +1,6 @@
+Fixed:
+  - project: Patternlab
+    component: Header
+    description: Fixed search button issues caused by resize events (#1187)
+    issue: DP-20029
+    impact: Patch

--- a/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
+++ b/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
@@ -786,7 +786,7 @@ window.addEventListener("resize", function () {
   const osInfo = navigator.appVersion;
   // On Android devices resize event is triggered when keyboard appears
   // and it closes the menu.
-  if (osInfo.indexOf("Android") === -1) {
+  if (osInfo.indexOf("Android") === -1 && osInfo.indexOf("iPhone") === -1) {
     debouncer = setTimeout(() => {
       closeMenu();
       hamburgerMenuAlertScrolling();


### PR DESCRIPTION
## Description
Fixes issue with search buttons not responding on some devices.

## Related Issue / Ticket

- [JIRA issue](https://jira.mass.gov/browse/DP-20029)

## Steps to Test
1. See the ticket for devices, OS versions, and browsers to test. When you click on the search button, it should consistently respond. This ticket does not address differences in scroll behavior between devices, it should simply show that the button now responds to presses.

## Screenshots 
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

*

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
