### PR TITLE
DP-20037 Retain scrolled position at the menu closes

### DIFF
--- a/changelogs/DP-20037.yml
+++ b/changelogs/DP-20037.yml
@@ -1,0 +1,6 @@
+Removed:
+  - project: Patternlab
+    component: Header
+    description: Remove top position value to set 0 when the menu closes. (#1188)
+    issue: DP-20037
+    impact: Patch

--- a/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
+++ b/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
@@ -578,9 +578,6 @@ function commonCloseMenuTasks() {
   if (body.style.position === "fixed") {
     body.style.position = "relative";
   }
-  if (body.style.top !== 0) {
-    body.style.top = 0;
-  }
 
   if (document.querySelector("html.stickyTOCtmp")) {
     document.querySelector("html.stickyTOCtmp").classList.add("stickyTOC");

--- a/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
+++ b/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
@@ -634,19 +634,19 @@ function openMenu() {
 function commonOpenMenuTasks() {
   body.classList.add("show-menu");
 
-  // if (osInfo.indexOf("iPhone") !== -1) {
+  if (osInfo.indexOf("iPhone") !== -1) {
     let heightAboveNavContainer = document.querySelector(".ma__header__hamburger__nav-container").getBoundingClientRect().top;
 
     if (heightAboveNavContainer > 0) {
-      // if (osInfo.indexOf("Version/12.") !== -1 || osInfo.indexOf("Version/11.") !== -1 || osInfo.indexOf("Version/12.") !== -1 || osInfo.indexOf("Version/10.") !== -1)  {
+      if (osInfo.indexOf("Version/12.") !== -1 || osInfo.indexOf("Version/11.") !== -1 || osInfo.indexOf("Version/12.") !== -1 || osInfo.indexOf("Version/10.") !== -1)  {
         let bodyOffset = document.querySelector(".ma__header__hamburger").getBoundingClientRect().top - 80;
         document.querySelector(".show-menu").style.top = `-${bodyOffset}px`;
         document.querySelector(".show-menu").style.position = "fixed";
-      // }
+      }
     }
     // The height setting makes the menu container scroll.
     hamburgerMenuContainer.style.height = "calc(100vh - 150px)";
-  // }
+  }
 
   if (document.querySelector("html.stickyTOC")) {
     document.querySelector("html.stickyTOC").classList.add("stickyTOCtmp");

--- a/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
+++ b/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
@@ -650,19 +650,19 @@ function openMenu() {
 function commonOpenMenuTasks() {
   body.classList.add("show-menu");
 
-  if (osInfo.indexOf("iPhone") !== -1) {
+  // if (osInfo.indexOf("iPhone") !== -1) {
     let heightAboveNavContainer = document.querySelector(".ma__header__hamburger__nav-container").getBoundingClientRect().top;
 
     if (heightAboveNavContainer > 0) {
-      if (osInfo.indexOf("Version/12.") !== -1 || osInfo.indexOf("Version/11.") !== -1 || osInfo.indexOf("Version/12.") !== -1 || osInfo.indexOf("Version/10.") !== -1)  {
+      // if (osInfo.indexOf("Version/12.") !== -1 || osInfo.indexOf("Version/11.") !== -1 || osInfo.indexOf("Version/12.") !== -1 || osInfo.indexOf("Version/10.") !== -1)  {
         let bodyOffset = document.querySelector(".ma__header__hamburger").getBoundingClientRect().top - 80;
         document.querySelector(".show-menu").style.top = `-${bodyOffset}px`;
         document.querySelector(".show-menu").style.position = "fixed";
-      }
+      // }
     }
     // The height setting makes the menu container scroll.
     hamburgerMenuContainer.style.height = "calc(100vh - 150px)";
-  }
+  // }
 
   if (document.querySelector("html.stickyTOC")) {
     document.querySelector("html.stickyTOC").classList.add("stickyTOCtmp");


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/develop/docs/for-developers/changelog-instructions.md)


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
Set the page elements stays where they were while the menu was open when it closes.

## Related Issue / Ticket

- [JIRA issue](https://jira.mass.gov/browse/DP-20037)

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Go to http://localhost:3000/patterns/05-pages-Homepage-hamburger/05-pages-Homepage-hamburger.html in;
- iPhone 8 / ios 12
- iPhone XR / ios 12
- iPhone 7 / ios 10

2. Open the menu, then close it.  See the page elements stays where they were scrolled up at opening the menu, not scroll up to the top of the page.

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

*

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
