### PR TITLE
DP-20039 fix Safari closing issue

### DIFF
--- a/assets/scss/03-organisms/_header-hamburger.scss
+++ b/assets/scss/03-organisms/_header-hamburger.scss
@@ -421,7 +421,6 @@ body.show-menu {
     & svg {
       fill: $c-white;
       height: 20px;
-      -webkit-transition: fill .4s;
       -o-transition: fill .4s;
       transition: fill .4s;
       width: 20px;

--- a/changelogs/DP-20039.yml
+++ b/changelogs/DP-20039.yml
@@ -1,0 +1,6 @@
+Removed:
+  - project: Patternlab
+    component: Header
+    description: Remove transition value causing Safari to crash in iOS 12. (#1189)
+    issue: DP-20039
+    impact: Patch


### PR DESCRIPTION
## Description
This PR addresses an issue that has been reported at various times with iOS and Safari related to browsers crashing when using certain webkit attributes, in this case transition. Transition unprefixed is supported in iOS12, so I removed the webkit-prefixed version.

## Related Issue / Ticket

- [JIRA issue](https://jira.mass.gov/browse/DP-20039)

## Steps to Test

1. Open the Drupal site in iOS 12 for iPhones 7 and 8.
 
## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

*

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
