### PR TITLE
DP-20038 Alert position and Menu scroll

### DIFF
--- a/assets/scss/01-atoms/global/_elements.scss
+++ b/assets/scss/01-atoms/global/_elements.scss
@@ -40,6 +40,7 @@ html {
 
 
 body {
+  width: 100vw;
   margin: 0;
   font-size: 1.375rem;
   line-height: 1.5;

--- a/changelogs/DP-20038.yml
+++ b/changelogs/DP-20038.yml
@@ -1,0 +1,20 @@
+Fixed:
+  - project: Patternlab
+    component: Header
+    description: Fix the page not to scroll up to the top of the page as the menu closes. (#1190)
+    issue: DP-20037
+    impact: Patch
+
+Fixed:
+  - project: Patternlab
+    component: Header
+    description: Fix the alert shifts as sub components open in the menu container. (#1190)
+    issue: DP-20038
+    impact: Patch
+
+Fixed:
+  - project: Patternlab
+    component: Header
+    description: Enable scrolling in the menu container to the bottom. (#1190)
+    issue: DP-20038
+    impact: Patch

--- a/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
+++ b/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
@@ -1,6 +1,7 @@
 const osInfo = navigator.appVersion;
 const body = document.querySelector("body");
 let width = body.clientWidth;
+let alertlOffsetPosition;
 const feedbackButton = document.querySelector(".ma__fixed-feedback-button");
 const menuBarHeight = document.querySelector(".ma__header__hamburger__nav") ? document.querySelector(".ma__header__hamburger__nav").offsetHeight : null;
 const menuOverlay = document.querySelector(".menu-overlay");
@@ -571,16 +572,21 @@ function closeMenu() {
     document.querySelector(".js-utility-nav--wide .ma__utility-nav__item .js-util-nav-toggle").removeAttribute("tabindex");
     document.querySelector(".js-header-search-access-button").removeAttribute("tabindex");
   }
+
+  if (body.style.position === "fixed") {
+    body.style.position = "relative";
+  }
+  // When the page is loaded first time, body initially has "top: 0;".
+  // As the menu closes, reset the override top value to 0.
+  if (body.style.top.indexOf("-") !== -1) {
+    body.style.top = 0;
+  }
+  // At the same time, the alert needs to be scrolled up to the position again to retain the page elements position.
+  window.scrollTo(0, alertlOffsetPosition);
 }
 
 function commonCloseMenuTasks() {
   body.classList.remove("show-menu");
-  if (body.style.position === "fixed") {
-    body.style.position = "relative";
-  }
-  if (body.style.top !== 0) {
-    body.style.top = 0;
-  }
 
   if (document.querySelector("html.stickyTOCtmp")) {
     document.querySelector("html.stickyTOCtmp").classList.add("stickyTOC");
@@ -620,36 +626,31 @@ function openMenu() {
   let alertsHeader = document.querySelector(".ma__emergency-alerts__header");
   if (alertsHeader !== null) {
     let emergencyAlerts = document.querySelector(".ma__emergency-alerts");
-    let scrollOffset = emergencyAlerts.offsetHeight - (alertsHeader.offsetHeight/2);
+
+    let emergencyAlertsHeight = emergencyAlerts.offsetHeight;
+
+    alertlOffsetPosition = emergencyAlertsHeight - (alertsHeader.offsetHeight/2);
     if (navigator.userAgent.match(/iPad|iPhone|iPod|Android|Windows Phone/i)) {
-      customScrollTo(scrollOffset, 250);
+      customScrollTo(alertlOffsetPosition, 250);
+      setTimeout(lockPage(), 250);
     }
     else {
       window.scrollTo({
-        top: scrollOffset,
+        top: alertlOffsetPosition,
         left: 0,
         behavior: "smooth"
       });
+      lockPage();
     }
+    function lockPage () {
+      document.querySelector("body").style.top = `-${alertlOffsetPosition}px`;
+      document.querySelector("body").style.position = "fixed";
+    };
   }
 }
 
 function commonOpenMenuTasks() {
   body.classList.add("show-menu");
-
-  if (osInfo.indexOf("iPhone") !== -1) {
-    let heightAboveNavContainer = document.querySelector(".ma__header__hamburger__nav-container").getBoundingClientRect().top;
-
-    if (heightAboveNavContainer > 0) {
-      if (osInfo.indexOf("Version/12.") !== -1 || osInfo.indexOf("Version/11.") !== -1 || osInfo.indexOf("Version/12.") !== -1 || osInfo.indexOf("Version/10.") !== -1)  {
-        let bodyOffset = document.querySelector(".ma__header__hamburger").getBoundingClientRect().top - 80;
-        document.querySelector(".show-menu").style.top = `-${bodyOffset}px`;
-        document.querySelector(".show-menu").style.position = "fixed";
-      }
-    }
-    // The height setting makes the menu container scroll.
-    hamburgerMenuContainer.style.height = "calc(100vh - 150px)";
-  }
 
   if (document.querySelector("html.stickyTOC")) {
     document.querySelector("html.stickyTOC").classList.add("stickyTOCtmp");

--- a/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
+++ b/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
@@ -578,6 +578,7 @@ function closeMenu() {
   }
   // When the page is loaded first time, body initially has "top: 0;".
   // As the menu closes, reset the override top value to 0.
+  // Note: The top value is recognized as a string, not number.
   if (body.style.top.indexOf("-") !== -1) {
     body.style.top = 0;
   }
@@ -631,9 +632,7 @@ function openMenu() {
   let alertsHeader = document.querySelector(".ma__emergency-alerts__header");
   if (alertsHeader !== null) {
     let emergencyAlerts = document.querySelector(".ma__emergency-alerts");
-
     let emergencyAlertsHeight = emergencyAlerts.offsetHeight;
-
     alertlOffsetPosition = emergencyAlertsHeight - (alertsHeader.offsetHeight/2);
     if (navigator.userAgent.match(/iPad|iPhone|iPod|Android|Windows Phone/i)) {
       customScrollTo(alertlOffsetPosition, 250);
@@ -650,8 +649,8 @@ function openMenu() {
     // Set the nav container height to enable scrolling to the bottom.
     let heightAboveMenuContainer = hamburgerMenuContainer.getBoundingClientRect().top;
     if (osInfo.indexOf("iPhone") !== -1) {
-      let removeFromHeight = heightAboveMenuContainer + 15;
-      hamburgerMenuContainer.style.height = `calc(100vh - ${removeFromHeight}px)`;
+      let subtractFromMenuHeight = heightAboveMenuContainer + 15;
+      hamburgerMenuContainer.style.height = `calc(100vh - ${subtractFromMenuHeight}px)`;
       hamburgerMenuContainer.style.paddingBottom = "20px";
     }
     else {

--- a/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
+++ b/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
@@ -621,6 +621,11 @@ function commonCloseMenuTasks() {
 }
 
 function openMenu() {
+  let lockPage = function () {
+    document.querySelector("body").style.top = `-${alertlOffsetPosition}px`;
+    document.querySelector("body").style.position = "fixed";
+  };
+
   commonOpenMenuTasks();
   menuButton.setAttribute("aria-pressed", "true");
   let alertsHeader = document.querySelector(".ma__emergency-alerts__header");
@@ -642,10 +647,6 @@ function openMenu() {
       });
       lockPage();
     }
-    function lockPage () {
-      document.querySelector("body").style.top = `-${alertlOffsetPosition}px`;
-      document.querySelector("body").style.position = "fixed";
-    };
   }
 }
 

--- a/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
+++ b/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
@@ -647,6 +647,16 @@ function openMenu() {
       });
       lockPage();
     }
+    // Set the nav container height to enable scrolling to the bottom.
+    let heightAboveMenuContainer = hamburgerMenuContainer.getBoundingClientRect().top;
+    if (osInfo.indexOf("iPhone") !== -1) {
+      let removeFromHeight = heightAboveMenuContainer + 15;
+      hamburgerMenuContainer.style.height = `calc(100vh - ${removeFromHeight}px)`;
+      hamburgerMenuContainer.style.paddingBottom = "20px";
+    }
+    else {
+      hamburgerMenuContainer.style.height = `calc(100vh - ${heightAboveMenuContainer}px)`;
+    }
   }
 }
 


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/develop/docs/for-developers/changelog-instructions.md)


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
- Lock the alert position where it's scrolled while the menu the open.
- Set the nav container height as the menu opens to enable scrolling to the bottom of the container.
- Scroll the alert to the position where it was when the menu opened when the menu closes and `top` of `<body>` gets reset to value 0.  So, as the menu closes, the page elements stays where they were while the menu was open.  No scroll up to the top of the page.

## Related Issue / Ticket

- [JIRA issue](https://jira.mass.gov/browse/DP-20038)
- [JIRA issue](https://jira.mass.gov/browse/DP-20037)


## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Go to http://localhost:3000/patterns/05-pages-Homepage-hamburger/05-pages-Homepage-hamburger.html.

2. Open the menu, then close it.  See the page elements stays where they were scrolled up at opening the menu, not scroll up to the top of the page in:
    - iPhone 8 / ios 12
    - iPhone XR / ios 12
    - iPhone 7 / ios 10

2. Open the menu, then open sub menus and log in to sub elements. Find;
    -  the alerts remains where it's scrolled, doesn't shift its position vertically,
    -  you can scroll the nav container to the bottom to see the last element in the container,
 in:
     - Win 10 / Edge 85
     - Win 10 / Chrome 85
     - Catalina / Chrome 85
     - Mojave / Chrome 85
     - High Sierra / Chrome 85
     - Yosemite / Chrome 85


## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

*

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
