### PR TITLE
DP-20054 S7 search button

### DIFF
--- a/changelogs/DP-20054.yml
+++ b/changelogs/DP-20054.yml
@@ -1,0 +1,7 @@
+Fixed:
+  - project: Patternlab
+    component: Header
+    description: Addresses a timing issue with jump to search that prevented it from working on some Android devices. (#1191)
+    issue: DP-20054
+    impact: Patch
+  

--- a/changelogs/DP-20054.yml
+++ b/changelogs/DP-20054.yml
@@ -4,4 +4,3 @@ Fixed:
     description: Addresses a timing issue with jump to search that prevented it from working on some Android devices. (#1191)
     issue: DP-20054
     impact: Patch
-  

--- a/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
+++ b/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
@@ -735,7 +735,7 @@ function jumpToSearch(e) {
       jumpToSearchButton.setAttribute("aria-pressed", "true");
       searchInput.setAttribute("autofocus", "");
       searchInput.focus();
-    }, 100);
+    }, 200);
   }
 }
 


### PR DESCRIPTION
## Description
When pressing search button after having used menu, the previous menu scroll and open state is remembered and the search box is sometimes not visible.

## Related Issue / Ticket

- [JIRA issue](https://jira.mass.gov/browse/DP-20054)


## Steps to Test


1. On a Galaxy S7 in Chrome, open the menu, expand some items, then close it.
2. Open the search. This should now open and focus on the search field.

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

*

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
