### PR TITLE
DP-20055 fix Firefox overlay

### DIFF
--- a/changelogs/DP-20055.yml
+++ b/changelogs/DP-20055.yml
@@ -1,0 +1,6 @@
+Removed:
+  - project: Patternlab
+    component: Header
+    description: Removed Firefox-specific code causing menu overlay issues in Firefox. (#1192)
+    issue: DP-20055
+    impact: Patch

--- a/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
+++ b/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
@@ -713,11 +713,7 @@ function commonOpenMenuTasks() {
 function offsetMenuOverlay () {
   let overlayOffset = document.querySelector(".ma__header__hamburger").getBoundingClientRect().top + menuBarHeight;
   if (width > 840) {
-    if (navigator.userAgent.indexOf("Firefox") !== -1) {
-      overlayOffset = overlayOffset - 14;
-    } else {
-      overlayOffset = overlayOffset -1;
-    }
+    overlayOffset = overlayOffset -1;
   }
   menuOverlay.style.top = overlayOffset + "px";
 }


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/develop/docs/for-developers/changelog-instructions.md)


## Description
This fixes an issue with the menu overlay in Firefox desktop browsers in Mac and Windows.

## Related Issue / Ticket

- [JIRA issue](https://jira.mass.gov/browse/DP-20055)

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Try opening the menu in Firefox for Mac and Windows. The overlay should no longer overlap the blue menu bar.

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

*

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
