### PR TITLE
DP-20085 Fixed sticky TOC for new global nav

### DIFF
--- a/assets/scss/03-organisms/_sticky-toc.scss
+++ b/assets/scss/03-organisms/_sticky-toc.scss
@@ -306,7 +306,7 @@
     height: 0;
     overflow: hidden;
     position: fixed;
-    top: 40px;
+    top: 0;
     left: 0;
     transition: height 0.1s ease-out;
     width: 100%;
@@ -457,7 +457,7 @@
   width: 100%;
   height: 100%;
   max-width: 550px;
-  top: 40px;
+  top: 0;
   z-index: 99;
   background-color: $c-white;
   transition: right 0.3s ease-out;

--- a/changelogs/DP-20085.yml
+++ b/changelogs/DP-20085.yml
@@ -1,0 +1,6 @@
+Fixed:
+  - project: Patternlab
+    component: Header
+    description: Fixed sticky TOC on the newer global nav. (#1194)
+    issue: DP-20085
+    impact: Patch


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/develop/docs/for-developers/changelog-instructions.md)


## Description
This sticky menu was previously expecting a sticky main menu to go with it.

## Related Issue / Ticket

- [JIRA issue](https://jira.mass.gov/browse/DP-20085)

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Update your local openmass environment to work with this branch
2. Go to http://mass.local/info-details/covid-19-updates-and-information
3. Scroll down the page to show the sticky TOC.
4. Open up menu items to check that submenus also stay on top

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

There is also a data-sticky attribute on these items that have the same set top positioning, but I can't see where/if this is actually used. Additionally, it might be worth verifying if there is anything else sticky beyond TOC that might need some adjustment.

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

*

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
