### PR TITLE
DP-20163 Remove extra space between the search component and the main menu in the menu container

### DIFF
--- a/assets/scss/03-organisms/_header-hamburger.scss
+++ b/assets/scss/03-organisms/_header-hamburger.scss
@@ -285,6 +285,11 @@ body.show-menu {
     .translated-ltr & {
       top: 44px;
     }
+
+    & .ma__header__nav-search {
+      margin-bottom: 0;
+      border-bottom: 0;
+    }
   }
 
   &__main-nav {

--- a/changelogs/DP-20163.yml
+++ b/changelogs/DP-20163.yml
@@ -1,0 +1,6 @@
+Changed:
+  - project: Patternlab
+    component: header
+    description: Remove extra space and bottom border from the search component in menu container. (#1201)
+    issue: DP-20163
+    impact: Patch


### PR DESCRIPTION
… container

<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/develop/docs/for-developers/changelog-instructions.md)


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
Remove the bottom margin and the bottom border from the search component in the menu container.

## Related Issue / Ticket

- [JIRA issue](https://jira.mass.gov/browse/DP-20163)
- [Github issue]()

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Go to http://localhost:3000/patterns/05-pages-Homepage-hamburger/05-pages-Homepage-hamburger.html in mobile view.
2. Find no extra space and border below the search component in the menu container.

## Screenshots
Before
<img width="783" alt="before" src="https://user-images.githubusercontent.com/9633303/95355017-162a0780-0893-11eb-89e4-4e251408906d.png">

After
<img width="465" alt="after" src="https://user-images.githubusercontent.com/9633303/95354997-11fdea00-0893-11eb-98e9-8db3a3050ad0.png">


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

*

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
