### PR TITLE
DP-20176 Utility nav item container open/close state icon

### DIFF
--- a/assets/scss/03-organisms/_sticky-toc.scss
+++ b/assets/scss/03-organisms/_sticky-toc.scss
@@ -305,15 +305,17 @@
     height: 0;
     overflow: hidden;
     position: fixed;
-    top: 40px;
+    top: 0;
     left: 0;
     transition: height 0.1s ease-out;
     width: 100%;
     background-color: $c-bg-subtle;
-    z-index: 79;
+    z-index: $z-sticky-content;
 
-    @media ($bp-header-toggle-min) {
-      top: 0;
+    @media ($bp-header-toggle-max) {
+      // Sticky toc is over the nav bar.
+      $z-sticky-content: 101;
+      z-index: $z-sticky-content;
     }
   }
 }

--- a/changelogs/DP-20176.yml
+++ b/changelogs/DP-20176.yml
@@ -5,7 +5,7 @@ Fixed:
     issue: DP-20085
     impact: Patch
 Changed:
-  - project: React
+  - project: Patternlab
     component: Header
     description: Fix utility sub container open/close state icon with keyboard navigation. (#1205)
     issue: DP-20176

--- a/changelogs/DP-20176.yml
+++ b/changelogs/DP-20176.yml
@@ -1,0 +1,12 @@
+Fixed:
+  - project: Patternlab
+    component: StickyTOC
+    description: Put back the lost fix for sticky TOC positioning. (#1205)
+    issue: DP-20085
+    impact: Patch
+Changed:
+  - project: React
+    component: Header
+    description: Fix utility sub container open/close state icon with keyboard navigation. (#1205)
+    issue: DP-20176
+    impact: Patch

--- a/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
+++ b/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
@@ -241,6 +241,7 @@ if (menuButton !== null) {
               utilNarrowButton.focus();
             }
           }
+          closeNarrowUtilContent();
         }
         else {
           let narrowNavItems = utilNarrowNav.querySelectorAll(".ma__utility-nav__link");


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/develop/docs/for-developers/changelog-instructions.md)


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->

Correct the close state of the utility nav item sub unit open/close state when the sub unit was closed via keyboard.

Put back the lost fix for the sticky TOC positioning. (This was merged into the integration branch, but it seems it got lost while other PRs were merged or resolving merge conflicts.)

## Related Issue / Ticket

- [JIRA issue](https://jira.mass.gov/browse/DP-20176)
- [Github issue]()

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Go to http://localhost:3000/patterns/05-pages-Homepage-hamburger/05-pages-Homepage-hamburger.html.

2. In mobile view to display the utility nav items in the menu container, open the log in to sub unit.

3. While the log in to button has focus, tab into the sub unit. Make sure one of the sub item links has focus.

4. Hit ESC to close the sub container.  Find the log in to button's icon on the right has "+" to indicate the sub unit is close.

TEST for DP-20085 fix:

1. Go to http://localhost:3000/patterns/05-pages-information-details/05-pages-information-details.html.

2. In the window size 840 px and less, scroll up the page to show the sticky nav.

3. As scrolling up, the sticky TOC stays at the very top of the page with no space between to see the blue nav bar between the window top and the sticky TOC.  Also, the sticky TOC overlaps the blue nav bar.

After
<img width="503" alt="after" src="https://user-images.githubusercontent.com/9633303/95620527-537ec880-0a3e-11eb-8a82-c060bb31e72a.png">

Before
<img width="521" alt="before" src="https://user-images.githubusercontent.com/9633303/95620545-5aa5d680-0a3e-11eb-8a7a-c1dcfd1c310b.png">





## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

*

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
