### PR TITLE
DP-20181 Focus from the linked logo in the menu to the menu button

### DIFF
--- a/changelogs/DP-20181.yml
+++ b/changelogs/DP-20181.yml
@@ -1,0 +1,6 @@
+Fixed:
+  - project: Patternlab
+    component: Header
+    description: Set focus on the menu button from the logo link in the menu container with shift + tab. (#1206)
+    issue: DP-20181
+    impact: Patch

--- a/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
+++ b/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
@@ -136,6 +136,17 @@ if (menuButton !== null) {
     }
   });
 
+  const logoLink = document.querySelector(".ma__header__hamburger__nav-container .ma__header__hamburger__logo--mobile a");
+  if(logoLink) {
+    logoLink.addEventListener("keydown", function (e) {
+      if ((e.shiftKey && e.key === "Tab") || (e.shiftKey && e.code === "Tab")) {
+        setTimeout(function timeoutFunction() {
+          document.querySelector(".js-header-menu-button").focus();
+        }, 100);
+      }
+    });
+  }
+
   const firstTopMenuItem = document.querySelector(".ma__header__hamburger__nav .ma__main__hamburger-nav__item:first-of-type .js-main-nav-hamburger__top-link");
   // To accomodate both button and link as the last top menu item, use 'ma__' classes instead of 'js-'.
   const lastTopMenuItem = document.querySelector(".ma__main__hamburger-nav__item:last-of-type .ma__main__hamburger-nav__top-link");


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/develop/docs/for-developers/changelog-instructions.md)


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
Fix focus from the linked logo to the menu button with SHIFT + TAB. It used to set focus on the search icon on the blue nav bar.

## Related Issue / Ticket

- [JIRA issue](https://jira.mass.gov/browse/DP-20181)
- [Github issue]()

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Go to http://localhost:3000/patterns/05-pages-Homepage-hamburger/05-pages-Homepage-hamburger.html.

2. In mobile view, open the menu and tab to the logo link, which is the first active element in the menu container.

3. SHIFT + TAB to move focus.

4. Find focus is set on the menu button.  After the step 3, hitting ENTER will closes the menu if the menu button has focus. 

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

*

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
