### PR TITLE
DP-20201: Fix scroll issues noticed on iOS

### DIFF
--- a/changelogs/DP-20201.yml
+++ b/changelogs/DP-20201.yml
@@ -1,0 +1,11 @@
+Fixed:
+  - project: Patternlab
+    component: Header
+    description: Move window scrollTo and remove inline body styling when closing the global nav menu. (#1210)
+    issue: DP-20201
+    impact: Patch
+  - project: Patternlab
+    component: Header
+    description: Move window scrollTo and remove inline body styling when closing the global nav menu. (#1210)
+    issue: DP-20209
+    impact: Patch

--- a/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
+++ b/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
@@ -462,16 +462,10 @@ function closeMenu() {
   }
 
   if (body.style.position === "fixed") {
-    body.style.position = "relative";
+    // At the same time, the alert needs to be scrolled up to the position again to retain the page elements position.
+    window.scrollTo(0, alertlOffsetPosition);
+    body.removeAttribute("style");
   }
-  // When the page is loaded first time, body initially has "top: 0;".
-  // As the menu closes, reset the override top value to 0.
-  // Note: The top value is recognized as a string, not number.
-  if (body.style.top.indexOf("-") !== -1) {
-    body.style.top = 0;
-  }
-  // At the same time, the alert needs to be scrolled up to the position again to retain the page elements position.
-  window.scrollTo(0, alertlOffsetPosition);
 }
 
 function commonCloseMenuTasks() {


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/develop/docs/for-developers/changelog-instructions.md)


## Description
This fix addresses an issue noticed on iOS devices, especially iPads, where the scroll position would jump up when trying to scroll down the page.

## Related Issue / Ticket

- [JIRA issue](https://jira.mass.gov/browse/DP-20201)
- [JIRA issue](https://jira.mass.gov/browse/DP-20209)

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

For DP-20201:
1. Go to page, such as http://mass.local/topics/higher-education
2. Open the menu
3. Close the menu
4. Scroll down the page. The scroll position should no longer jump to the top of the page.

For DP-20209:
1. Go to page, such as http://mass.local/topics/legal-justice 
2. Open the menu
3. Close the menu
4. Reopen the menu
4. Scroll down the menu, which should now scroll

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

*

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
