### PR TITLE
DP-20279 Set up a specific task order for Safari 13 in MacOS

### DIFF
--- a/changelogs/DP-20279.yml
+++ b/changelogs/DP-20279.yml
@@ -1,0 +1,6 @@
+Fixed:
+  - project: Patternlab
+    component: Header
+    description: Handle the menu closing tasks differently in Safari 13 on MacOS. (#1225)
+    issue: DP-20279
+    impact: Patch

--- a/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
+++ b/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
@@ -378,10 +378,21 @@ function closeMenu() {
   }
 
   if (body.style.position === "fixed") {
-    // At the same time, the alert needs to be scrolled up to the position again to retain the page elements position.
-    body.removeAttribute("style");
-    body.style.position = "relative";
-    window.scrollTo(0, alertlOffsetPosition);
+    // navigator.appVersion in Chrome contains "Safari", so needs to exclude it to target Safari.
+    if (osInfo.indexOf("Mac") != -1 && osInfo.indexOf("Safari") != -1 && osInfo.indexOf("Version/13") !== -1 && osInfo.indexOf("Chrome") === -1) {
+      body.style.position = "relative";
+      window.scrollTo(0, alertlOffsetPosition);
+      body.style.top = 0;
+    } else {
+      // At the same time, the alert needs to be scrolled up to the position again to retain the page elements position.
+      body.removeAttribute("style");
+      body.style.position = "relative";
+      window.scrollTo(0, alertlOffsetPosition);
+    }
+    // // At the same time, the alert needs to be scrolled up to the position again to retain the page elements position.
+    // body.removeAttribute("style");
+    // body.style.position = "relative";
+    // window.scrollTo(0, alertlOffsetPosition);
   }
 }
 

--- a/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
+++ b/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
@@ -389,10 +389,6 @@ function closeMenu() {
       body.style.position = "relative";
       window.scrollTo(0, alertlOffsetPosition);
     }
-    // // At the same time, the alert needs to be scrolled up to the position again to retain the page elements position.
-    // body.removeAttribute("style");
-    // body.style.position = "relative";
-    // window.scrollTo(0, alertlOffsetPosition);
   }
 }
 


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/develop/docs/for-developers/changelog-instructions.md)


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
In Safari 13 on MacOS, as the menu closes, the task to scroll up the page seems to run with some delay comparing to other browsers + OS.

Targeting Safari 13 on MacOS, in the closeMenu function, changed the order of the tasks.

## Related Issue / Ticket

- [JIRA issue](https://jira.mass.gov/browse/DP-20279)
- [Github issue]()

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Go to any page, but Home.
2. Open the menu, then close.
3. Check if the scrolling is obvious or not.  If not, the fix is working.

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

*

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
