### PR TITLE
React/styles followup

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -112,7 +112,6 @@
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-react": "^7.20.0",
     "eslint-plugin-react-hooks": "^2.5.0",
-    "github-markdown-css": "^3.0.1",
     "gulp": "^4.0.2",
     "gulp-babel": "^8.0.0",
     "gulp-rename": "^2.0.0",

--- a/packages/react/src/components/styles/_global.scss
+++ b/packages/react/src/components/styles/_global.scss
@@ -3,9 +3,8 @@
 @forward "00-base/configure" with (
   $assets-path: "~@massds/mayflower-assets/static" !default,
   $fonts-enable-rtl: true !default,
-  $fonts-langs-support: false
+  $fonts-langs-support: true
 );
-@forward "00-base/z-index";
 @use "00-base/elements";
 @use "00-base/layout";
 @use "00-base/fonts";

--- a/packages/react/src/markdown.scss
+++ b/packages/react/src/markdown.scss
@@ -1,1 +1,0 @@
-@import '../node_modules/github-markdown-css/github-markdown.css';


### PR DESCRIPTION
v10 followup:
- removed unused github markdown css
- fix typography story language support

Before:
https://mayflower.digital.mass.gov/react/index.html?path=/docs/brand-typography--noto-sans (live)
![Screen Shot 2020-10-28 at 9 42 22 AM](https://user-images.githubusercontent.com/5789411/97443914-f0c47280-1901-11eb-8ec7-87949204f79f.png)


After:
![Screen Shot 2020-10-28 at 9 41 22 AM](https://user-images.githubusercontent.com/5789411/97443910-f02bdc00-1901-11eb-8738-b8a0bcd99f57.png)