### PR TITLE
change path to be relative to current directory

### DIFF
--- a/changelogs/hotfix-patternlab-sitelogo-prod.yml
+++ b/changelogs/hotfix-patternlab-sitelogo-prod.yml
@@ -1,0 +1,6 @@
+Fixed:
+  - project: Patternlab
+    component: SiteLogo
+    description: Set Patternlab SiteLogo global path in patternlab to be relative to the current path in order to fix production urls. (#1254)
+    issue:
+    impact: Patch

--- a/packages/patternlab/styleguide/source/_data/data.json
+++ b/packages/patternlab/styleguide/source/_data/data.json
@@ -5,6 +5,6 @@
   "bodyClass": "",
   "directory": "assets",
   "googleLanguages": "ar,es,fr,pt,ht,it,km,ko,ru,vi,zh-CN",
-  "sealImage": "/assets/images/logo/stateseal.png",
+  "sealImage": "./assets/images/logo/stateseal.png",
   "comment": "See \\PatternLab\\DynamicDataListener for further dynamic properties."
 }

--- a/packages/patternlab/styleguide/source/_data/data.json
+++ b/packages/patternlab/styleguide/source/_data/data.json
@@ -5,6 +5,6 @@
   "bodyClass": "",
   "directory": "assets",
   "googleLanguages": "ar,es,fr,pt,ht,it,km,ko,ru,vi,zh-CN",
-  "sealImage": "./assets/images/logo/stateseal.png",
+  "sealImage": "../../assets/images/logo/stateseal.png",
   "comment": "See \\PatternLab\\DynamicDataListener for further dynamic properties."
 }


### PR DESCRIPTION
On v10.1.0 production sites, the production urls for the sitelogo are relative to the root path. Fixing the path in patternlab to allow site logo to render in all places.
![Screen Shot 2020-11-02 at 10 40 12 AM](https://user-images.githubusercontent.com/5789411/97887728-4af57700-1cf8-11eb-96f0-b4ab2e4039e2.png)
![Screen Shot 2020-11-02 at 10 40 39 AM](https://user-images.githubusercontent.com/5789411/97887731-4b8e0d80-1cf8-11eb-81bb-ae07ad05cecf.png)

https://mayflower.digital.mass.gov/patternlab/
https://mayflower.digital.mass.gov/patternlab/v/10.1.0
