### PR TITLE
DP-20499 Push up the sticky nav to the top of the page with screen width 780px and less

### DIFF
--- a/changelogs/DP-20499.yml
+++ b/changelogs/DP-20499.yml
@@ -1,0 +1,6 @@
+Fixed:
+  - project: Patternlab
+    component: StickyNav
+    description: Align stikcy nav to the top of the page with screen width 780px and less. (#1268)
+    issue: DP-20499
+    impact: Minor

--- a/packages/assets/scss/02-molecules/_sticky-nav.scss
+++ b/packages/assets/scss/02-molecules/_sticky-nav.scss
@@ -62,7 +62,7 @@
 
   &[data-sticky='middle'] {
     position: fixed;
-    top: 40px;
+    top: 0;
     z-index: $z-overlay;
 
     .translated-rtl &,


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/develop/docs/for-developers/changelog-instructions.md)


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
Align the sticky nav to the top of the page with screen size 780px and less. 

## Related Issue / Ticket

- [JIRA issue](https://jira.mass.gov/browse/DP-20499)
- [Github issue]()

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1.  Go to /patternlab/patterns/05-pages-location-general-content/05-pages-location-general-content.html with the window width 780px or smaller.

2. Scroll down the page where the sticky nav is displayed.

3. Find the sticky nav is lined up to the top of the page and there is no space between them.

## Screenshots
Before
<img width="431" alt="MF-before" src="https://user-images.githubusercontent.com/9633303/99114849-7cefbe80-25bf-11eb-9abe-547fdad4021c.png">

After
<img width="488" alt="MF-after" src="https://user-images.githubusercontent.com/9633303/99122487-6734c600-25cc-11eb-8bdf-0fee703d6ae8.png">




## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

*

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
