### PR TITLE
Docs/more-formstack-updates

### DIFF
--- a/packages/starters/formstack/mayflower-theme.css
+++ b/packages/starters/formstack/mayflower-theme.css
@@ -1,0 +1,282 @@
+/* layout */
+.fsBody  {
+    padding: 0;
+    margin-top: 60px;
+
+}
+.fsBody .fsForm {
+    font-family: 'texta';
+    font-size: 22px;
+    font-size: 1.375rem;
+    line-height: 1.5;
+    margin: 0;
+    padding: 0;
+    max-width: 50rem;
+}
+
+
+/* Headline */
+
+
+.fsBody .fsSectionHeader {
+    background-color: transparent;
+    padding: 0;
+    margin-bottom: 20px;
+}
+.fsBody .fsSectionHeader .fsSectionHeading {
+    text-align: left;
+    position: relative;
+    padding-bottom: 15px;
+    color: #535353;
+    font-weight: 700;
+    font-size: 48px;
+    font-size: 3rem;
+    line-height: 1.07;
+}
+
+.fsBody .fsSectionHeader .fsSectionHeading:after {
+    content: "";
+    height: 3px;
+    position: absolute;
+    bottom: 0;
+    left: 0.075em;
+    width: 1.85em;
+    background-color: rgba(67, 149, 111, 0.5);
+    -webkit-transform: skew(-30deg);
+    -ms-transform: skew(-30deg);
+    transform: skew(-30deg);
+}
+
+
+/* Labels */
+
+.fsBody .fsForm .fsLabel {
+    font-weight: 500;
+    margin-bottom: 0.5rem;
+    display: block;
+    font-size: 22px;
+    font-size: 1.375rem;
+    line-height: 1.5;
+}
+/*.fsBody .fsForm .fsRequiredMarker {
+    display: none;
+}
+*/
+.fsBody .fsForm .fsLabel:not(.fsRequiredLabel):after {
+    content: ' (optional)';
+}
+
+/* Inputs */
+
+.fsBody .fsForm fieldset {
+    border: none;
+    padding-left: 0;
+}
+.fsBody .fsForm input[type="text"].fsField,
+.fsBody .fsForm input[type="email"].fsField,
+.fsBody .fsForm input[type="tel"].fsField {
+    background-color: white;
+    border-color: #dcdcdc !important;
+    color: #535353;
+    border: 2px solid;
+    min-height: 46px;
+    padding: 0 18px;
+}
+.fsBody .fsForm input[type="tel"].fsField {
+    min-width: 12rem;
+}
+.fsBody .fsForm textarea {
+    background-color: white;
+    border-color: #dcdcdc !important;
+    border: 2px solid;
+}
+
+.fsForm select:not([multiple="multiple"]) {
+    background-color: white;
+    border-color: #dcdcdc;
+    border: 2px solid #dcdcdc;
+    background-image: none;
+    max-width: 100%;
+}
+
+.fsBody .fsSubField {
+  margin-top: 10px;
+}
+
+
+/* Matrix */
+.fsMatrix {
+  border-collapse: collapse;
+}
+
+.fsMatrix th, .fsMatrix td {
+  padding: 1em;
+  text-align: center;
+}
+
+
+/* Radios, checkbox */
+
+.fsBody .fsForm .fsOptionLabel {
+    font-size: 22px;
+    font-size: 1.375rem;
+    line-height: 1.5;
+    position: relative;
+}
+.fsBody .fsForm .fsOptionLabel.horizontal {
+    /* Just avoid horizontal radios even if authored that way.*/
+    float: none;
+}
+.fsBody .fsForm .fsOptionLabel input[type="radio"],
+.fsBody .fsForm .fsOptionLabel input[type="checkbox"] {
+    margin-right: 0.5rem;
+    vertical-align: middle;
+}
+.fsBody .fsForm .fsOptionLabel input[type="radio"]:focus,
+.fsBody .fsForm .fsOptionLabel input[type="checkbox"]:focus {
+    box-shadow: none;
+}
+
+@media (max-width: 40em) {
+    .fsBody .fsForm label.fsOptionLabel {
+        background: none;
+        border: none;
+        padding: 10px 0;
+    }
+}
+
+
+/* Supporting text */
+
+.fsBody .fsForm .fsSupporting {
+    font-weight: 300;
+    font-style: italic;
+    font-size: 1rem;
+    line-height: 1.2;
+}
+
+.fsBody .fsField::placeholder {
+  color: #cccccc;
+}
+
+/* Submit */
+
+.fsBody .fsForm input.fsSubmitButton {
+    font-weight: 700;
+    background-color: #14558f !important;
+    color: white;
+    border: 3px solid #14558f;
+    box-shadow: 0 0.25rem 0.5rem rgba(1, 1, 1, 0.25);
+    display: inline-block;
+    letter-spacing: 0.1em;
+    padding: 0.4em 1em;
+    text-decoration: none;
+    text-transform: uppercase;
+    -webkit-transition: all 0.4s ease;
+    transition: all 0.4s ease;
+}
+
+.fsSubmitButton {
+  background-color: #14558f !important;
+}
+
+.fsBody .fsForm input.fsSubmitButton:hover {
+    background-color: rgba(20, 85, 143, 0.75) !important;
+    border-color:  transparent;
+}
+
+.fsBody [data-char-left] {
+    margin-bottom: 1.5rem;
+}
+
+.fsBody .fsCounter {
+    position: absolute;
+    width: .1em;
+    height: .1em;
+    left: -999em;
+    overflow: hidden;
+}
+
+/* Next Button */
+
+.fsNextButton {
+    font-weight: 700;
+    background-color: #14558f !important;
+    color: white;
+    border: 3px solid #14558f;
+    box-shadow: 0 0.25rem 0.5rem rgba(1, 1, 1, 0.25);
+    display: inline-block;
+    letter-spacing: 0.1em;
+    padding: 0.4em 1em;
+    text-decoration: none;
+    text-transform: uppercase;
+    -webkit-transition: all 0.4s ease;
+    transition: all 0.4s ease;
+    float: left !important;
+}
+
+.fsNextButton .fsSlim {
+    display: none;
+}
+
+.fsNextButton:hover {
+    background-color: rgba(20, 85, 143, 0.75) !important;
+    border-color:  transparent;
+}
+
+
+.fhttps://help.formstack.com/hc/en-us/articles/360019519891-Custom-Form-Themes-and-CSSsBody .fsFieldRow {
+    margin-bottom: 3.5rem !important;
+}
+
+.fsBody .fsForm .fsPagination {
+  text-align: left;
+}
+
+.fsBody .fsForm .fsSubmitButton {
+  cursor: pointer;
+}
+
+
+.fsForm, .fsError {
+    float: none !important;
+}
+
+.fsForm  div.fsError {
+    color: white;
+    border-radius: 0;
+    background-color: #f34343;
+    font-weight: bold;
+}
+.fsPage .fsValidationError {
+    background-color: transparent;
+}
+.fsPage .fsValidationError .fsLabel,
+.fsValidationError .fsLabel span,
+div.fsValidationError label.fsLabel{
+    color: #f34343 !important;
+    padding-left: 0;
+    background: none;
+}
+
+.fsPage .fsValidationError input,
+.fsPage .fsValidationError textarea {
+    border: 2px solid #f34343;
+}
+
+
+/* remove branding */
+a[title="Web Form Builder"] {
+    display: none;
+}
+
+/* specifc to given form */
+
+#fsSubmit3193712 {
+    padding-top: 0px !important;
+}
+
+input.fsSubmitButton {
+    font-family: "Texta","Helvetica","Arial",sans-serif;
+    font-size: 1rem;
+}

--- a/packages/starters/formstack/mayflower-theme.css
+++ b/packages/starters/formstack/mayflower-theme.css
@@ -332,3 +332,119 @@ div[fs-field-type="richtext"] a {
     outline: solid;
     outline-color: #487fe0;
 }*/
+
+
+/* standalone theme */
+
+.fsBody .fsForm .fsSectionHeader > .fsSectionText{
+ color: #ffffff;
+}
+
+.fsBody .fsForm .fsOptionLabel {
+ font-size:1.1em;
+}
+
+/* DP-19875 Remove the extra character count */
+.fsFieldRow .ma__textarea__wrapper::after {
+  content: '';
+}
+
+/* text */
+.fsRowBody input[type="text"],
+.fsRowBody input[type="email"],
+.fsRowBody input[type="number"],
+.fsRowBody input[type="tel"],
+.fsForm select, .fsForm textarea {
+  font-size: .9rem;
+}
+
+h1 {
+ font-size: 1.5rem;
+ font-weight: 350;
+}
+
+/* Field labels */
+.fsLabel,
+.fsLabelVertical .fsLabel {
+  margin-bottom: 6px;
+}
+.fsRequiredMarker {
+  font-size: .8rem;
+  color: #CD0D0D;
+}
+
+/* Help text */
+.fsBody .fsSupporting {
+  font-size: .7rem;
+  line-height: 1.4;
+}
+
+/* Buttons */
+input[type=file].fsField,
+input.fsSubmitButton {
+  font-weight: 500;
+  font-size: 1rem !important;
+  letter-spacing: .1rem;
+  text-transform: uppercase;
+  background-color: #14558f;
+  -webkit-box-shadow: 0 0.25rem 0.5rem rgba(1,1,1,.25);
+  -moz-box-shadow: 0 0.25rem 0.5rem rgba(1,1,1,.25);
+  box-shadow:  0 0.25rem 0.5rem rgba(1,1,1,.25);
+}
+
+.fsForm .fsSubmit {
+  margin-top: 10px;
+  padding: 10px 0;
+}
+
+input[type=file].fsField:hover,
+input[type=file].fsField:hover,
+input.fsSubmitButton:hover,
+input.fsSubmitButton:hover {
+  opacity: .9;
+}
+
+
+/* File upload */
+input[type=file].fsField,
+.fsFileUploadButton,
+.fsFileUploadButton[value="Choose File"] {
+  padding: 0 10px;
+  background-color: #14558f;
+  margin-right: 5px;
+  margin-bottom: 5px;
+  font-size: .9rem;
+  transition: all .3s ease;
+}
+
+.fsFileUploadButton[value="Choose File"]:hover {
+  opacity: .9;
+}
+
+.fsFileUploadButton[value="Remove File"] {
+  margin-right: 5px;
+  font-size: .9rem;
+  background-color: #F5F5F5;
+  color: #555555;
+  border: 2px solid #555555;
+  transition: all .3s ease;
+}
+
+.fsFileUploadButton[value="Remove File"]:hover {
+  background-color: #FFFFFF;
+  color: #CD0D0D;
+  border: 2px solid #CD0D0D;
+}
+
+.fsFileUploadName {
+  font-size: .9rem;
+}
+
+/* Callout alert */
+.ma__callout-alert {
+  padding: 20px !important;
+  color: #555555;
+  font-weight: 350;
+  border: 4px solid #fbe28d !important;
+  background-color: #fef9e8;
+}

--- a/packages/starters/formstack/mayflower-theme.css
+++ b/packages/starters/formstack/mayflower-theme.css
@@ -39,9 +39,12 @@
     bottom: 0;
     left: 0.075em;
     width: 1.85em;
+    background-color: rgb(67, 149, 111);
     background-color: rgba(67, 149, 111, 0.5);
     -webkit-transform: skew(-30deg);
+    -moz-transform: skew(-30deg);
     -ms-transform: skew(-30deg);
+    -o-transform: skew(-30deg);
     transform: skew(-30deg);
 }
 
@@ -54,12 +57,10 @@
     font-size: 1.375rem;
     line-height: 1.5;
 }
-/*.fsBody .fsForm .fsRequiredMarker {
-    display: none;
-}
-*/
+
 .fsBody .fsForm .fsLabel:not(.fsRequiredLabel):after {
     content: ' (optional)';
+    font-size: .8rem;
 }
 
 /* Inputs */
@@ -112,48 +113,13 @@
     text-align: center;
 }
 
-/* Radios, checkbox */
-.fsBody .fsForm .fsOptionLabel {
-    font-size: 22px;
-    font-size: 1.375rem;
-    line-height: 1.5;
-    position: relative;
-}
-.fsBody .fsForm .fsOptionLabel.horizontal {
-    /* Just avoid horizontal radios even if authored that way.*/
-    float: none;
-}
-.fsBody .fsForm .fsOptionLabel input[type="radio"],
-.fsBody .fsForm .fsOptionLabel input[type="checkbox"] {
-    margin-right: 0.5rem;
-    vertical-align: middle;
-    cursor: pointer;
-}
-.fsBody .fsForm .fsOptionLabel input[type="radio"]:focus,
-.fsBody .fsForm .fsOptionLabel input[type="checkbox"]:focus {
-    box-shadow: none;
-    cursor: pointer;
-}
-
-.fsBody .fsForm input[type="number"] {
-    font-family: "Noto Sans VF","Noto Sans","Helvetica","Arial",sans-serif;
-}
-
-
-@media (max-width: 40em) {
-    .fsBody .fsForm label.fsOptionLabel {
-        background: none;
-        border: none;
-        padding: 10px 0;
-    }
-}
-
 /* Supporting text */
-.fsBody .fsForm .fsSupporting {
+.fsBody .fsForm .fsSupporting,
+.fsBody .showMobile {
     font-weight: 300;
     font-style: italic;
     font-size: 1rem;
-    line-height: 1.2;
+    line-height: 1.4;
 }
 
 .fsBody .fsField::placeholder {
@@ -174,6 +140,8 @@
     text-decoration: none;
     text-transform: uppercase;
     -webkit-transition: all 0.4s ease;
+    -moz-transition: all 0.4s ease;
+    -o-transition: all 0.4s ease;
     transition: all 0.4s ease;
     cursor: pointer;
 }
@@ -183,6 +151,7 @@
 }
 
 .fsBody .fsForm input.fsSubmitButton:hover {
+    background-color: rgb(20, 85, 143);
     background-color: rgba(20, 85, 143, 0.75) !important;
     border-color:  transparent;
 }
@@ -212,6 +181,8 @@
     text-decoration: none;
     text-transform: uppercase;
     -webkit-transition: all 0.4s ease;
+    -moz-transition: all 0.4s ease;
+    -o-transition: all 0.4s ease;
     transition: all 0.4s ease;
     float: left !important;
 }
@@ -221,6 +192,7 @@
 }
 
 .fsNextButton:hover {
+    background-color: rgb(20, 85, 143);
     background-color: rgba(20, 85, 143, 0.75) !important;
     border-color:  transparent;
 }
@@ -266,7 +238,7 @@ a[title="Web Form Builder"] {
 
 /* specifc to given form */
 #fsSubmit3193712 {
-    padding-top: 0px !important;
+    padding-top: 0 !important;
 }
 
 input.fsSubmitButton {
@@ -274,6 +246,7 @@ input.fsSubmitButton {
 }
 
 div[fs-field-type="richtext"] a {
+    border-bottom-color: rgb(20,85,143);
     border-bottom-color: rgba(20,85,143,0.5);
     border-bottom-width: 1px;
     border-bottom-style: solid;
@@ -291,7 +264,6 @@ div[fs-field-type="richtext"] a {
     justify-content: space-between;
     flex-grow: 2;
 }
-
 .fsSubFieldGroup .fsSubField:nth-child(1):nth-last-child(3),
 .fsSubFieldGroup .fsSubField:nth-child(2):nth-last-child(2),
 .fsSubFieldGroup .fsSubField:nth-child(3):nth-last-child(1),
@@ -304,147 +276,125 @@ div[fs-field-type="richtext"] a {
     width: auto;
     flex-grow: 2;
 }
-
 .fsBody .fsForm input[type="text"].fsField,
 .fsBody .fsForm input[type="email"].fsField,
 .fsBody .fsForm input[type="tel"].fsField {
-    min-height: unset;
+    min-height: 0;
     max-height: 46px;
     width: 100%;
 }
 
+/* Make the asterisk small and red */
 .fsRequiredMarker {
   font-size: 1rem;
   color: #CD0D0D;
 }
 
-div[fs-field-type="radio"] div.fieldset-content {
-    display: flex;
-    flex-wrap: wrap;
-}
-
 div[fs-field-type="richtext"] a {
     border-bottom: 0;
 }
-/*
-*:input:focus {
-    outline-offset: -1px;
-    outline: solid;
-    outline-color: #487fe0;
-}*/
 
-
-/* standalone theme */
-
-.fsBody .fsForm .fsSectionHeader > .fsSectionText{
- color: #ffffff;
+/* Radios, checkboxes */
+div[fs-field-type="radio"] div.fieldset-content,
+div[fs-field-type="checkbox"] div.fieldset-content{
+    display: flex;
+    flex-wrap: wrap;
 }
-
+.fsRowBody input[type="radio"],
+.fsRowBody input[type="checkbox"] {
+    min-height: 1rem;
+}
 .fsBody .fsForm .fsOptionLabel {
- font-size:1.1em;
+    font-size: 22px;
+    font-size: 1.375rem;
+    line-height: 1.5;
+    position: relative;
+}
+.fsBody .fsForm .fsOptionLabel.horizontal {
+    float: none;
+}
+/* For "other" option, wrap to a new line. */
+.fieldset-content .horizontal[data-children-count="2"],
+.fieldset-content .vertical[data-children-count="2"] {
+    width: 100%;
+}
+.fieldset-content .horizontal[data-children-count="2"] input[type="text"],
+.fieldset-content .vertical[data-children-count="2"] input[type="text"] {
+    width: 100%;
+    border: 2px solid rgb(220,220,220);
+}
+.fieldset-content .vertical {
+    width: 100%;
+}
+.fsBody .fsForm .fsOptionLabel input[type="radio"],
+.fsBody .fsForm .fsOptionLabel input[type="checkbox"] {
+    margin-right: 0.5rem;
+    vertical-align: middle;
+    cursor: pointer;
+}
+.fsBody .fsForm .fsOptionLabel input[type="radio"]:focus,
+.fsBody .fsForm .fsOptionLabel input[type="checkbox"]:focus {
+    box-shadow: none;
+    cursor: pointer;
+}
+@media (max-width: 40em) {
+    .fsBody .fsForm label.fsOptionLabel {
+        background: none;
+        border: none;
+        padding: 10px 0;
+    }
 }
 
-/* DP-19875 Remove the extra character count */
-.fsFieldRow .ma__textarea__wrapper::after {
-  content: '';
+.fsBody .fsForm input[type="number"] {
+    font-family: "Noto Sans VF","Noto Sans","Helvetica","Arial",sans-serif;
 }
 
-/* text */
-.fsRowBody input[type="text"],
-.fsRowBody input[type="email"],
-.fsRowBody input[type="number"],
-.fsRowBody input[type="tel"],
-.fsForm select, .fsForm textarea {
-  font-size: .9rem;
+/* For the calendar icon. */
+/* Flex collapses the width of the  parent to it's children. */
+div[fs-field-type="datetime"] fieldset {
+    display: flex;
+}
+/* Then the inner div needs relative context for the absolute icon. */
+div[fs-field-type="datetime"] .fieldset-content {
+    position: relative;
+}
+/* Add the new icon at the bottom z-index. */
+div[fs-field-type="datetime"] .fieldset-content:after {
+    content: '';
+    position: absolute;
+    right: -40px;
+    top: 0;
+    display: block;
+    height: 42px;
+    width: 42px;
+    background-image: url(https://unpkg.com/@massds/mayflower@10.2.0/assets/images/icons/date-picker.svg);
+    background-position: center;
+    background-repeat: no-repeat;
+    z-index: 0;
+}
+/* Last, hide the old icon with opacity
+/* but lift it one z level so it's still clickable */
+.fsBody .ui-datepicker-trigger {
+    position: absolute;
+    top: 0;
+    margin-left: 0;
+    height: 42px;
+    opacity: 0;
+    cursor: pointer;
+    z-index: 1;
 }
 
-h1 {
- font-size: 1.5rem;
- font-weight: 350;
+.fsCurrency.fsCurrencyPrefix {
+    font-size: 1.75rem;
 }
 
-/* Field labels */
-.fsLabel,
-.fsLabelVertical .fsLabel {
-  margin-bottom: 6px;
+.fsCreditcardFieldContainer {
+    display: block;
 }
-.fsRequiredMarker {
-  font-size: .8rem;
-  color: #CD0D0D;
+.fsCreditcardFieldContainer div {
+    display: inline-block;
 }
 
-/* Help text */
-.fsBody .fsSupporting {
-  font-size: .7rem;
-  line-height: 1.4;
-}
-
-/* Buttons */
-input[type=file].fsField,
-input.fsSubmitButton {
-  font-weight: 500;
-  font-size: 1rem !important;
-  letter-spacing: .1rem;
-  text-transform: uppercase;
-  background-color: #14558f;
-  -webkit-box-shadow: 0 0.25rem 0.5rem rgba(1,1,1,.25);
-  -moz-box-shadow: 0 0.25rem 0.5rem rgba(1,1,1,.25);
-  box-shadow:  0 0.25rem 0.5rem rgba(1,1,1,.25);
-}
-
-.fsForm .fsSubmit {
-  margin-top: 10px;
-  padding: 10px 0;
-}
-
-input[type=file].fsField:hover,
-input[type=file].fsField:hover,
-input.fsSubmitButton:hover,
-input.fsSubmitButton:hover {
-  opacity: .9;
-}
-
-
-/* File upload */
-input[type=file].fsField,
-.fsFileUploadButton,
-.fsFileUploadButton[value="Choose File"] {
-  padding: 0 10px;
-  background-color: #14558f;
-  margin-right: 5px;
-  margin-bottom: 5px;
-  font-size: .9rem;
-  transition: all .3s ease;
-}
-
-.fsFileUploadButton[value="Choose File"]:hover {
-  opacity: .9;
-}
-
-.fsFileUploadButton[value="Remove File"] {
-  margin-right: 5px;
-  font-size: .9rem;
-  background-color: #F5F5F5;
-  color: #555555;
-  border: 2px solid #555555;
-  transition: all .3s ease;
-}
-
-.fsFileUploadButton[value="Remove File"]:hover {
-  background-color: #FFFFFF;
-  color: #CD0D0D;
-  border: 2px solid #CD0D0D;
-}
-
-.fsFileUploadName {
-  font-size: .9rem;
-}
-
-/* Callout alert */
-.ma__callout-alert {
-  padding: 20px !important;
-  color: #555555;
-  font-weight: 350;
-  border: 4px solid #fbe28d !important;
-  background-color: #fef9e8;
+.fsMatrixFieldset .fsMatrix {
+    width: 100%;
 }

--- a/packages/starters/formstack/mayflower-theme.css
+++ b/packages/starters/formstack/mayflower-theme.css
@@ -2,10 +2,11 @@
 .fsBody  {
     padding: 0;
     margin-top: 60px;
-
+    font-family: "Noto Sans VF","Noto Sans","Helvetica","Arial",sans-serif;
 }
+
 .fsBody .fsForm {
-    font-family: 'texta';
+    font-family: "Noto Sans VF","Noto Sans","Helvetica","Arial",sans-serif;
     font-size: 22px;
     font-size: 1.375rem;
     line-height: 1.5;
@@ -14,15 +15,13 @@
     max-width: 50rem;
 }
 
-
 /* Headline */
-
-
 .fsBody .fsSectionHeader {
     background-color: transparent;
     padding: 0;
     margin-bottom: 20px;
 }
+
 .fsBody .fsSectionHeader .fsSectionHeading {
     text-align: left;
     position: relative;
@@ -47,9 +46,7 @@
     transform: skew(-30deg);
 }
 
-
 /* Labels */
-
 .fsBody .fsForm .fsLabel {
     font-weight: 500;
     margin-bottom: 0.5rem;
@@ -67,7 +64,6 @@
 }
 
 /* Inputs */
-
 .fsBody .fsForm fieldset {
     border: none;
     padding-left: 0;
@@ -77,6 +73,7 @@
 .fsBody .fsForm input[type="tel"].fsField {
     background-color: white;
     border-color: #dcdcdc !important;
+    font-family: "Noto Sans VF","Noto Sans","Helvetica","Arial",sans-serif;
     color: #535353;
     border: 2px solid;
     min-height: 46px;
@@ -92,6 +89,7 @@
 }
 
 .fsForm select:not([multiple="multiple"]) {
+    font-family: "Noto Sans VF","Noto Sans","Helvetica","Arial",sans-serif;
     background-color: white;
     border-color: #dcdcdc;
     border: 2px solid #dcdcdc;
@@ -103,7 +101,6 @@
   margin-top: 10px;
 }
 
-
 /* Matrix */
 .fsMatrix {
   border-collapse: collapse;
@@ -114,9 +111,7 @@
   text-align: center;
 }
 
-
 /* Radios, checkbox */
-
 .fsBody .fsForm .fsOptionLabel {
     font-size: 22px;
     font-size: 1.375rem;
@@ -145,9 +140,7 @@
     }
 }
 
-
 /* Supporting text */
-
 .fsBody .fsForm .fsSupporting {
     font-weight: 300;
     font-style: italic;
@@ -160,7 +153,6 @@
 }
 
 /* Submit */
-
 .fsBody .fsForm input.fsSubmitButton {
     font-weight: 700;
     background-color: #14558f !important;
@@ -198,7 +190,6 @@
 }
 
 /* Next Button */
-
 .fsNextButton {
     font-weight: 700;
     background-color: #14558f !important;
@@ -224,8 +215,7 @@
     border-color:  transparent;
 }
 
-
-.fhttps://help.formstack.com/hc/en-us/articles/360019519891-Custom-Form-Themes-and-CSSsBody .fsFieldRow {
+.fsBody .fsFieldRow {
     margin-bottom: 3.5rem !important;
 }
 
@@ -236,7 +226,6 @@
 .fsBody .fsForm .fsSubmitButton {
   cursor: pointer;
 }
-
 
 .fsForm, .fsError {
     float: none !important;
@@ -271,12 +260,55 @@ a[title="Web Form Builder"] {
 }
 
 /* specifc to given form */
-
 #fsSubmit3193712 {
     padding-top: 0px !important;
 }
 
 input.fsSubmitButton {
-    font-family: "Texta","Helvetica","Arial",sans-serif;
+    font-family: "Noto Sans VF","Noto Sans","Helvetica","Arial",sans-serif;
     font-size: 1rem;
+}
+
+div[fs-field-type="richtext"] a {
+    border-bottom-color: rgba(20,85,143,0.5);
+    border-bottom-width: 1px;
+    border-bottom-style: solid;
+}
+
+/* DP-19875 Remove the extra character count */
+.fsFieldRow .ma__textarea__wrapper::after {
+  content: '';
+}
+
+.fsSubFieldGroup {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  flex-grow: 2;
+  align-items: center;
+}
+
+.fsSubFieldGroup .fsSubField:nth-child(1):nth-last-child(3),
+.fsSubFieldGroup .fsSubField:nth-child(2):nth-last-child(2),
+.fsSubFieldGroup .fsSubField:nth-child(3):nth-last-child(1),
+.fsBody .fsSubField.fsNameFirst,
+.fsBody .fsSubField.fsNameMiddle,
+.fsBody .fsSubField.fsNameLast,
+.fsBody .fsSubField.fsFieldCity,
+.fsBody .fsSubField.fsFieldState,
+.fsBody .fsSubField.fsFieldZip {
+  width: auto;
+  flex-grow: 2;
+}
+
+/*.fsBody .fsSubField.fsFieldAddress,
+.fsBody .fsSubField.fsFieldAddress2,
+.fsBody .fsSubField.fsFieldCountry*/
+
+.fsBody .fsForm input[type="text"].fsField,
+.fsBody .fsForm input[type="email"].fsField,
+.fsBody .fsForm input[type="tel"].fsField {
+    max-height: 46px;
+    min-height: unset;
+    width: 100%;
 }

--- a/packages/starters/formstack/mayflower-theme.css
+++ b/packages/starters/formstack/mayflower-theme.css
@@ -398,3 +398,19 @@ div[fs-field-type="datetime"] .fieldset-content:after {
 .fsMatrixFieldset .fsMatrix {
     width: 100%;
 }
+
+/* Hide increment and decrement buttons */
+/* These behave unpredictably           */
+button.ma__input-number__plus,
+button.ma__input-number__minus {
+    display: none !important;
+}
+
+/* Different markup of 'other' field */
+.fieldset-content:last-child div.horizontal {
+    width: 100%;
+}
+.fieldset-content:last-child div.horizontal input[type="text"] {
+    border: 2px solid rgb(220,220,220);
+    width: 100%;
+}

--- a/packages/starters/formstack/mayflower-theme.css
+++ b/packages/starters/formstack/mayflower-theme.css
@@ -2,7 +2,6 @@
 .fsBody  {
     padding: 0;
     margin-top: 60px;
-    font-family: "Noto Sans VF","Noto Sans","Helvetica","Arial",sans-serif;
 }
 
 .fsBody .fsForm {
@@ -15,7 +14,7 @@
     max-width: 50rem;
 }
 
-/* Headline */
+/* Headings */
 .fsBody .fsSectionHeader {
     background-color: transparent;
     padding: 0;
@@ -68,6 +67,7 @@
     border: none;
     padding-left: 0;
 }
+
 .fsBody .fsForm input[type="text"].fsField,
 .fsBody .fsForm input[type="email"].fsField,
 .fsBody .fsForm input[type="tel"].fsField {
@@ -95,6 +95,7 @@
     border: 2px solid #dcdcdc;
     background-image: none;
     max-width: 100%;
+    cursor: pointer;
 }
 
 .fsBody .fsSubField {
@@ -107,8 +108,8 @@
 }
 
 .fsMatrix th, .fsMatrix td {
-  padding: 1em;
-  text-align: center;
+    padding: 1em;
+    text-align: center;
 }
 
 /* Radios, checkbox */
@@ -126,11 +127,18 @@
 .fsBody .fsForm .fsOptionLabel input[type="checkbox"] {
     margin-right: 0.5rem;
     vertical-align: middle;
+    cursor: pointer;
 }
 .fsBody .fsForm .fsOptionLabel input[type="radio"]:focus,
 .fsBody .fsForm .fsOptionLabel input[type="checkbox"]:focus {
     box-shadow: none;
+    cursor: pointer;
 }
+
+.fsBody .fsForm input[type="number"] {
+    font-family: "Noto Sans VF","Noto Sans","Helvetica","Arial",sans-serif;
+}
+
 
 @media (max-width: 40em) {
     .fsBody .fsForm label.fsOptionLabel {
@@ -149,11 +157,12 @@
 }
 
 .fsBody .fsField::placeholder {
-  color: #cccccc;
+    color: #cccccc;
 }
 
 /* Submit */
 .fsBody .fsForm input.fsSubmitButton {
+    font-family: "Noto Sans VF","Noto Sans","Helvetica","Arial",sans-serif;
     font-weight: 700;
     background-color: #14558f !important;
     color: white;
@@ -166,10 +175,11 @@
     text-transform: uppercase;
     -webkit-transition: all 0.4s ease;
     transition: all 0.4s ease;
+    cursor: pointer;
 }
 
 .fsSubmitButton {
-  background-color: #14558f !important;
+    background-color: #14558f !important;
 }
 
 .fsBody .fsForm input.fsSubmitButton:hover {
@@ -220,11 +230,7 @@
 }
 
 .fsBody .fsForm .fsPagination {
-  text-align: left;
-}
-
-.fsBody .fsForm .fsSubmitButton {
-  cursor: pointer;
+    text-align: left;
 }
 
 .fsForm, .fsError {
@@ -253,7 +259,6 @@ div.fsValidationError label.fsLabel{
     border: 2px solid #f34343;
 }
 
-
 /* remove branding */
 a[title="Web Form Builder"] {
     display: none;
@@ -265,7 +270,6 @@ a[title="Web Form Builder"] {
 }
 
 input.fsSubmitButton {
-    font-family: "Noto Sans VF","Noto Sans","Helvetica","Arial",sans-serif;
     font-size: 1rem;
 }
 
@@ -277,15 +281,15 @@ div[fs-field-type="richtext"] a {
 
 /* DP-19875 Remove the extra character count */
 .fsFieldRow .ma__textarea__wrapper::after {
-  content: '';
+    content: '';
 }
 
+/* Fix for sub-field groups */
 .fsSubFieldGroup {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  flex-grow: 2;
-  align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    flex-grow: 2;
 }
 
 .fsSubFieldGroup .fsSubField:nth-child(1):nth-last-child(3),
@@ -297,18 +301,34 @@ div[fs-field-type="richtext"] a {
 .fsBody .fsSubField.fsFieldCity,
 .fsBody .fsSubField.fsFieldState,
 .fsBody .fsSubField.fsFieldZip {
-  width: auto;
-  flex-grow: 2;
+    width: auto;
+    flex-grow: 2;
 }
-
-/*.fsBody .fsSubField.fsFieldAddress,
-.fsBody .fsSubField.fsFieldAddress2,
-.fsBody .fsSubField.fsFieldCountry*/
 
 .fsBody .fsForm input[type="text"].fsField,
 .fsBody .fsForm input[type="email"].fsField,
 .fsBody .fsForm input[type="tel"].fsField {
-    max-height: 46px;
     min-height: unset;
+    max-height: 46px;
     width: 100%;
 }
+
+.fsRequiredMarker {
+  font-size: 1rem;
+  color: #CD0D0D;
+}
+
+div[fs-field-type="radio"] div.fieldset-content {
+    display: flex;
+    flex-wrap: wrap;
+}
+
+div[fs-field-type="richtext"] a {
+    border-bottom: 0;
+}
+/*
+*:input:focus {
+    outline-offset: -1px;
+    outline: solid;
+    outline-color: #487fe0;
+}*/


### PR DESCRIPTION
## Description
Additional updates to Mayflower Formstack theme
-Added Noto to all font-family rules
-Fixed layout issues with flex
-Made override for radios with "other" option so it wraps and is 100% width
-Added rules to replace calendar icon
-Added override to disable up/down arrows that cause input errors
-Fixed layout gap in joined-up credit-card number fields by hiding the field borders and styling the container border
-Made matrix width 100%

## Related Issue / Ticket
- [JIRA issue](CON-274)

## Steps to Test
1. Pull branch
2. Copy CSS
3. Go to Formstack.com and paste into advanced CSS
4. Go to https://edit.mass.gov/forms/mayflower-theme-test---unpublished and compare to screenshots

## Screenshots
<img width="736" alt="Screen Shot 2020-12-10 at 11 51 45 AM" src="https://user-images.githubusercontent.com/3894652/101810673-af1d0f00-3ade-11eb-921c-27382471bd01.png">
<img width="442" alt="Screen Shot 2020-12-10 at 11 51 12 AM" src="https://user-images.githubusercontent.com/3894652/101810680-b0e6d280-3ade-11eb-91a0-03e81ae280d7.png">
<img width="772" alt="Screen Shot 2020-12-10 at 11 51 18 AM" src="https://user-images.githubusercontent.com/3894652/101810676-afb5a580-3ade-11eb-8d93-f63a1277a049.png">
<img width="786" alt="Screen Shot 2020-12-10 at 11 51 06 AM" src="https://user-images.githubusercontent.com/3894652/101810681-b0e6d280-3ade-11eb-88dc-f21a94f7c5be.png">
<img width="759" alt="Screen Shot 2020-12-10 at 11 50 50 AM" src="https://user-images.githubusercontent.com/3894652/101810684-b17f6900-3ade-11eb-9cbe-b763aef53724.png">


#### @TODO
Start using sass to pull in the Mayflower variables and mixins and compile this CSS file.
Figure out the javascript mismatch that is leading to the input errors with up/down arrows on numeric fields.
