### PR TITLE
Core/fix auto deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -435,7 +435,7 @@ workflows:
           requires: [build]
           filters:
             branches: { ignore: /(docs|patternlab\/|site\/).*/ }
-      - core_deploy_storybook:
+      - core_deploy_tag:
           requires: [core_build_storybook]
           filters:
             branches: { ignore: /(docs|patternlab\/|site\/).*/ }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,10 +290,8 @@ jobs:
           sudo apt-get update && sudo apt-get -y -qq install awscli
           cd packages/core
           aws s3 sync storybook-static "s3://mayflower.digital.mass.gov/core/b/$CIRCLE_BRANCH" --delete
-          # Use cp instead of sync for root copy.  sync lists all keys and is too slow.
-          aws s3 cp --recursive storybook-static "s3://mayflower.digital.mass.gov/core"
           aws configure set preview.cloudfront true
-          aws cloudfront create-invalidation --distribution-id $AWS_DISTRIBUTION_ID --paths '/core*'
+          aws cloudfront create-invalidation --distribution-id $AWS_DISTRIBUTION_ID --paths '/core/b/$CIRCLE_BRANCH'
 
   auto_changelog:
     <<: *react_defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -281,6 +281,20 @@ jobs:
             aws cloudfront create-invalidation --distribution-id $AWS_DISTRIBUTION_ID --paths '/core*'
           fi
 
+  core_deploy_branch:
+    <<: *patternlab_defaults
+    steps:
+      - attach_workspace:
+          at: ~/code
+      - run: |
+          sudo apt-get update && sudo apt-get -y -qq install awscli
+          cd packages/core
+          aws s3 sync storybook-static "s3://mayflower.digital.mass.gov/core/b/$CIRCLE_BRANCH" --delete
+          # Use cp instead of sync for root copy.  sync lists all keys and is too slow.
+          aws s3 cp --recursive storybook-static "s3://mayflower.digital.mass.gov/core"
+          aws configure set preview.cloudfront true
+          aws cloudfront create-invalidation --distribution-id $AWS_DISTRIBUTION_ID --paths '/core*'
+
   auto_changelog:
     <<: *react_defaults
     steps:
@@ -435,10 +449,10 @@ workflows:
           requires: [build]
           filters:
             branches: { ignore: /(docs|patternlab\/|site\/).*/ }
-      - core_deploy_tag:
+      - core_deploy_branch:
           requires: [core_build_storybook]
           filters:
-            branches: { ignore: /(docs|patternlab\/|site\/).*/ }
+            branches: { ignore: /(docs|patternlab\/|site\/|react\/).*/ }
 
   # Release branch automation every Monday at 2:00 p.m. ET "00 18 * * 1"
   release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -515,7 +515,8 @@ workflows:
       - core_build_storybook:
           requires: [build]
           filters:
-            branches: { ignore: /(docs|patternlab\/|site\/).*/ }
+            branches: { ignore: /.*/ }
+            tags: { only: /.*/ }
       - core_deploy_tag:
           requires: [core_build_storybook]
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -435,6 +435,10 @@ workflows:
           requires: [build]
           filters:
             branches: { ignore: /(docs|patternlab\/|site\/).*/ }
+      - core_deploy_storybook:
+          requires: [core_build_storybook]
+          filters:
+            branches: { ignore: /(docs|patternlab\/|site\/).*/ }
 
   # Release branch automation every Monday at 2:00 p.m. ET "00 18 * * 1"
   release:

--- a/changelogs/fix-auto-deploy.yml
+++ b/changelogs/fix-auto-deploy.yml
@@ -1,0 +1,12 @@
+Changed:
+  - project: Core
+    component: CircleCI
+    description: Fixed tag deploy conditions and added branch deployment to S3. (#1327)
+    issue: 
+    impact: Patch
+Fixed:
+  - project: Core
+    component: Storybook
+    description: Fix MDX docs title extra spacing. (#1327)
+    issue: 
+    impact: Patch

--- a/packages/core/stories/styles/_markdown.scss
+++ b/packages/core/stories/styles/_markdown.scss
@@ -1,10 +1,9 @@
 
 @use "00-base/configure" as *;
 
-h1, h2, h3, h4, h5, h6 {
+h2, h3, h4, h5, h6 {
   margin-top: 1em !important;
   margin-bottom: 0.2em !important;
-
 }
 
 hr {


### PR DESCRIPTION
In the [last release (v11.0.0)](https://github.com/massgov/mayflower/pull/1321), `core_deploy_tag` auto-deploy core job didn't get triggered. This PR is to fix that.  We will need to validate with a release. 