### PR TITLE
Core/add brand banner

### DIFF
--- a/changelogs/DP-20730.yml
+++ b/changelogs/DP-20730.yml
@@ -1,6 +1,11 @@
 Added:
-  - project: React
+  - project: React, Assets
     component: BrandBanner
     description: Added BrandBanner molecule. (#1334)
+    issue: DP-20730
+    impact: Minor
+  - project: Core
+    component: BrandBanner, Template
+    description: Added documentation for BrandBanner. (#1338)
     issue: DP-20730
     impact: Minor

--- a/packages/core/.storybook/preview.js
+++ b/packages/core/.storybook/preview.js
@@ -22,6 +22,7 @@ export const parameters = {
 		],
 		'Elements',
 		'Components', [
+			'BrandBanner',
 			'Header',
 			'Footer',
         	'Template'

--- a/packages/core/stories/components/BrandBanner/BrandBanner.stories.js
+++ b/packages/core/stories/components/BrandBanner/BrandBanner.stories.js
@@ -2,49 +2,47 @@ import React from 'react';
 import BrandBanner from '@massds/mayflower-react/dist/BrandBanner';
 import logo from '@massds/mayflower-assets/static/images/logo/stateseal.png';
 import logoWhite from '@massds/mayflower-assets/static/images/logo/stateseal-white.png';
-import { headerBasic } from '../Header/Header.stories.js';
+import { headerBasic } from '../Header/Header.stories';
 
 import { attachHTML } from '../../util/renderCode';
 
 const { STORYBOOK_CDN_PATH } = process.env;
-
 
 const brandBannerWithoutSeal = (
   <BrandBanner seal={logo} hasToggle={false} hasSeal={false} />
 );
 
 const brandBannerWithoutSealWithHeader = (
-    <>
+  <>
     {brandBannerWithoutSeal}
     {headerBasic}
-    </>
-  );
+  </>
+);
 
 // Light
 const brandBannerBasic = (
-    <BrandBanner seal={logo} hasToggle={false} />
-  );
+  <BrandBanner seal={logo} hasToggle={false} />
+);
 
 const brandBannerLightThemePrimaryAlt = (
-    <BrandBanner seal={logo} hasToggle={false} bgTheme="light" bgColor="c-primary-alt" />
+  <BrandBanner seal={logo} hasToggle={false} bgTheme="light" bgColor="c-primary-alt" />
 );
 
 const brandBannerLightThemeGray = (
-    <BrandBanner seal={logo} hasToggle={false} bgTheme="light" bgColor="c-gray" />
+  <BrandBanner seal={logo} hasToggle={false} bgTheme="light" bgColor="c-gray" />
 );
-
 
 // Dark
 const brandBannerDarkTheme = (
-    <BrandBanner seal={logoWhite} hasToggle={false} bgTheme="dark" />
+  <BrandBanner seal={logoWhite} hasToggle={false} bgTheme="dark" />
 );
 
 const brandBannerDarkThemePrimaryAlt = (
-    <BrandBanner seal={logoWhite} hasToggle={false} bgTheme="dark" bgColor="c-primary-alt" />
+  <BrandBanner seal={logoWhite} hasToggle={false} bgTheme="dark" bgColor="c-primary-alt" />
 );
 
 const brandBannerDarkThemeGray = (
-    <BrandBanner seal={logoWhite} hasToggle={false} bgTheme="dark" bgColor="c-gray" />
+  <BrandBanner seal={logoWhite} hasToggle={false} bgTheme="dark" bgColor="c-gray" />
 );
 
 const notesBrandBanner = `// Link to CSS: <link rel="stylesheet" href="${STORYBOOK_CDN_PATH}/css/brand-banner.css">`;
@@ -55,20 +53,20 @@ export const brandBannerNoSeal = () => brandBannerWithoutSeal;
 
 export const brandBannerNoSealWithHeader = () => brandBannerWithoutSealWithHeader;
 
-export const brandBannerLight= () => brandBannerBasic;
+export const brandBannerLight = () => brandBannerBasic;
 attachHTML(brandBannerLight, brandBannerBasic, notesBrandBanner);
 
-export const brandBannerLightPrimaryAlt= () => brandBannerLightThemePrimaryAlt;
+export const brandBannerLightPrimaryAlt = () => brandBannerLightThemePrimaryAlt;
 attachHTML(brandBannerLightPrimaryAlt, brandBannerLightThemePrimaryAlt, notesBrandBanner);
 
-export const brandBannerLightGray= () => brandBannerLightThemeGray;
+export const brandBannerLightGray = () => brandBannerLightThemeGray;
 attachHTML(brandBannerLightGray, brandBannerLightThemeGray, notesBrandBanner);
 
-export const brandBannerDark= () => brandBannerDarkTheme;
+export const brandBannerDark = () => brandBannerDarkTheme;
 attachHTML(brandBannerDark, brandBannerDarkTheme, notesBrandBanner);
 
-export const brandBannerDarkPrimaryAlt= () => brandBannerDarkThemePrimaryAlt;
+export const brandBannerDarkPrimaryAlt = () => brandBannerDarkThemePrimaryAlt;
 attachHTML(brandBannerDarkPrimaryAlt, brandBannerDarkThemePrimaryAlt, notesBrandBanner);
 
-export const brandBannerDarkGray= () => brandBannerDarkThemeGray;
+export const brandBannerDarkGray = () => brandBannerDarkThemeGray;
 attachHTML(brandBannerDarkGray, brandBannerDarkThemeGray, notesBrandBanner);

--- a/packages/core/stories/components/BrandBanner/BrandBanner.stories.js
+++ b/packages/core/stories/components/BrandBanner/BrandBanner.stories.js
@@ -28,8 +28,12 @@ const brandBannerDarkTheme = (
 </>
 );
 
+const notesBrandBanner = `// Link to CSS: <link rel="stylesheet" href="${STORYBOOK_CDN_PATH}/css/brand-banner.css">`;
+
 export const brandBannerExample = () => brandBannerBasic;
 
 export const brandBannerLight= () => brandBannerLightTheme;
+attachHTML(brandBannerLight, brandBannerLightTheme, notesBrandBanner);
 
 export const brandBannerDark= () => brandBannerDarkTheme;
+attachHTML(brandBannerDark, brandBannerDarkTheme, notesBrandBanner);

--- a/packages/core/stories/components/BrandBanner/BrandBanner.stories.js
+++ b/packages/core/stories/components/BrandBanner/BrandBanner.stories.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import BrandBanner from '@massds/mayflower-react/dist/BrandBanner';
 import logo from '@massds/mayflower-assets/static/images/logo/stateseal.png';
+import logoWhite from '@massds/mayflower-assets/static/images/logo/stateseal-white.png';
 
 import { attachHTML } from '../../util/renderCode';
 
@@ -10,4 +11,25 @@ const brandBannerBasic = (
   <BrandBanner seal={logo} hasToggle={false} />
 );
 
+const brandBannerLightTheme = (
+    <>
+        <BrandBanner seal={logo} hasToggle={false} />
+        <BrandBanner seal={logo} hasToggle={false} bgTheme="light" bgColor="c-primary-alt" />
+        <BrandBanner seal={logo} hasToggle={false} bgTheme="light" bgColor="c-gray" />
+    </>
+  );
+
+
+const brandBannerDarkTheme = (
+<>
+    <BrandBanner seal={logoWhite} hasToggle={false} bgTheme="dark" />
+    <BrandBanner seal={logoWhite} hasToggle={false} bgTheme="dark" bgColor="c-primary-alt" />
+    <BrandBanner seal={logoWhite} hasToggle={false} bgTheme="dark" bgColor="c-gray" />
+</>
+);
+
 export const brandBannerExample = () => brandBannerBasic;
+
+export const brandBannerLight= () => brandBannerLightTheme;
+
+export const brandBannerDark= () => brandBannerDarkTheme;

--- a/packages/core/stories/components/BrandBanner/BrandBanner.stories.js
+++ b/packages/core/stories/components/BrandBanner/BrandBanner.stories.js
@@ -2,14 +2,28 @@ import React from 'react';
 import BrandBanner from '@massds/mayflower-react/dist/BrandBanner';
 import logo from '@massds/mayflower-assets/static/images/logo/stateseal.png';
 import logoWhite from '@massds/mayflower-assets/static/images/logo/stateseal-white.png';
+import { headerBasic } from '../Header/Header.stories.js';
 
 import { attachHTML } from '../../util/renderCode';
 
 const { STORYBOOK_CDN_PATH } = process.env;
 
-const brandBannerBasic = (
-  <BrandBanner seal={logo} hasToggle={false} />
+
+const brandBannerWithoutSeal = (
+  <BrandBanner seal={logo} hasToggle={false} hasSeal={false} />
 );
+
+const brandBannerWithoutSealWithHeader = (
+    <>
+    {brandBannerWithoutSeal}
+    {headerBasic}
+    </>
+  );
+
+// Light
+const brandBannerBasic = (
+    <BrandBanner seal={logo} hasToggle={false} />
+  );
 
 const brandBannerLightThemePrimaryAlt = (
     <BrandBanner seal={logo} hasToggle={false} bgTheme="light" bgColor="c-primary-alt" />
@@ -20,7 +34,7 @@ const brandBannerLightThemeGray = (
 );
 
 
-
+// Dark
 const brandBannerDarkTheme = (
     <BrandBanner seal={logoWhite} hasToggle={false} bgTheme="dark" />
 );
@@ -36,6 +50,10 @@ const brandBannerDarkThemeGray = (
 const notesBrandBanner = `// Link to CSS: <link rel="stylesheet" href="${STORYBOOK_CDN_PATH}/css/brand-banner.css">`;
 
 export const brandBannerExample = () => brandBannerBasic;
+
+export const brandBannerNoSeal = () => brandBannerWithoutSeal;
+
+export const brandBannerNoSealWithHeader = () => brandBannerWithoutSealWithHeader;
 
 export const brandBannerLight= () => brandBannerBasic;
 attachHTML(brandBannerLight, brandBannerBasic, notesBrandBanner);

--- a/packages/core/stories/components/BrandBanner/BrandBanner.stories.js
+++ b/packages/core/stories/components/BrandBanner/BrandBanner.stories.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import BrandBanner from '@massds/mayflower-react/dist/BrandBanner';
+import logo from '@massds/mayflower-assets/static/images/logo/stateseal.png';
+
+import { attachHTML } from '../../util/renderCode';
+
+const { STORYBOOK_CDN_PATH } = process.env;
+
+const brandBannerBasic = (
+  <BrandBanner seal={logo} hasToggle={false} />
+);
+
+export const brandBannerExample = () => brandBannerBasic;

--- a/packages/core/stories/components/BrandBanner/BrandBanner.stories.js
+++ b/packages/core/stories/components/BrandBanner/BrandBanner.stories.js
@@ -11,29 +11,46 @@ const brandBannerBasic = (
   <BrandBanner seal={logo} hasToggle={false} />
 );
 
-const brandBannerLightTheme = (
-    <>
-        <BrandBanner seal={logo} hasToggle={false} />
-        <BrandBanner seal={logo} hasToggle={false} bgTheme="light" bgColor="c-primary-alt" />
-        <BrandBanner seal={logo} hasToggle={false} bgTheme="light" bgColor="c-gray" />
-    </>
-  );
+const brandBannerLightThemePrimaryAlt = (
+    <BrandBanner seal={logo} hasToggle={false} bgTheme="light" bgColor="c-primary-alt" />
+);
+
+const brandBannerLightThemeGray = (
+    <BrandBanner seal={logo} hasToggle={false} bgTheme="light" bgColor="c-gray" />
+);
+
 
 
 const brandBannerDarkTheme = (
-<>
     <BrandBanner seal={logoWhite} hasToggle={false} bgTheme="dark" />
+);
+
+const brandBannerDarkThemePrimaryAlt = (
     <BrandBanner seal={logoWhite} hasToggle={false} bgTheme="dark" bgColor="c-primary-alt" />
+);
+
+const brandBannerDarkThemeGray = (
     <BrandBanner seal={logoWhite} hasToggle={false} bgTheme="dark" bgColor="c-gray" />
-</>
 );
 
 const notesBrandBanner = `// Link to CSS: <link rel="stylesheet" href="${STORYBOOK_CDN_PATH}/css/brand-banner.css">`;
 
 export const brandBannerExample = () => brandBannerBasic;
 
-export const brandBannerLight= () => brandBannerLightTheme;
-attachHTML(brandBannerLight, brandBannerLightTheme, notesBrandBanner);
+export const brandBannerLight= () => brandBannerBasic;
+attachHTML(brandBannerLight, brandBannerBasic, notesBrandBanner);
+
+export const brandBannerLightPrimaryAlt= () => brandBannerLightThemePrimaryAlt;
+attachHTML(brandBannerLightPrimaryAlt, brandBannerLightThemePrimaryAlt, notesBrandBanner);
+
+export const brandBannerLightGray= () => brandBannerLightThemeGray;
+attachHTML(brandBannerLightGray, brandBannerLightThemeGray, notesBrandBanner);
 
 export const brandBannerDark= () => brandBannerDarkTheme;
 attachHTML(brandBannerDark, brandBannerDarkTheme, notesBrandBanner);
+
+export const brandBannerDarkPrimaryAlt= () => brandBannerDarkThemePrimaryAlt;
+attachHTML(brandBannerDarkPrimaryAlt, brandBannerDarkThemePrimaryAlt, notesBrandBanner);
+
+export const brandBannerDarkGray= () => brandBannerDarkThemeGray;
+attachHTML(brandBannerDarkGray, brandBannerDarkThemeGray, notesBrandBanner);

--- a/packages/core/stories/components/BrandBanner/BrandBanner.stories.mdx
+++ b/packages/core/stories/components/BrandBanner/BrandBanner.stories.mdx
@@ -18,8 +18,9 @@ The brand banner identifies official websites of the Commonwealth of Massachuset
   <Story story={stories.brandBannerExample} />
 </Canvas>
 
-It’s required for the mass.gov domain and all its subdomains (mass.gov domain policy), and recommends all other .gov state websites using it as a consistent and trustworthy identifier for the public users.
+> It’s required for the mass.gov domain and all its subdomains (mass.gov domain policy), and recommends all other .gov state websites using it as a consistent and trustworthy identifier for the public users. It's prohibited for non Massachusetts state government websites to use this banner.
 
+<br />
 
 # Overview
 
@@ -29,13 +30,16 @@ The Mayflower brand banner is a thin banner attached to the top of all pages of 
 
 ## Variations
 
-### Light Theme
+### Colors and Themes
+The brand banners are provided in multiple color options in both light and dark theme to work with different adjecent backgrounds and additional branding colors.
+
+#### Light Theme
 
 <Canvas>
   <Story story={stories.brandBannerLight} />
 </Canvas>
 
-### Dark Theme
+#### Dark Theme
 
 <Canvas>
   <Story story={stories.brandBannerDark} />

--- a/packages/core/stories/components/BrandBanner/BrandBanner.stories.mdx
+++ b/packages/core/stories/components/BrandBanner/BrandBanner.stories.mdx
@@ -38,8 +38,24 @@ The brand banners are provided in multiple color options in both light and dark 
   <Story story={stories.brandBannerLight} />
 </Canvas>
 
+<Canvas>
+  <Story story={stories.brandBannerLightPrimaryAlt} />
+</Canvas>
+
+<Canvas>
+  <Story story={stories.brandBannerLightGray} />
+</Canvas>
+
 #### Dark Theme
 
 <Canvas>
   <Story story={stories.brandBannerDark} />
+</Canvas>
+
+<Canvas>
+  <Story story={stories.brandBannerDarkPrimaryAlt} />
+</Canvas>
+
+<Canvas>
+  <Story story={stories.brandBannerDarkGray} />
 </Canvas>

--- a/packages/core/stories/components/BrandBanner/BrandBanner.stories.mdx
+++ b/packages/core/stories/components/BrandBanner/BrandBanner.stories.mdx
@@ -12,14 +12,13 @@ import * as stories from './BrandBanner.stories.js';
 
 # Brand Banner
 
-The brand banner identifies official websites of the Commonwealth of Massachusetts. It ensures the visitors of getting information or performing transactions on an official and secure government website. 
+It assures visitors that they are using an official and secure government website.
 
 <Canvas withSource="none" >
   <Story story={stories.brandBannerExample} />
 </Canvas>
 
-> It’s required for the mass.gov domain and all its subdomains (mass.gov domain policy), and recommends all other .gov state websites using it as a consistent and trustworthy identifier for the public users. It's prohibited for non Massachusetts state government websites to use this banner.
-
+> According to the Mass.gov domain policy, all sites under the mass.gov domain and its subdomains **must** use the brand banner. Other .gov state websites **should** use it as a consistent and trustworthy identifier. Any entity not directly under the authority of the government of Massachusetts is **prohibited** from using the banner
 
 ## Overview
 

--- a/packages/core/stories/components/BrandBanner/BrandBanner.stories.mdx
+++ b/packages/core/stories/components/BrandBanner/BrandBanner.stories.mdx
@@ -12,6 +12,31 @@ import * as stories from './BrandBanner.stories.js';
 
 # Brand Banner
 
+The brand banner identifies official websites of the Commonwealth of Massachusetts. It ensures the visitors of getting information or performing transactions on an official and secure government website. 
+
 <Canvas withSource="none" >
   <Story story={stories.brandBannerExample} />
+</Canvas>
+
+It’s required for the mass.gov domain and all its subdomains (mass.gov domain policy), and recommends all other .gov state websites using it as a consistent and trustworthy identifier for the public users.
+
+
+# Overview
+
+The Mayflower brand banner is a thin banner attached to the top of all pages of a site for branding and assurance purposes. It contains:
+- An optional state seal (This is optional when the SiteLogo in Header is also a state seal, to avoid repetition)
+- The text: An official website of the Commonwealth of Massachusetts
+
+## Variations
+
+### Light Theme
+
+<Canvas>
+  <Story story={stories.brandBannerLight} />
+</Canvas>
+
+### Dark Theme
+
+<Canvas>
+  <Story story={stories.brandBannerDark} />
 </Canvas>

--- a/packages/core/stories/components/BrandBanner/BrandBanner.stories.mdx
+++ b/packages/core/stories/components/BrandBanner/BrandBanner.stories.mdx
@@ -1,0 +1,17 @@
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+
+import generateTitle from '../../util/generateTitle';
+import * as stories from './BrandBanner.stories.js';
+
+<Meta
+  title={generateTitle('BrandBanner')}
+  parameters={{
+    viewMode: 'docs'
+  }}
+/>
+
+# Brand Banner
+
+<Canvas withSource="none" >
+  <Story story={stories.brandBannerExample} />
+</Canvas>

--- a/packages/core/stories/components/BrandBanner/BrandBanner.stories.mdx
+++ b/packages/core/stories/components/BrandBanner/BrandBanner.stories.mdx
@@ -24,10 +24,17 @@ The brand banner identifies official websites of the Commonwealth of Massachuset
 ## Overview
 
 The Mayflower brand banner is a thin banner attached to the top of all pages of a site for branding and assurance purposes. It contains:
-- An optional state seal (This is optional when the SiteLogo in Header is also a state seal, to avoid repetition)
+- An optional state seal
 - The text: An official website of the Commonwealth of Massachusetts
 
 ## Variations
+### Brand Banner Without the State Seal
+
+In cases where the state seal is being used as the site logo in the Header component, omit the state seal in the brand banner to avoid repetition.
+
+<Canvas withSource="none">
+  <Story story={stories.brandBannerNoSeal} />
+</Canvas>
 
 ### Colors and Themes
 The brand banners are provided in multiple color options in both light and dark theme to work with different adjecent backgrounds and additional branding colors.
@@ -59,3 +66,4 @@ The brand banners are provided in multiple color options in both light and dark 
 <Canvas>
   <Story story={stories.brandBannerDarkGray} />
 </Canvas>
+

--- a/packages/core/stories/components/BrandBanner/BrandBanner.stories.mdx
+++ b/packages/core/stories/components/BrandBanner/BrandBanner.stories.mdx
@@ -20,9 +20,8 @@ The brand banner identifies official websites of the Commonwealth of Massachuset
 
 > It’s required for the mass.gov domain and all its subdomains (mass.gov domain policy), and recommends all other .gov state websites using it as a consistent and trustworthy identifier for the public users. It's prohibited for non Massachusetts state government websites to use this banner.
 
-<br />
 
-# Overview
+## Overview
 
 The Mayflower brand banner is a thin banner attached to the top of all pages of a site for branding and assurance purposes. It contains:
 - An optional state seal (This is optional when the SiteLogo in Header is also a state seal, to avoid repetition)

--- a/packages/core/stories/components/Header/Header.stories.js
+++ b/packages/core/stories/components/Header/Header.stories.js
@@ -15,7 +15,7 @@ import { attachHTML } from '../../util/renderCode';
 
 const { STORYBOOK_CDN_PATH } = process.env;
 
-const headerBasic = (
+export const headerBasic = (
   <HeaderSlim
     siteLogo={(
       <SiteLogo

--- a/packages/core/stories/components/Template/Template.stories.js
+++ b/packages/core/stories/components/Template/Template.stories.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import * as headerStories from '../Header/Header.stories';
 import * as footerStories from '../Footer/Footer.stories';
 import * as brandBannerStories from '../BrandBanner/BrandBanner.stories';
@@ -7,7 +8,9 @@ import { attachHTML } from '../../util/renderCode';
 
 const { STORYBOOK_CDN_PATH } = process.env;
 
-export const Template = ({ renderBrandBanner=brandBannerStories.brandBannerNoSeal(), renderHeader, renderFooter, reversed }) => (
+export const Template = ({
+  renderBrandBanner = brandBannerStories.brandBannerNoSeal(), renderHeader, renderFooter, reversed
+}) => (
   <div id="body-wrapper">
     {renderBrandBanner}
     {renderHeader}
@@ -51,18 +54,29 @@ export const Template = ({ renderBrandBanner=brandBannerStories.brandBannerNoSea
   </div>
 );
 
-const templateSlim = <Template 
-  renderBrandBanner={brandBannerStories.brandBannerNoSeal()}
-  renderHeader={headerStories.headerSlimmest()}
-  renderFooter={footerStories.footerSlim()}
-/>;
+Template.propTypes = {
+  renderBrandBanner: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
+  renderHeader: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
+  renderFooter: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
+  reversed: PropTypes.bool
+};
 
-const templateFullNav = <Template 
-  renderBrandBanner={brandBannerStories.brandBannerNoSeal()}
-  renderHeader={headerStories.headerFullNav()}
-  renderFooter={footerStories.footerFullNav()}
-  reversed={true} 
-/>;
+const templateSlim = (
+  <Template
+    renderBrandBanner={brandBannerStories.brandBannerNoSeal()}
+    renderHeader={headerStories.headerSlimmest()}
+    renderFooter={footerStories.footerSlim()}
+  />
+);
+
+const templateFullNav = (
+  <Template
+    renderBrandBanner={brandBannerStories.brandBannerNoSeal()}
+    renderHeader={headerStories.headerFullNav()}
+    renderFooter={footerStories.footerFullNav()}
+    reversed
+  />
+);
 
 const globalCSS = `<link rel="stylesheet" href="${STORYBOOK_CDN_PATH}/css/global.min.css">`;
 const layoutCSS = `<link rel="stylesheet" href="${STORYBOOK_CDN_PATH}/css/layout.min.css">`;
@@ -110,5 +124,3 @@ attachHTML(templateBasic, templateSlim, notesTemplateSlim);
 
 export const templateFull = () => templateFullNav;
 attachHTML(templateFull, templateFullNav, notesTemplate);
-
- 

--- a/packages/core/stories/components/Template/Template.stories.js
+++ b/packages/core/stories/components/Template/Template.stories.js
@@ -1,13 +1,15 @@
 import React from 'react';
 import * as headerStories from '../Header/Header.stories';
 import * as footerStories from '../Footer/Footer.stories';
+import * as brandBannerStories from '../BrandBanner/BrandBanner.stories';
 
 import { attachHTML } from '../../util/renderCode';
 
 const { STORYBOOK_CDN_PATH } = process.env;
 
-export const template = ({ renderHeader, renderFooter, reversed }) => (
+export const template = ({ renderBrandBanner, renderHeader, renderFooter, reversed }) => (
   <div id="body-wrapper">
+    {renderBrandBanner}
     {renderHeader}
     <main id="main-content">
       <div className="pre-content sp--bottom">
@@ -49,9 +51,18 @@ export const template = ({ renderHeader, renderFooter, reversed }) => (
   </div>
 );
 
-const templateSlim = template({ renderHeader: headerStories.headerSlimmest(), renderFooter: footerStories.footerSlim() });
+const templateSlim = template({ 
+  renderBrandBanner: brandBannerStories.brandBannerNoSeal(),
+  renderHeader: headerStories.headerSlimmest(),
+  renderFooter: footerStories.footerSlim()
+});
 
-const templateFullNav = template({ renderHeader: headerStories.headerFullNav(), renderFooter: footerStories.footerFullNav(), reversed: true });
+const templateFullNav = template({ 
+  renderBrandBanner: brandBannerStories.brandBannerLight(),
+  renderHeader: headerStories.headerFullNav(),
+  renderFooter: footerStories.footerFullNav(),
+  reversed: true 
+});
 
 const notesTemplateSlim = `
   // Link to CSS:

--- a/packages/core/stories/components/Template/Template.stories.js
+++ b/packages/core/stories/components/Template/Template.stories.js
@@ -7,7 +7,7 @@ import { attachHTML } from '../../util/renderCode';
 
 const { STORYBOOK_CDN_PATH } = process.env;
 
-export const template = ({ renderBrandBanner, renderHeader, renderFooter, reversed }) => (
+export const Template = ({ renderBrandBanner, renderHeader, renderFooter, reversed }) => (
   <div id="body-wrapper">
     {renderBrandBanner}
     {renderHeader}
@@ -50,19 +50,31 @@ export const template = ({ renderBrandBanner, renderHeader, renderFooter, revers
     {renderFooter}
   </div>
 );
+Template.args = {
+  renderBrandBanner: brandBannerStories.brandBannerNoSeal()
+}
+Template.argTypes = {
+  renderBrandBanner: {
+    control: {
+      type: 'select',
+      options: ['1', '2']
+    }
+  }
+};
 
-const templateSlim = template({ 
-  renderBrandBanner: brandBannerStories.brandBannerNoSeal(),
-  renderHeader: headerStories.headerSlimmest(),
-  renderFooter: footerStories.footerSlim()
-});
 
-const templateFullNav = template({ 
-  renderBrandBanner: brandBannerStories.brandBannerNoSeal(),
-  renderHeader: headerStories.headerFullNav(),
-  renderFooter: footerStories.footerFullNav(),
-  reversed: true 
-});
+const templateSlim = <Template 
+  renderBrandBanner={brandBannerStories.brandBannerNoSeal()}
+  renderHeader={headerStories.headerSlimmest()}
+  renderFooter={footerStories.footerSlim()}
+/>;
+
+const templateFullNav = <Template 
+  renderBrandBanner={brandBannerStories.brandBannerNoSeal()}
+  renderHeader={headerStories.headerFullNav()}
+  renderFooter={footerStories.footerFullNav()}
+  reversed={true} 
+/>;
 
 const notesTemplateSlim = `
   // Link to CSS:
@@ -102,3 +114,5 @@ attachHTML(templateBasic, templateSlim, notesTemplateSlim);
 
 export const templateFull = () => templateFullNav;
 attachHTML(templateFull, templateFullNav, notesTemplate);
+
+ 

--- a/packages/core/stories/components/Template/Template.stories.js
+++ b/packages/core/stories/components/Template/Template.stories.js
@@ -58,7 +58,7 @@ const templateSlim = template({
 });
 
 const templateFullNav = template({ 
-  renderBrandBanner: brandBannerStories.brandBannerLight(),
+  renderBrandBanner: brandBannerStories.brandBannerNoSeal(),
   renderHeader: headerStories.headerFullNav(),
   renderFooter: footerStories.footerFullNav(),
   reversed: true 

--- a/packages/core/stories/components/Template/Template.stories.js
+++ b/packages/core/stories/components/Template/Template.stories.js
@@ -7,7 +7,7 @@ import { attachHTML } from '../../util/renderCode';
 
 const { STORYBOOK_CDN_PATH } = process.env;
 
-export const Template = ({ renderBrandBanner, renderHeader, renderFooter, reversed }) => (
+export const Template = ({ renderBrandBanner=brandBannerStories.brandBannerNoSeal(), renderHeader, renderFooter, reversed }) => (
   <div id="body-wrapper">
     {renderBrandBanner}
     {renderHeader}
@@ -50,18 +50,6 @@ export const Template = ({ renderBrandBanner, renderHeader, renderFooter, revers
     {renderFooter}
   </div>
 );
-Template.args = {
-  renderBrandBanner: brandBannerStories.brandBannerNoSeal()
-}
-Template.argTypes = {
-  renderBrandBanner: {
-    control: {
-      type: 'select',
-      options: ['1', '2']
-    }
-  }
-};
-
 
 const templateSlim = <Template 
   renderBrandBanner={brandBannerStories.brandBannerNoSeal()}
@@ -76,18 +64,24 @@ const templateFullNav = <Template
   reversed={true} 
 />;
 
+const globalCSS = `<link rel="stylesheet" href="${STORYBOOK_CDN_PATH}/css/global.min.css">`;
+const layoutCSS = `<link rel="stylesheet" href="${STORYBOOK_CDN_PATH}/css/layout.min.css">`;
+const brandBannerCSS = `<link rel="stylesheet" href="${STORYBOOK_CDN_PATH}/css/brand-banner.min.css">`;
+
 const notesTemplateSlim = `
   // Link to CSS:
-  <link rel="stylesheet" href="${STORYBOOK_CDN_PATH}/css/global.css">
-  <link rel="stylesheet" href="${STORYBOOK_CDN_PATH}/css/layout.css">
+  ${globalCSS}
+  ${layoutCSS}
+  ${brandBannerCSS}
   <link rel="stylesheet" href="${STORYBOOK_CDN_PATH}/css/header-slim.css">
   <link rel="stylesheet" href="${STORYBOOK_CDN_PATH}/css/footer-slim.css">
 `;
 
 const notesTemplate = `
   // Link to CSS:
-  <link rel="stylesheet" href="${STORYBOOK_CDN_PATH}/css/global.css">
-  <link rel="stylesheet" href="${STORYBOOK_CDN_PATH}/css/layout.css">
+  ${globalCSS}
+  ${layoutCSS}
+  ${brandBannerCSS}
   <link rel="stylesheet" href="${STORYBOOK_CDN_PATH}/css/header.css">
   <link rel="stylesheet" href="${STORYBOOK_CDN_PATH}/css/footer.css">
 
@@ -98,9 +92,11 @@ const notesTemplate = `
 export const notesTemplateCSS = `
 <head>
   <!-- Mayflower fonts and other basic styles -->
-  <link rel="stylesheet" href="${STORYBOOK_CDN_PATH}/css/global.css">
+  ${globalCSS}
   <!-- Mayflower page layout styles -->
-  <link rel="stylesheet" href="${STORYBOOK_CDN_PATH}/css/layout.css">
+  ${layoutCSS}
+  <!-- Mayflower Brand Banner styles -->
+  ${brandBannerCSS}
   <!-- Add Mayflower Header and Footer specific styles -->
 </head>
 `;

--- a/packages/core/stories/components/Template/Template.stories.mdx
+++ b/packages/core/stories/components/Template/Template.stories.mdx
@@ -22,7 +22,7 @@ The templates demostrates how to assemble a page with a Mayflower Header, Footer
   `
   ${stories.notesTemplateCSS}
 <body>
-  ${renderReactMarkup(stories.template({renderHeader: '// Insert Header HTML here', renderFooter: '// Insert Footer HTML here'}))}
+  ${renderReactMarkup(<stories.Template renderHeader='// Insert Header HTML here' renderFooter = '// Insert Footer HTML here' />)}
   ${stories.notesTemplateJS}
 </body>
   `

--- a/packages/core/stories/meta.json
+++ b/packages/core/stories/meta.json
@@ -59,6 +59,10 @@
     "kind": "Elements",
     "story": "Links"
   },
+  "BrandBanner": {
+    "kind": "Components",
+    "story": "BrandBanner"
+  },
   "Header": {
     "kind": "Components",
     "story": "Header"

--- a/packages/core/stories/styles/index.scss
+++ b/packages/core/stories/styles/index.scss
@@ -30,6 +30,8 @@
 @use '@massds/mayflower-assets/scss/01-atoms/decorative-link';
 @use '@massds/mayflower-assets/scss/02-molecules/callout-link';
 
+// BrandBanner
+@use '@massds/mayflower-assets/scss/02-molecules/brand-banner';
 
 // Header
 @use '@massds/mayflower-assets/scss/01-atoms/site-logo';

--- a/packages/core/stories/tokens/icons/Icon.stories.js
+++ b/packages/core/stories/tokens/icons/Icon.stories.js
@@ -12,7 +12,6 @@ export const Icons = (args) => (
       }
   </ul>
 );
-Icons.storyName = 'All Icons';
 Icons.args = {
   width: 40,
   height: 50,

--- a/packages/react/src/components/atoms/buttons/ButtonWithIcon/index.js
+++ b/packages/react/src/components/atoms/buttons/ButtonWithIcon/index.js
@@ -59,7 +59,7 @@ ButtonWithIcon.propTypes = {
   /** id for the button */
   id: PropTypes.string,
   /** button or link content rendered in a span */
-  children: PropTypes.element,
+  children: PropTypes.oneOfType([PropTypes.element, PropTypes.node]),
   /** When populated with a url, this component renders a <a> vs a <button> */
   href: PropTypes.string,
   // Function to run on click of the button.

--- a/packages/react/src/components/atoms/headings/ColoredHeading/index.js
+++ b/packages/react/src/components/atoms/headings/ColoredHeading/index.js
@@ -28,7 +28,7 @@ ColoredHeading.propTypes = {
   /** The heading level */
   level: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   /** The color of the heading */
-  color: PropTypes.oneOf(['', 'green', 'blue'])
+  color: PropTypes.oneOf(['', 'green', 'blue', 'gray'])
 };
 
 ColoredHeading.defaultProps = {


### PR DESCRIPTION
This PR adds documentation of the BrandBanner component to core:
- Adds documentation, HTML and CSS in BrandBanner page
- Adds BrandBanner to Template page

![Screen Shot 2021-01-07 at 4 30 09 PM](https://user-images.githubusercontent.com/5789411/103947160-a6335380-5105-11eb-83c4-37582a96daa0.png)
