### PR TITLE
[Core] fix Site Logo downloads

### DIFF
--- a/packages/core/stories/tokens/logo/Logo.stories.mdx
+++ b/packages/core/stories/tokens/logo/Logo.stories.mdx
@@ -52,8 +52,8 @@ This is the primary color use of the Great Seal. Specific parts of the Great Sea
   <Story story={stories.sealColor} />
   <Story story={stories.sealColorBGLight} />
   <Story story={stories.sealColorBGDark} />
-	<ButtonWithIcon text="SVG" icon={<IconDownload />} usage="secondary" size="small" capitalizedhref={`${STORYBOOK_CDN_PATH}/static/images/logo/stateseal-color.svg`} download />
-  <ButtonWithIcon text="PNG (200 x 200 px)" icon={<IconDownload />} usage="secondary" size="small" capitalized href={`${STORYBOOK_CDN_PATH}/static/images/logo/stateseal-color.png`} download />
+	<ButtonWithIcon text="SVG" icon={<IconDownload />} usage="secondary" size="small" capitalized href={`${STORYBOOK_CDN_PATH}/static/images/logo/stateseal-color.svg`} download={`${STORYBOOK_CDN_PATH}/static/images/logo/stateseal-color.svg`} target="_blank" />
+  <ButtonWithIcon text="PNG (200 x 200 px)" icon={<IconDownload />} usage="secondary" size="small" capitalized href={`${STORYBOOK_CDN_PATH}/static/images/logo/stateseal-color.png`} download target="_blank"/>
 </Canvas>
 
 ### Single-color variations
@@ -71,8 +71,8 @@ The black variation should be used on a background that is solid white, or a tin
   <Story story={stories.sealBlack} />
   <Story story={stories.sealBlackBGLight} />
   <Story story={stories.sealBlackBGLight1} />
-	<ButtonWithIcon text="SVG" icon={<IconDownload />} usage="secondary" size="small" capitalizedhref={`${STORYBOOK_CDN_PATH}/static/images/logo/stateseal-black.svg`} download />
-  <ButtonWithIcon text="PNG (200 x 200 px)" icon={<IconDownload />} usage="secondary" size="small" capitalized href={`${STORYBOOK_CDN_PATH}/static/images/logo/stateseal-black.png`} download />
+	<ButtonWithIcon text="SVG" icon={<IconDownload />} usage="secondary" size="small" capitalized href={`${STORYBOOK_CDN_PATH}/static/images/logo/stateseal-black.svg`} download={`${STORYBOOK_CDN_PATH}/static/images/logo/stateseal-black.svg`} target="_blank" />
+  <ButtonWithIcon text="PNG (200 x 200 px)" icon={<IconDownload />} usage="secondary" size="small" capitalized href={`${STORYBOOK_CDN_PATH}/static/images/logo/stateseal-black.png`} download target="_blank" />
 </Canvas>
 
 <div className="ma__row">
@@ -86,8 +86,8 @@ The white variation should be used on a background that is a solid brand color, 
   <Story story={stories.sealWhiteBGDark} />
   <Story story={stories.sealWhiteBGDark1} />
   <Story story={stories.sealWhiteBGDark2} />
-	<ButtonWithIcon text="SVG" icon={<IconDownload />} usage="secondary" size="small" capitalized href={`${STORYBOOK_CDN_PATH}/static/images/logo/stateseal-white.svg`} download />
-  <ButtonWithIcon text="PNG (200 x 200 px)" icon={<IconDownload />} usage="secondary" size="small" capitalized href={`${STORYBOOK_CDN_PATH}/static/images/logo/stateseal-white.png`} download />
+	<ButtonWithIcon text="SVG" icon={<IconDownload />} usage="secondary" size="small" capitalized href={`${STORYBOOK_CDN_PATH}/static/images/logo/stateseal-white.svg`} download={`${STORYBOOK_CDN_PATH}/static/images/logo/stateseal-white.svg`} target="_blank" />
+  <ButtonWithIcon text="PNG (200 x 200 px)" icon={<IconDownload />} usage="secondary" size="small" capitalized href={`${STORYBOOK_CDN_PATH}/static/images/logo/stateseal-white.png`} download target="_blank"/>
 </Canvas>
 
 <div className="ma__row">
@@ -101,8 +101,8 @@ The gray variation should be used only on a background that is solid white, or a
   <Story story={stories.seal} />
   <Story story={stories.sealBGLight} />
   <Story story={stories.sealBGLight1} />
-	<ButtonWithIcon text="SVG" icon={<IconDownload />} usage="secondary" size="small" capitalizedhref={`${STORYBOOK_CDN_PATH}/static/images/logo/stateseal.svg`} download />
-  <ButtonWithIcon text="PNG (200 x 200 px)" icon={<IconDownload />} usage="secondary" size="small" capitalized href={`${STORYBOOK_CDN_PATH}/static/images/logo/stateseal.png`} download />
+	<ButtonWithIcon text="SVG" icon={<IconDownload />} usage="secondary" size="small" capitalized href={`${STORYBOOK_CDN_PATH}/static/images/logo/stateseal.svg`} download={`${STORYBOOK_CDN_PATH}/static/images/logo/stateseal.svg`} target="_blank" />
+  <ButtonWithIcon text="PNG (200 x 200 px)" icon={<IconDownload />} usage="secondary" size="small" capitalized href={`${STORYBOOK_CDN_PATH}/static/images/logo/stateseal.png`} download target="_blank" />
 </Canvas>
 
 <br />


### PR DESCRIPTION
All the state seal svg download options don't work on prod https://mayflower.digital.mass.gov/core/index.html?path=/docs/foundation-logo--seal-example

To test:
- [ ] pull down this branch
- [ ] rush start:core
- [ ] navigate to foundation/Logo and verify all download links work properly