### PR TITLE
Release 11.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Mayflower Release Notes
 All notable changes to this project will be documented in this file.
 
+## 11.1.2 (1/26/2021)
+### Changed 
+- (Patternlab) [Assets] DP-20768: Set fillImage.js to get the page content container width for full size elements. (#1337)
+
 ## 11.1.1 (1/25/2021)
 ### Added 
 - (Patternlab) [Figure] DP-20555: Add a skip link to figure component as an accessibility improvement. (#1324)

--- a/changelogs/DP-20768.yml
+++ b/changelogs/DP-20768.yml
@@ -1,6 +1,0 @@
-Changed:
-  - project: Patternlab
-    component: Assets
-    description: Set fillImage.js to get the page content container width for full size elements. (#1337)
-    issue: DP-20768
-    impact: Patch

--- a/packages/core/.env
+++ b/packages/core/.env
@@ -1,4 +1,4 @@
-VERSION=11.1.1
+VERSION=11.1.2
 PKG=@massds/mayflower-assets
 STORYBOOK_CDN=https://unpkg.com/
 STORYBOOK_PKG=$PKG@$VERSION


### PR DESCRIPTION
## 11.1.2 (1/26/2021)
### Changed 
- (Patternlab) [Assets] DP-20768: Set fillImage.js to get the page content container width for full size elements. (#1337)