### PR TITLE
Release/11.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## 11.1.2 (1/26/2021)
 ### Changed 
-- (Patternlab) [Assets] DP-20768: Set fillImage.js to get the page content container width for full size elements. (#1337)
+- (Patternlab) [Assets] DP-20768: Set fillImage.js to get the page content container width for full size elements with figure component. (#1337)
 
 ## 11.1.1 (1/25/2021)
 ### Added 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Mayflower Release Notes
 All notable changes to this project will be documented in this file.
 
+## 11.1.2 (1/26/2021)
+### Changed 
+- (Patternlab) [Assets] DP-20768: Set fillImage.js to get the page content container width for full size elements. (#1337)
+
 ## 11.1.1 (1/25/2021)
 ### Added 
 - (Patternlab) [Figure] DP-20555: Add a skip link to figure component as an accessibility improvement. (#1324)

--- a/changelogs/DP-20768.yml
+++ b/changelogs/DP-20768.yml
@@ -1,0 +1,6 @@
+Changed:
+  - project: Patternlab
+    component: Assets
+    description: Set fillImage.js to get the page content container width for full size elements. (#1337)
+    issue: DP-20768
+    impact: Patch

--- a/changelogs/DP-20768.yml
+++ b/changelogs/DP-20768.yml
@@ -1,6 +1,0 @@
-Changed:
-  - project: Patternlab
-    component: Assets
-    description: Set fillImage.js to get the page content container width for full size elements. (#1337)
-    issue: DP-20768
-    impact: Patch

--- a/packages/assets/scss/01-atoms/_iframe.scss
+++ b/packages/assets/scss/01-atoms/_iframe.scss
@@ -54,6 +54,14 @@
   }
 }
 
+// Full page display 
+
+.ma__figure--full.ma__iframe__container,
+.ma__figure--full .ma__iframe__container {
+  padding-right: 0;
+  padding-left: 0;
+}
+
 //theme
 
 .ma__iframe {

--- a/packages/core/.env
+++ b/packages/core/.env
@@ -1,4 +1,4 @@
-VERSION=11.1.1
+VERSION=11.1.2
 PKG=@massds/mayflower-assets
 STORYBOOK_CDN=https://unpkg.com/
 STORYBOOK_PKG=$PKG@$VERSION

--- a/packages/patternlab/styleguide/source/assets/js/modules/imageFill.js
+++ b/packages/patternlab/styleguide/source/assets/js/modules/imageFill.js
@@ -8,7 +8,7 @@ export default (function (window, document, $, undefined) {
 
   function mediaWidth() {
     // Define wrapper width for use.
-    var wrapperWidth = $(".main-content").width();
+    var wrapperWidth = $("#main-content > .main-content--two").width();
 
     $(".ma__figure--full, .ma__iframe--full").each(function () {
       var $thisMedia = $(this);


### PR DESCRIPTION
## 11.1.2 (1/26/2021)
### Changed 
- (Patternlab) [Assets] DP-20768: Set fillImage.js to get the page content container width for full size elements. (#1337)