### PR TITLE
Release 11.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Mayflower Release Notes
 All notable changes to this project will be documented in this file.
 
+## 11.1.3 (2/1/2021)
+### Changed 
+- (Patternlab) [Relationship Indicator] DP-19859: Fix the Relationship Indicator display at the show all state in IE. (#1341)
+
+### Fixed 
+- (Patternlab) [Figure] DP-21059: Make a skip link target to be displayed only when its associated skip link is clicked. (#1352)
+
 ## 11.1.2 (1/26/2021)
 ### Changed 
 - (Patternlab) [Assets] DP-20768: Set fillImage.js to get the page content container width for full size elements with figure component. (#1337)

--- a/changelogs/DP-19859.yml
+++ b/changelogs/DP-19859.yml
@@ -1,6 +1,0 @@
-Changed:
-  - project: Patternlab
-    component: Relationship Indicator
-    description: Fix the Relationship Indicator display at the show all state in IE. (#1341)
-    issue: DP-19859
-    impact: Patch

--- a/changelogs/DP-21059.yml
+++ b/changelogs/DP-21059.yml
@@ -1,0 +1,6 @@
+Fixed:
+  - project: Patternlab
+    component: Figure
+    description: Make a skip link target to be displayed only when its associated skip link is clicked. (#1352)
+    issue: DP-21059
+    impact: Patch

--- a/changelogs/DP-21059.yml
+++ b/changelogs/DP-21059.yml
@@ -1,6 +1,0 @@
-Fixed:
-  - project: Patternlab
-    component: Figure
-    description: Make a skip link target to be displayed only when its associated skip link is clicked. (#1352)
-    issue: DP-21059
-    impact: Patch

--- a/packages/assets/scss/01-atoms/_figure.scss
+++ b/packages/assets/scss/01-atoms/_figure.scss
@@ -44,7 +44,6 @@
     }
 
     &:target {
-      display: block;
 
       & .ma__figure__skip-link_destination {
         // The border is added to be more recognizable.

--- a/packages/core/.env
+++ b/packages/core/.env
@@ -1,4 +1,4 @@
-VERSION=11.1.2
+VERSION=11.1.3
 PKG=@massds/mayflower-assets
 STORYBOOK_CDN=https://unpkg.com/
 STORYBOOK_PKG=$PKG@$VERSION

--- a/packages/patternlab/styleguide/source/assets/js/modules/skipLinkTarget.js
+++ b/packages/patternlab/styleguide/source/assets/js/modules/skipLinkTarget.js
@@ -1,49 +1,34 @@
-// Find the skip link which has focus.
+/**
+ * Control display of a skip link target component.
+ */
 document.querySelectorAll(".ma__figure__skip-link").forEach(link => {
 
   let linkTarget = "";
   let linkTargetHash = "";
 
-  link.addEventListener("focus", (e) => {
+  link.addEventListener("click", (e) => {
     // Find the matched linkTarget.
     let sibling = e.currentTarget.nextElementSibling;
 
-    // Remove inline style when users move backward while the target is still active
-    // to display the link target as the link is clicked.
-    if (linkTarget.hasAttribute("style")) {
-      linkTarget.removeAttribute("style");
-    }
-
-    // let figure;
     while (sibling) {
       if (sibling.hasAttribute("id") && sibling.id.includes("figure-")) {
         linkTarget = sibling;
-      }
 
+        // Show the linkTarget.
+        linkTarget.style.display = "block";
+      }
       sibling = sibling.nextElementSibling;
     }
-
-    // After the skip link is clicked, check a keypress action with tab or arrow keys,
-    // which indicates that users attempts to leave the link target to another element.
-    document.addEventListener("keydown", (e) => {
-      if (e.key === "Tab" || e.key === "ArrowUp" || e.key === "ArrowRight" || e.key === "ArrowDown" || e.key === "ArrowLeft" ) {
-        linkTarget.style.display = "none";
-        linkTargetHash = location.hash;
-      }
-    });
   });
 
-  // Check for hash change to clean up the inline style.
-  window.addEventListener("hashchange", () => {
-    // Below runs only with a skip link hash.
-    if (location.hash.includes("figure-")) {
-      let newHash = location.hash;
-      if (linkTargetHash !== location.hash && linkTarget.hasAttribute("style")) {
-        // Remove inline syle added earlier.
-        linkTarget.removeAttribute("style");
-        // Update linkTargetHash with the current hash.
-        linkTargetHash = newHash;
-      }
+  // Hide the linkTarget as users move to next element.
+  // After the skip link is clicked, check a keypress action with tab or arrow keys,
+  // which indicates that users attempts to leave the link target to another element.
+  // No need to display the link target at this point.
+  // a link target never gets focus.
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Tab" || e.key === "ArrowUp" || e.key === "ArrowRight" || e.key === "ArrowDown" || e.key === "ArrowLeft" ) {
+      document.querySelector(location.hash).style.display = "none";
     }
-  }, false);
+  });
 });


### PR DESCRIPTION
## 11.1.3 (2/1/2021)
### Changed 
- (Patternlab) [Relationship Indicator] DP-19859: Fix the Relationship Indicator display at the show all state in IE. (#1341)

### Fixed 
- (Patternlab) [Figure] DP-21059: Make a skip link target to be displayed only when its associated skip link is clicked. (#1352)
