### PR TITLE
[Core] add a way to directly download the mayflower assets package

### DIFF
--- a/changelogs/DP-21186.yml
+++ b/changelogs/DP-21186.yml
@@ -1,0 +1,48 @@
+# Every PR must have a changelog. To create a changelog:
+# 1. Make a copy of this file and name it with the ticket number.
+# 2. Keep the original format of one of the examples at the bottom, and override each element of it using ___TEMPLATE___ for reference
+# 3. Remove all comments from the copied file
+
+#___CHANGE TYPES___
+# - Added for new features.
+# - Changed for changes in existing functionality.
+# - Deprecated for soon-to-be removed features.
+# - Removed for now removed features.
+# - Fixed for any bug fixes.
+# - Security in case of vulnerabilities.
+# e.g. Added
+
+#___PROJECT___
+# - Patternlab
+# - React
+# - Docs
+# e.g. React
+# e.g. React, Patternlab
+
+#___COMPONENT___
+# Component name(s) in `PascalCase`
+# e.g. Header
+# e.g. Form, InputSlider, InputTextTypeAhead
+
+#___DESCRIPTION___
+# PR description and PR number (append PR number with # to create a link to the PR in Github)
+# If you need multiple lines, start the first line with the following "|-" characters.
+# For any breaking changes, add a comment in the PR describing the necessary changes on the consumer side and link that comment in the description.
+#e.g. Adds apples to apple trees for admin apple pickers (#PR)
+
+#___ISSUE___
+# A Jira ticket or a Github issue number (append Github issue number with # to create a link to the issue in Github)
+# e.g. DP-12345 or #123
+
+#___IMPACT___
+# - Major impact when you make incompatible API changes,
+# - Minor impact when you add functionality in a backwards compatible manner, and
+# - Patch impact when you make backwards compatible bug fixes.
+# e.g. Minor
+# See https://semver.org/ for more info.
+Added:
+  - project: Core
+    component: Usage
+    description: Added documentation on downloading the mayflower assets package without using npm. (#1357)
+    issue: DP-21186
+    impact: Patch

--- a/packages/core/stories/about/Usage.stories.mdx
+++ b/packages/core/stories/about/Usage.stories.mdx
@@ -3,12 +3,12 @@ import { linkTo } from '@storybook/addon-links';
 import Button from '@massds/mayflower-react/dist/Button';
 
 import generateTitle from '../util/generateTitle';
-const { STORYBOOK_CDN_PATH, STORYBOOK_CDN, STORYBOOK_PKG } = process.env;
+const { STORYBOOK_CDN_PATH, STORYBOOK_CDN, STORYBOOK_PKG, PKG, VERSION } = process.env;
 
 
 <Meta title={generateTitle('Usage')} />
 
-<h1>Get Started with Mayflower <small>version {process.env.VERSION}</small></h1>
+<h1>Get Started with Mayflower <small>version {VERSION}</small></h1>
 
 
 
@@ -57,6 +57,13 @@ The package @massds/mayflower-assets is published on NPM. If you use Node.js, yo
 npm install @massds/mayflower-assets
 ```
 
+If you are not using NPM, you can also directly <a href={`https://registry.npmjs.org/${PKG}/-/mayflower-assets-${VERSION}.tgz`}>download a compressed package for the latest version</a>, or specify a version in the URL:
+<pre>
+  <code>
+  {`https://registry.npmjs.org/${PKG}/-/mayflower-assets-[version].tgz`}
+  </code>
+</pre>
+
 ### Link to the Mayflower CDN
 
 Mayflower leverages the UNPKG CDN and allows you to load any file in the @massds/mayflower-assets package directly.
@@ -64,7 +71,7 @@ Mayflower leverages the UNPKG CDN and allows you to load any file in the @massds
 To load any file from the @massds/mayflower-assets package using a URL like:
 
 ```
-unpkg.com/@massds/mayflower-assets@:version/:file
+unpkg.com/@massds/mayflower-assets@[version]/[file]
 ```
 
 To explore the whole package for a specific version, you can


### PR DESCRIPTION
Added:
  - project: Core
    component: Usage
    description: Added documentation on downloading the mayflower assets package without using npm. (#1357)
    issue: DP-21186
    impact: Patch

![Screen Shot 2021-02-10 at 3 35 00 PM](https://user-images.githubusercontent.com/5789411/107579126-aae69e00-6bc2-11eb-8163-481df627c66a.png)



Test link:  https://mayflower.digital.mass.gov/core/b/core/add-alternative-download/index.html?path=/docs/overview-get-started--page