### PR TITLE
Dp 20435/refactor utility nav for reuse

### DIFF
--- a/packages/react/src/components/organisms/Header/UtilityNav.data.js
+++ b/packages/react/src/components/organisms/Header/UtilityNav.data.js
@@ -1,12 +1,13 @@
 export default {
-  items: [{
+  stateItem: {
     text: 'State Organizations',
-    ariaLabelText: '',
+    ariaLabel: '',
     icon: 'building',
     link: 'https://www.mass.gov/info-details/massachusetts-state-organizations-a-to-z'
-  }, {
+  },
+  loginItem: {
     text: 'Log in to...',
-    ariaLabelText: 'Log in to one of Mass.gov\'s most frequently accessed services',
+    ariaLabel: 'Log in to one of Mass.gov\'s most frequently accessed services',
     icon: 'login',
     closeText: 'Close',
     panel: {
@@ -25,5 +26,5 @@ export default {
         type: 'external'
       }]
     }
-  }]
+  }
 };

--- a/packages/react/src/components/organisms/Header/UtilityNav.data.js
+++ b/packages/react/src/components/organisms/Header/UtilityNav.data.js
@@ -7,13 +7,10 @@ export default {
   }, {
     text: 'Log in to...',
     ariaLabelText: 'Log in to one of Mass.gov\'s most frequently accessed services',
-    description: 'Top-requested sites to log in to services provided by the state',
     icon: 'login',
     closeText: 'Close',
     panel: {
-      description: {
-        text: 'Top-requested sites to log in to services provided by the state'
-      },
+      description: 'Top-requested sites to log in to services provided by the state',
       links: [{
         text: 'Virtual Gateway (SNAP)',
         href: 'https://sso.hhs.state.ma.us/oam/server/obrareq.cgi?encquery%3DA2%2Fmo5AkZreDycpyP0JZAEOYGvW2hviyNhH9Sht2xPp0V1%2BBtWfHnmRGr6zNHOqOlcjphPk7p6bpHHRyNzzk9IYQ%2FcN%2B%2FIcqL2ThnI217OsIKZepptTpGBx83SI0NWjsE7vDi72caItXWlelbGQT7ePanlrVUUy2%2Fj1UEUaXi5G7m47KO9djBnoetZRCtp9G2ZTNFf6zvCGU7Cs02AXYUj2JMH4aqol%2Bh3OK6uhJNNkFvwQ1MFRUa4gR1az4iaW9u83ExKb2a9eDv8ZIUqhlq3%2BNVGTqZHAsHX4KOONSGQRBwCtLNPWwruacjdd9CaEqeIJ2tnP45KrM93edZ6zU1yoWGbAp%2BUWWMqk4HyrtuA8%3D%20agentid%3Dwebgate1%20ver%3D1%20crmethod%3D2',

--- a/packages/react/src/components/organisms/Header/UtilityNav.data.js
+++ b/packages/react/src/components/organisms/Header/UtilityNav.data.js
@@ -1,0 +1,32 @@
+export default {
+  items: [{
+    text: 'State Organizations',
+    ariaLabelText: '',
+    icon: 'building',
+    link: 'https://www.mass.gov/info-details/massachusetts-state-organizations-a-to-z'
+  }, {
+    text: 'Log in to...',
+    ariaLabelText: 'Log in to one of Mass.gov\'s most frequently accessed services',
+    description: 'Top-requested sites to log in to services provided by the state',
+    icon: 'login',
+    closeText: 'Close',
+    panel: {
+      description: {
+        text: 'Top-requested sites to log in to services provided by the state'
+      },
+      links: [{
+        text: 'Virtual Gateway (SNAP)',
+        href: 'https://sso.hhs.state.ma.us/oam/server/obrareq.cgi?encquery%3DA2%2Fmo5AkZreDycpyP0JZAEOYGvW2hviyNhH9Sht2xPp0V1%2BBtWfHnmRGr6zNHOqOlcjphPk7p6bpHHRyNzzk9IYQ%2FcN%2B%2FIcqL2ThnI217OsIKZepptTpGBx83SI0NWjsE7vDi72caItXWlelbGQT7ePanlrVUUy2%2Fj1UEUaXi5G7m47KO9djBnoetZRCtp9G2ZTNFf6zvCGU7Cs02AXYUj2JMH4aqol%2Bh3OK6uhJNNkFvwQ1MFRUa4gR1az4iaW9u83ExKb2a9eDv8ZIUqhlq3%2BNVGTqZHAsHX4KOONSGQRBwCtLNPWwruacjdd9CaEqeIJ2tnP45KrM93edZ6zU1yoWGbAp%2BUWWMqk4HyrtuA8%3D%20agentid%3Dwebgate1%20ver%3D1%20crmethod%3D2',
+        type: 'external'
+      }, {
+        text: 'Unemployment Online',
+        href: 'https://uionline.detma.org/Claimant/Core/Login.ASPX',
+        type: 'external'
+      }, {
+        text: 'Child Support Enforcement',
+        href: 'https://ecse.cse.state.ma.us/ECSE/Login/login.asp',
+        type: 'external'
+      }]
+    }
+  }]
+};

--- a/packages/react/src/components/organisms/Header/index.js
+++ b/packages/react/src/components/organisms/Header/index.js
@@ -35,6 +35,8 @@ import { LoginItem, TranslateItem, StateItem } from 'MayflowerReactOrganisms/Hea
 import getFallbackComponent from 'MayflowerReactComponents/utilities/getFallbackComponent';
 import useWindowWidth from 'MayflowerReactComponents/hooks/use-window-width';
 
+import UtilityNavData from './UtilityNav.data';
+
 const DefaultMobileLogo = React.memo(() => (<HamburgerSiteLogo Wrapper={HamburgerMobileLogoWrapper} />));
 
 const Header = ({
@@ -65,7 +67,7 @@ const Header = ({
         tempItems.push(TranslateItem);
       }
       tempItems.push(StateItem);
-      tempItems.push(LoginItem);
+      tempItems.push(<LoginItem data={UtilityNavData.items[1]} />);
       return tempItems;
     }
     return utilityItems;

--- a/packages/react/src/components/organisms/Header/index.js
+++ b/packages/react/src/components/organisms/Header/index.js
@@ -35,8 +35,6 @@ import { LoginItem, TranslateItem, StateItem } from 'MayflowerReactOrganisms/Hea
 import getFallbackComponent from 'MayflowerReactComponents/utilities/getFallbackComponent';
 import useWindowWidth from 'MayflowerReactComponents/hooks/use-window-width';
 
-import UtilityNavData from './UtilityNav.data';
-
 const DefaultMobileLogo = React.memo(() => (<HamburgerSiteLogo Wrapper={HamburgerMobileLogoWrapper} />));
 
 const Header = ({
@@ -67,7 +65,7 @@ const Header = ({
         tempItems.push(TranslateItem);
       }
       tempItems.push(StateItem);
-      tempItems.push(<LoginItem data={UtilityNavData.items[1]} />);
+      tempItems.push(LoginItem);
       return tempItems;
     }
     return utilityItems;

--- a/packages/react/src/components/organisms/Header/utility-items.js
+++ b/packages/react/src/components/organisms/Header/utility-items.js
@@ -223,6 +223,7 @@ PanelItem.propTypes = {
   title: propTypes.string,
   CustomIcon: propTypes.elementType,
   description: propTypes.string,
+  ariaLabel: propTypes.string,
   links: propTypes.arrayOf(propTypes.object)
 };
 
@@ -244,7 +245,7 @@ LoginItem.propTypes = {
   data: propTypes.shape({
     panel: propTypes.shape({
       description: propTypes.string,
-      links: propTypes.array
+      links: propTypes.arrayOf(propTypes.object)
     }),
     text: propTypes.string,
     ariaLabel: propTypes.string

--- a/packages/react/src/components/organisms/Header/utility-items.js
+++ b/packages/react/src/components/organisms/Header/utility-items.js
@@ -230,16 +230,26 @@ PanelItem.propTypes = {
 export const LoginItem = ({
   data = UtilityNavData.items[1]
 }) => {
-  const { panel, text, ariaLabelText, description } = data;
+  const { panel: { links, description }, text, ariaLabelText } = data;
   return(
     <PanelItem
-      links={panel.links}
+      links={links}
       title={text}
       CustomIcon={IconLogin}
       description={description}
       ariaLabelText={ariaLabelText}
     />
   )
+};
+LoginItem.propTypes = {
+  data: propTypes.shape({
+    panel: propTypes.shape({
+      description: propTypes.string,
+      links: propTypes.array
+    }),
+    text: propTypes.string,
+    ariaLabelText: propTypes.string
+  })
 };
 
 export const TranslateItem = () => {
@@ -255,7 +265,9 @@ export const TranslateItem = () => {
   );
 };
 
-export const StateItem = () => (
+export const StateItem = ({
+  data
+}) => (
   <a className="ma__utility-nav__link direct-link" href="#">
     <IconBuilding />
     <span>State Organizations</span>

--- a/packages/react/src/components/organisms/Header/utility-items.js
+++ b/packages/react/src/components/organisms/Header/utility-items.js
@@ -31,7 +31,7 @@ const PanelItem = ({
   title = '',
   CustomIcon,
   description = '',
-  ariaLabelText = '',
+  ariaLabel = '',
   links = []
 }) => {
   const windowWidth = useWindowWidth();
@@ -181,7 +181,7 @@ const PanelItem = ({
         type="button"
         className="ma__utility-nav__link js-util-nav-toggle"
         aria-haspopup="true"
-        aria-label={ariaLabelText}
+        aria-label={ariaLabel}
         aria-expanded="false"
       >
         {CustomIcon && <CustomIcon />}
@@ -228,16 +228,16 @@ PanelItem.propTypes = {
 };
 
 export const LoginItem = ({
-  data = UtilityNavData.items[1]
+  data = UtilityNavData.loginItem
 }) => {
-  const { panel: { links, description }, text, ariaLabelText } = data;
+  const { panel: { links, description }, text, ariaLabel } = data;
   return(
     <PanelItem
       links={links}
       title={text}
       CustomIcon={IconLogin}
       description={description}
-      ariaLabelText={ariaLabelText}
+      ariaLabel={ariaLabel}
     />
   )
 };
@@ -248,7 +248,7 @@ LoginItem.propTypes = {
       links: propTypes.array
     }),
     text: propTypes.string,
-    ariaLabelText: propTypes.string
+    ariaLabel: propTypes.string
   })
 };
 
@@ -266,10 +266,20 @@ export const TranslateItem = () => {
 };
 
 export const StateItem = ({
-  data
-}) => (
-  <a className="ma__utility-nav__link direct-link" href="#">
+  data = UtilityNavData.stateItem
+}) => {
+  const { link, ariaLabel, text } = data;
+  return (
+  <a className="ma__utility-nav__link direct-link" href={link} aria-label={ariaLabel}>
     <IconBuilding />
-    <span>State Organizations</span>
+    <span>{text}</span>
   </a>
-);
+)};
+
+StateItem.propTypes = {
+  data: propTypes.shape({
+    link: propTypes.string,
+    text: propTypes.string,
+    ariaLabel: propTypes.string
+  })
+};

--- a/packages/react/src/components/organisms/Header/utility-items.js
+++ b/packages/react/src/components/organisms/Header/utility-items.js
@@ -4,121 +4,139 @@ import GoogleTranslateElement from 'MayflowerReactButtons/GoogleTranslateElement
 import IconBuilding from 'MayflowerReactBase/Icon/IconBuilding';
 import IconLogin from 'MayflowerReactBase/Icon/IconLogin';
 import useWindowWidth from 'MayflowerReactComponents/hooks/use-window-width';
+import UtilityNavData from './UtilityNav.data';
 
-export const LoginItem = ({ narrow }) => {
+const UtilityLink = ({ href, children }) => (
+  <li className="ma__utility-panel__item js-clickable">
+    <span className="ma__decorative-link">
+      <a
+        href={href}
+        className="js-clickable-link"
+      >
+        {children}
+        <svg aria-hidden="true" focusable="false"><use xlinkHref="#7d83e994275beeb5601876202075c2b3.422" /></svg>
+        <svg xmlns="http://www.w3.org/2000/svg" style={{ display: 'none' }}><symbol xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" version="1.1" viewBox="0 0 16 18" id="7d83e994275beeb5601876202075c2b3.422"><path d="M983.721 1887.28L983.721 1887.28L986.423 1890L986.423 1890L986.423 1890L983.721 1892.72L983.721 1892.72L978.318 1898.17L975.617 1895.45L979.115 1891.92L971.443 1891.92L971.443 1888.0700000000002L979.103 1888.0700000000002L975.617 1884.5500000000002L978.318 1881.8300000000002Z " transform="matrix(1,0,0,1,-971,-1881)" /></symbol></svg>
+      </a>
+    </span>
+  </li>
+);
+UtilityLink.propTypes = {
+  href: propTypes.string,
+  children: propTypes.node
+};
+
+
+const PanelItem = ({
+  narrow,
+  title = '',
+  CustomIcon,
+  description = '',
+  ariaLabelText = '',
+  links = []
+}) => {
+  const windowWidth = useWindowWidth();
+  const isMobileWindow = windowWidth !== null && windowWidth < 860;
   const loginToggleRef = React.useRef();
   const loginContentRef = React.useRef();
   const loginCloseRef = React.useRef();
+  const loginContainerRef = React.useRef();
   React.useEffect(() => {
     const utilButton = loginToggleRef.current;
     const utilCloseButton = loginCloseRef.current;
     const utilContent = loginContentRef.current;
-    const utilContainer = utilContent ? utilContent.querySelector('.ma__utility-nav__container') : null;
-    if (utilButton && utilCloseButton && utilContent) {
-      // Open
-      if (!narrow) {
-        const closeUtilWideContent = () => {
-          // Content state
-          utilContent.style.height = '0';
-          utilContent.style.opacity = '0';
-          utilContent.classList.add('is-closed');
-          utilContent.setAttribute('aria-hidden', 'true');
-          // Close button state
-          utilCloseButton.setAttribute('aria-expanded', 'false');
-          // Utility button state
-          utilButton.setAttribute('aria-expanded', 'false');
-          utilButton.setAttribute('aria-pressed', 'false');
-          const closestHamburgerNav = utilButton.closest('.ma__header__hamburger__nav');
-          if (closestHamburgerNav) {
-            closestHamburgerNav.classList.toggle('util-nav-content-open');
-          }
-        };
-        utilButton.addEventListener('click', (e) => {
-          const thisWideButton = e.target.closest('.js-util-nav-toggle');
-          const thisWideContent = thisWideButton.nextElementSibling;
-
-          if (thisWideContent.classList.contains('is-closed')) {
-            const closestHamburgerNav = thisWideButton.closest('.ma__header__hamburger__nav');
-            if (closestHamburgerNav) {
-              closestHamburgerNav.classList.add('util-nav-content-open');
-            }
-
-            thisWideContent.classList.remove('is-closed');
-            thisWideContent.removeAttribute('aria-hidden');
-            thisWideContent.removeAttribute('style');
-            thisWideContent.style.height = 'auto';
-            thisWideContent.style.opacity = '1';
-
-            // Button State
-            thisWideButton.setAttribute('aria-expanded', 'true');
-            thisWideButton.setAttribute('aria-pressed', 'true');
-          }
-
-          thisWideButton.setAttribute('aria-expanded', 'true');
-          thisWideButton.setAttribute('aria-pressed', 'true');
-        });
-        utilCloseButton.addEventListener('click', () => {
-          closeUtilWideContent();
-        });
-      } else {
-        const closeNarrowUtilContent = () => {
-          const thisNavContainer = utilButton.closest('.ma__utility-nav__item');
-          utilButton.setAttribute('aria-expanded', 'false');
-          utilContent.setAttribute('aria-hidden', 'true');
-          thisNavContainer.style.pointerEvents = 'none';
-          setTimeout(() => {
-            thisNavContainer.removeAttribute('style');
-          }, 700);
-          utilContent.style.maxHeight = '0';
-          utilContainer.style.opacity = '0';
-          setTimeout(() => {
-            utilContent.classList.add('is-closed');
-          }, 500);
-        };
-        utilContent.style.maxHeight = '0';
-        utilContainer.style.opacity = '0';
-
-        utilButton.addEventListener('click', (e) => {
-          const thisButton = e.target.closest('.js-util-nav-toggle');
-          const thisNavContainer = e.target.closest('.ma__utility-nav__item');
-          const utilNarrowContent = thisButton.nextElementSibling;
-
-          if (utilNarrowContent.classList.contains('is-closed')) {
-            // TO OPEN
-
-            closeSubMenu();
-
-            thisButton.setAttribute('aria-expanded', 'true');
-            utilNarrowContent.removeAttribute('aria-hidden');
-            thisNavContainer.style.pointerEvents = 'none';
-            /** Slide down. */
-            thisNavContainer.removeAttribute('style');
-
-            /** Show the content. */
-            utilNarrowContent.classList.remove('is-closed');
-            utilNarrowContent.style.maxHeight = 'auto';
-
-            /** Get the computed height of the content. */
-            const contentHeight = `${utilContent.querySelector('.ma__utility-nav__content-body').clientHeight}px`;
-
-            /** Set the height of the submenu as 0px, */
-            /** so we can trigger the slide down animation. */
-            utilContent.style.maxHeight = '0';
-            utilContent.style.Height = '0';
-
-            // These height settings display the bottom border of the parent li at the correct spot.
-            utilContent.style.height = contentHeight;
-            utilContainer.style.height = contentHeight;
-
-            utilContent.style.maxHeight = contentHeight;
-            utilContainer.style.opacity = '1';
-          } else {
-            closeNarrowUtilContent();
-          }
-        });
+    const utilContainer = utilContent ? loginContainerRef.current : null;
+    const closeUtilWideContent = () => {
+      // Content state
+      utilContent.style.height = '0';
+      utilContent.style.opacity = '0';
+      utilContent.classList.add('is-closed');
+      utilContent.setAttribute('aria-hidden', 'true');
+      // Close button state
+      utilCloseButton.setAttribute('aria-expanded', 'false');
+      // Utility button state
+      utilButton.setAttribute('aria-expanded', 'false');
+      utilButton.setAttribute('aria-pressed', 'false');
+      const closestHamburgerNav = utilButton.closest('.ma__header__hamburger__nav');
+      if (closestHamburgerNav) {
+        closestHamburgerNav.classList.toggle('util-nav-content-open');
       }
-    }
+    };
+    const closeNarrowUtilContent = () => {
+      const thisNavContainer = utilButton.closest('.ma__utility-nav__item');
+      utilButton.setAttribute('aria-expanded', 'false');
+      utilContent.setAttribute('aria-hidden', 'true');
+      thisNavContainer.style.pointerEvents = 'none';
+      setTimeout(() => {
+        thisNavContainer.removeAttribute('style');
+      }, 700);
+      utilContent.style.maxHeight = '0';
+      utilContainer.style.opacity = '0';
+      setTimeout(() => {
+        utilContent.classList.add('is-closed');
+      }, 500);
+    };
+    const utilButtonNarrowClick = (e) => {
+      const thisButton = e.target.closest('.js-util-nav-toggle');
+      const thisNavContainer = e.target.closest('.ma__utility-nav__item');
+      const utilNarrowContent = thisButton.nextElementSibling;
 
+      if (utilNarrowContent.classList.contains('is-closed')) {
+        // TO OPEN
+
+        closeSubMenu();
+
+        thisButton.setAttribute('aria-expanded', 'true');
+        utilNarrowContent.removeAttribute('aria-hidden');
+        thisNavContainer.style.pointerEvents = 'none';
+        /** Slide down. */
+        thisNavContainer.removeAttribute('style');
+
+        /** Show the content. */
+        utilNarrowContent.classList.remove('is-closed');
+        utilNarrowContent.style.maxHeight = 'auto';
+
+        /** Get the computed height of the content. */
+        const contentHeight = `${utilContent.querySelector('.ma__utility-nav__content-body').clientHeight}px`;
+
+        /** Set the height of the submenu as 0px, */
+        /** so we can trigger the slide down animation. */
+        utilContent.style.maxHeight = '0';
+        utilContent.style.Height = '0';
+
+        // These height settings display the bottom border of the parent li at the correct spot.
+        utilContent.style.height = contentHeight;
+        utilContainer.style.height = contentHeight;
+
+        utilContent.style.maxHeight = contentHeight;
+        utilContainer.style.opacity = '1';
+      } else {
+        closeNarrowUtilContent();
+      }
+    };
+    const utilButtonWideClick = (e) => {
+      const thisWideButton = e.target.closest('.js-util-nav-toggle');
+      const thisWideContent = thisWideButton.nextElementSibling;
+
+      if (thisWideContent.classList.contains('is-closed')) {
+        const closestHamburgerNav = thisWideButton.closest('.ma__header__hamburger__nav');
+        if (closestHamburgerNav) {
+          closestHamburgerNav.classList.add('util-nav-content-open');
+        }
+
+        thisWideContent.classList.remove('is-closed');
+        thisWideContent.removeAttribute('aria-hidden');
+        thisWideContent.removeAttribute('style');
+        thisWideContent.style.height = 'auto';
+        thisWideContent.style.opacity = '1';
+
+        // Button State
+        thisWideButton.setAttribute('aria-expanded', 'true');
+        thisWideButton.setAttribute('aria-pressed', 'true');
+      }
+
+      thisWideButton.setAttribute('aria-expanded', 'true');
+      thisWideButton.setAttribute('aria-pressed', 'true');
+    };
     function closeSubMenu() {
       const openSubMenu = document.querySelector('.submenu-open');
 
@@ -137,7 +155,25 @@ export const LoginItem = ({ narrow }) => {
         openSubMenu.classList.remove('submenu-open');
       }
     }
-  }, [narrow, loginToggleRef, loginCloseRef, loginContentRef]);
+    if (utilButton && utilCloseButton && utilContent && utilContainer) {
+      // Open
+      if (!isMobileWindow) {
+        utilContent.removeAttribute('style');
+        utilContainer.removeAttribute('style');
+        utilButton.addEventListener('click', utilButtonWideClick);
+        utilCloseButton.addEventListener('click', closeUtilWideContent);
+      } else {
+        utilContent.style.maxHeight = '0';
+        utilContainer.style.opacity = '0';
+        utilButton.addEventListener('click', utilButtonNarrowClick);
+      }
+    }
+    return(() => {
+      utilButton.removeEventListener('click', utilButtonWideClick);
+      utilCloseButton.removeEventListener('click', closeUtilWideContent);
+      utilButton.removeEventListener('click', utilButtonNarrowClick);
+    });
+  }, [isMobileWindow, narrow, loginToggleRef, loginCloseRef, loginContentRef, loginContainerRef]);
   return(
     <React.Fragment>
       <button
@@ -145,181 +181,65 @@ export const LoginItem = ({ narrow }) => {
         type="button"
         className="ma__utility-nav__link js-util-nav-toggle"
         aria-haspopup="true"
-        aria-label="Log in links for this page"
+        aria-label={ariaLabelText}
         aria-expanded="false"
       >
-        <IconLogin />
-        <span>
-          Log in to...
-        </span>
+        {CustomIcon && <CustomIcon />}
+        {title && title.length > 0 && (<span>{title}</span>)}
         <span className="toggle-indicator" aria-hidden="true" />
       </button>
       <div ref={loginContentRef} aria-hidden="true" className="ma__utility-nav__content js-util-nav-content is-closed">
-        <div className="ma__utility-nav__container">
+        <div ref={loginContainerRef} className="ma__utility-nav__container">
           <div className="ma__utility-nav__content-title">
             <button ref={loginCloseRef} type="button" className="ma__utility-nav__close js-close-util-nav">
               <span>Close</span>
               <span className="ma__utility-nav__close-icon" aria-hidden="true">+</span>
             </button>
-            <svg aria-hidden="true" focusable="false"><use xlinkHref="#5165fd979757da72f1a1a3a1b4595e1e.7" /></svg>
-            <svg xmlns="http://www.w3.org/2000/svg" style={{ display: 'none' }}><symbol xmlns="http://www.w3.org/2000/svg" aria-hidden="true" version="1.1" viewBox="0 0 20 16" id="5165fd979757da72f1a1a3a1b4595e1e.7"><path d="M1338.67 19.6L1338.67 16.400000000000002L1345.3300000000002 22L1338.67 27.6L1338.67 24.400000000000002L1332 24.400000000000002L1332 19.6ZM1340.33 14L1340.33 15.6L1350.33 15.6L1350.33 28.4L1340.33 28.4L1340.33 30L1352 30L1352 14Z " transform="matrix(1,0,0,1,-1332,-14)" /></symbol></svg>
-            <h2>Log in to...</h2>
+            {CustomIcon && <CustomIcon />}
+            {title && title.length > 0 && (<h2>{title}</h2>)}
           </div>
           <div className="ma__utility-nav__content-body">
-
             <div className="ma__utility-panel">
-              <div className="ma__utility-panel__description ma__utility-panel__description--full">
-
-                <div className="ma__rich-text ">
-                  <p>Login links for this page</p>
+              {description && description.length > 0 && (
+                <div className="ma__utility-panel__description ma__utility-panel__description--full">
+                  <div className="ma__rich-text">
+                    <p>{description}</p>
+                  </div>
                 </div>
-              </div>
-
+              )}
               <ul className="ma__utility-panel__items">
-                <li className="ma__utility-panel__item js-clickable">
-                  <span className="ma__decorative-link">
-                    <a
-                      href="#"
-                      className="js-clickable-link"
-                    >
-                      Contextual Login 1&nbsp;
-                      <svg aria-hidden="true" focusable="false"><use xlinkHref="#7d83e994275beeb5601876202075c2b3.422" /></svg>
-                      <svg xmlns="http://www.w3.org/2000/svg" style={{ display: 'none' }}><symbol xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" version="1.1" viewBox="0 0 16 18" id="7d83e994275beeb5601876202075c2b3.422"><path d="M983.721 1887.28L983.721 1887.28L986.423 1890L986.423 1890L986.423 1890L983.721 1892.72L983.721 1892.72L978.318 1898.17L975.617 1895.45L979.115 1891.92L971.443 1891.92L971.443 1888.0700000000002L979.103 1888.0700000000002L975.617 1884.5500000000002L978.318 1881.8300000000002Z " transform="matrix(1,0,0,1,-971,-1881)" /></symbol></svg>
-                    </a>
-                  </span>
-                </li>
-                <li className="ma__utility-panel__item js-clickable">
-                  <span className="ma__decorative-link">
-                    <a
-                      href=""
-                      className="js-clickable-link"
-                    >
-                      Contextual Login 2&nbsp;
-                      <svg aria-hidden="true" focusable="false"><use xlinkHref="#7d83e994275beeb5601876202075c2b3.423" /></svg>
-                      <svg xmlns="http://www.w3.org/2000/svg" style={{ display: 'none' }}><symbol xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" version="1.1" viewBox="0 0 16 18" id="7d83e994275beeb5601876202075c2b3.423"><path d="M983.721 1887.28L983.721 1887.28L986.423 1890L986.423 1890L986.423 1890L983.721 1892.72L983.721 1892.72L978.318 1898.17L975.617 1895.45L979.115 1891.92L971.443 1891.92L971.443 1888.0700000000002L979.103 1888.0700000000002L975.617 1884.5500000000002L978.318 1881.8300000000002Z " transform="matrix(1,0,0,1,-971,-1881)" /></symbol></svg>
-                    </a>
-                  </span>
-                </li>
+                { links.length > 0 && links.map((link) => (
+                  <UtilityLink key={`utility-link.${link.href}.${link.text}`} href={link.href}>{link.text}</UtilityLink>
+                ))}
               </ul>
             </div>
-
-            <div className="ma__utility-panel">
-              <div className="ma__utility-panel__description ma__utility-panel__description--full">
-
-                <div className="ma__rich-text ">
-                  <p>These are the top requested sites you can log in to access state provided services</p>
-                </div>
-              </div>
-
-              <ul className="ma__utility-panel__items">
-                <li className="ma__utility-panel__item js-clickable">
-                  <span className="ma__decorative-link">
-                    <a
-                      href="https://uionline.detma.org/Claimant/Core/Login.ASPX"
-                      className="js-clickable-link"
-                    >
-                      Unemployment Online&nbsp;
-                      <svg aria-hidden="true" focusable="false"><use xlinkHref="#7d83e994275beeb5601876202075c2b3.424" /></svg>
-                      <svg xmlns="http://www.w3.org/2000/svg" style={{ display: 'none' }}><symbol xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" version="1.1" viewBox="0 0 16 18" id="7d83e994275beeb5601876202075c2b3.424"><path d="M983.721 1887.28L983.721 1887.28L986.423 1890L986.423 1890L986.423 1890L983.721 1892.72L983.721 1892.72L978.318 1898.17L975.617 1895.45L979.115 1891.92L971.443 1891.92L971.443 1888.0700000000002L979.103 1888.0700000000002L975.617 1884.5500000000002L978.318 1881.8300000000002Z " transform="matrix(1,0,0,1,-971,-1881)" /></symbol></svg>
-                    </a>
-                  </span>
-                </li>
-                <li className="ma__utility-panel__item js-clickable">
-                  <span className="ma__decorative-link">
-                    <a
-                      href="https://sso.hhs.state.ma.us/oam/server/obrareq.cgi?encquery%3DA2%2Fmo5AkZreDycpyP0JZAEOYGvW2hviyNhH9Sht2xPp0V1%2BBtWfHnmRGr6zNHOqOlcjphPk7p6bpHHRyNzzk9IYQ%2FcN%2B%2FIcqL2ThnI217OsIKZepptTpGBx83SI0NWjsE7vDi72caItXWlelbGQT7ePanlrVUUy2%2Fj1UEUaXi5G7m47KO9djBnoetZRCtp9G2ZTNFf6zvCGU7Cs02AXYUj2JMH4aqol%2Bh3OK6uhJNNkFvwQ1MFRUa4gR1az4iaW9u83ExKb2a9eDv8ZIUqhlq3%2BNVGTqZHAsHX4KOONSGQRBwCtLNPWwruacjdd9CaEqeIJ2tnP45KrM93edZ6zU1yoWGbAp%2BUWWMqk4HyrtuA8%3D%20agentid%3Dwebgate1%20ver%3D1%20crmethod%3D2"
-                      className="js-clickable-link"
-                    >
-                      Virtual Gateway (SNAP)&nbsp;
-                      <svg aria-hidden="true" focusable="false"><use xlinkHref="#7d83e994275beeb5601876202075c2b3.425" /></svg>
-                      <svg xmlns="http://www.w3.org/2000/svg" style={{ display: 'none' }}><symbol xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" version="1.1" viewBox="0 0 16 18" id="7d83e994275beeb5601876202075c2b3.425"><path d="M983.721 1887.28L983.721 1887.28L986.423 1890L986.423 1890L986.423 1890L983.721 1892.72L983.721 1892.72L978.318 1898.17L975.617 1895.45L979.115 1891.92L971.443 1891.92L971.443 1888.0700000000002L979.103 1888.0700000000002L975.617 1884.5500000000002L978.318 1881.8300000000002Z " transform="matrix(1,0,0,1,-971,-1881)" /></symbol></svg>
-                    </a>
-                  </span>
-                </li>
-                <li className="ma__utility-panel__item js-clickable">
-                  <span className="ma__decorative-link">
-                    <a
-                      href="https://ecse.cse.state.ma.us/ECSE/Login/login.asp"
-                      className="js-clickable-link"
-                    >
-                      Child Support Enforcement&nbsp;
-                      <svg aria-hidden="true" focusable="false"><use xlinkHref="#7d83e994275beeb5601876202075c2b3.426" /></svg>
-                      <svg xmlns="http://www.w3.org/2000/svg" style={{ display: 'none' }}><symbol xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" version="1.1" viewBox="0 0 16 18" id="7d83e994275beeb5601876202075c2b3.426"><path d="M983.721 1887.28L983.721 1887.28L986.423 1890L986.423 1890L986.423 1890L983.721 1892.72L983.721 1892.72L978.318 1898.17L975.617 1895.45L979.115 1891.92L971.443 1891.92L971.443 1888.0700000000002L979.103 1888.0700000000002L975.617 1884.5500000000002L978.318 1881.8300000000002Z " transform="matrix(1,0,0,1,-971,-1881)" /></symbol></svg>
-                    </a>
-                  </span>
-                </li>
-                <li className="ma__utility-panel__item js-clickable">
-                  <span className="ma__decorative-link">
-                    <a
-                      href="https://mtc.dor.state.ma.us/mtc/_/"
-                      className="js-clickable-link"
-                    >
-                      MassTaxConnect&nbsp;
-                      <svg aria-hidden="true" focusable="false"><use xlinkHref="#7d83e994275beeb5601876202075c2b3.427" /></svg>
-                      <svg xmlns="http://www.w3.org/2000/svg" style={{ display: 'none' }}><symbol xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" version="1.1" viewBox="0 0 16 18" id="7d83e994275beeb5601876202075c2b3.427"><path d="M983.721 1887.28L983.721 1887.28L986.423 1890L986.423 1890L986.423 1890L983.721 1892.72L983.721 1892.72L978.318 1898.17L975.617 1895.45L979.115 1891.92L971.443 1891.92L971.443 1888.0700000000002L979.103 1888.0700000000002L975.617 1884.5500000000002L978.318 1881.8300000000002Z " transform="matrix(1,0,0,1,-971,-1881)" /></symbol></svg>
-                    </a>
-                  </span>
-                </li>
-                <li className="ma__utility-panel__item js-clickable">
-                  <span className="ma__decorative-link">
-                    <a
-                      href="https://atlas-myrmv.massdot.state.ma.us/myrmv/"
-                      className="js-clickable-link"
-                    >
-                      myRmv&nbsp;
-                      <svg aria-hidden="true" focusable="false"><use xlinkHref="#7d83e994275beeb5601876202075c2b3.428" /></svg>
-                      <svg xmlns="http://www.w3.org/2000/svg" style={{ display: 'none' }}><symbol xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" version="1.1" viewBox="0 0 16 18" id="7d83e994275beeb5601876202075c2b3.428"><path d="M983.721 1887.28L983.721 1887.28L986.423 1890L986.423 1890L986.423 1890L983.721 1892.72L983.721 1892.72L978.318 1898.17L975.617 1895.45L979.115 1891.92L971.443 1891.92L971.443 1888.0700000000002L979.103 1888.0700000000002L975.617 1884.5500000000002L978.318 1881.8300000000002Z " transform="matrix(1,0,0,1,-971,-1881)" /></symbol></svg>
-                    </a>
-                  </span>
-                </li>
-                <li className="ma__utility-panel__item js-clickable">
-                  <span className="ma__decorative-link">
-                    <a
-                      href="https://www.mahealthconnector.org/"
-                      className="js-clickable-link"
-                    >
-                      Massachusetts Health Connector&nbsp;
-                      <svg aria-hidden="true" focusable="false"><use xlinkHref="#7d83e994275beeb5601876202075c2b3.429" /></svg>
-                      <svg xmlns="http://www.w3.org/2000/svg" style={{ display: 'none' }}><symbol xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" version="1.1" viewBox="0 0 16 18" id="7d83e994275beeb5601876202075c2b3.429"><path d="M983.721 1887.28L983.721 1887.28L986.423 1890L986.423 1890L986.423 1890L983.721 1892.72L983.721 1892.72L978.318 1898.17L975.617 1895.45L979.115 1891.92L971.443 1891.92L971.443 1888.0700000000002L979.103 1888.0700000000002L975.617 1884.5500000000002L978.318 1881.8300000000002Z " transform="matrix(1,0,0,1,-971,-1881)" /></symbol></svg>
-                    </a>
-                  </span>
-                </li>
-                <li className="ma__utility-panel__item js-clickable">
-                  <span className="ma__decorative-link">
-                    <a
-                      href="https://juryduty.majury.gov/ojcweb/public/start.aspx"
-                      className="js-clickable-link"
-                    >
-                      Massachusetts Juror Service Website&nbsp;
-                      <svg aria-hidden="true" focusable="false"><use xlinkHref="#7d83e994275beeb5601876202075c2b3.430" /></svg>
-                      <svg xmlns="http://www.w3.org/2000/svg" style={{ display: 'none' }}><symbol xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" version="1.1" viewBox="0 0 16 18" id="7d83e994275beeb5601876202075c2b3.430"><path d="M983.721 1887.28L983.721 1887.28L986.423 1890L986.423 1890L986.423 1890L983.721 1892.72L983.721 1892.72L978.318 1898.17L975.617 1895.45L979.115 1891.92L971.443 1891.92L971.443 1888.0700000000002L979.103 1888.0700000000002L975.617 1884.5500000000002L978.318 1881.8300000000002Z " transform="matrix(1,0,0,1,-971,-1881)" /></symbol></svg>
-                    </a>
-                  </span>
-                </li>
-                <li className="ma__utility-panel__item js-clickable">
-                  <span className="ma__decorative-link">
-                    <a
-                      href="https://massanf.taleo.net/careersection/ex/jobsearch.ftl"
-                      className="js-clickable-link"
-                    >
-                      Find a Commonwealth Job&nbsp;
-                      <svg aria-hidden="true" focusable="false"><use xlinkHref="#7d83e994275beeb5601876202075c2b3.431" /></svg>
-                      <svg xmlns="http://www.w3.org/2000/svg" style={{ display: 'none' }}><symbol xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" version="1.1" viewBox="0 0 16 18" id="7d83e994275beeb5601876202075c2b3.431"><path d="M983.721 1887.28L983.721 1887.28L986.423 1890L986.423 1890L986.423 1890L983.721 1892.72L983.721 1892.72L978.318 1898.17L975.617 1895.45L979.115 1891.92L971.443 1891.92L971.443 1888.0700000000002L979.103 1888.0700000000002L975.617 1884.5500000000002L978.318 1881.8300000000002Z " transform="matrix(1,0,0,1,-971,-1881)" /></symbol></svg>
-                    </a>
-                  </span>
-                </li>
-              </ul>
-            </div>
-
           </div>
         </div>
       </div>
     </React.Fragment>
   );
 };
-LoginItem.propTypes = {
-  /** Represents when the component is being displayed on a narrow viewport. */
-  narrow: propTypes.bool
+PanelItem.propTypes = {
+  narrow: propTypes.bool,
+  title: propTypes.string,
+  CustomIcon: propTypes.elementType,
+  description: propTypes.string,
+  links: propTypes.arrayOf(propTypes.object)
+};
+
+export const LoginItem = ({
+  data = UtilityNavData.items[1]
+}) => {
+  const { panel, text, ariaLabelText, description } = data;
+  return(
+    <PanelItem
+      links={panel.links}
+      title={text}
+      CustomIcon={IconLogin}
+      description={description}
+      ariaLabelText={ariaLabelText}
+    />
+  )
 };
 
 export const TranslateItem = () => {

--- a/packages/react/src/components/organisms/Header/utility-items.js
+++ b/packages/react/src/components/organisms/Header/utility-items.js
@@ -25,7 +25,6 @@ UtilityLink.propTypes = {
   children: propTypes.node
 };
 
-
 const PanelItem = ({
   narrow,
   title = '',
@@ -239,7 +238,7 @@ export const LoginItem = ({
       description={description}
       ariaLabel={ariaLabel}
     />
-  )
+  );
 };
 LoginItem.propTypes = {
   data: propTypes.shape({
@@ -269,12 +268,13 @@ export const StateItem = ({
   data = UtilityNavData.stateItem
 }) => {
   const { link, ariaLabel, text } = data;
-  return (
-  <a className="ma__utility-nav__link direct-link" href={link} aria-label={ariaLabel}>
-    <IconBuilding />
-    <span>{text}</span>
-  </a>
-)};
+  return(
+    <a className="ma__utility-nav__link direct-link" href={link} aria-label={ariaLabel}>
+      <IconBuilding />
+      <span>{text}</span>
+    </a>
+  );
+};
 
 StateItem.propTypes = {
   data: propTypes.shape({

--- a/packages/react/src/index.js
+++ b/packages/react/src/index.js
@@ -145,6 +145,11 @@ export FooterSlim from 'MayflowerReactOrganisms/FooterSlim';
 export RichText from 'MayflowerReactOrganisms/RichText';
 export UtilityPanel from 'MayflowerReactOrganisms/UtilityPanel';
 export UtilityNav from 'MayflowerReactOrganisms/UtilityNav';
+export {
+  TranslateItem,
+  StateItem,
+  LoginItem
+} from 'MayflowerReactOrganisms/Header/utility-items';
 export Header from 'MayflowerReactOrganisms/Header';
 export HeaderSlim from 'MayflowerReactOrganisms/HeaderSlim';
 export HeaderHamburger from 'MayflowerReactOrganisms/HeaderHamburger';


### PR DESCRIPTION
Refactor utility items in Header/utility-items.js to allow the search to use it directly or override with its own props. This removes the hard-coded items in the items and allows props to be passed in, which will significantly reduce the duplicated code in search in other implementation of the Mayflower header with utility items
See code reduction --> https://github.com/massgov/massgov-search/pull/626/commits/21541c05bab6927dd22e44a739b7f79876abd30f

Link to this PR when testing bug #4 described in https://github.com/massgov/massgov-search/pull/626#issuecomment-759764376

