### PR TITLE
[React] fix hamburger nav search icon mobile conditional

### DIFF
--- a/packages/react/src/components/molecules/HamburgerNav/index.js
+++ b/packages/react/src/components/molecules/HamburgerNav/index.js
@@ -254,14 +254,18 @@ const HamburgerNav = ({
               <span className="ma__header__hamburger__menu-icon" />
               <span className="ma__header__hamburger__menu-text js-header__menu-text" />
             </button>
-            <button
-              type="button"
-              aria-expanded="false"
-              className="ma__header__hamburger__search-access-button js-header-search-access-button"
-            >
-              <span className="ma__visually-hidden">Access to search</span>
-              <IconSearch />
-            </button>
+            {
+              navSearch && (
+                <button
+                  type="button"
+                  aria-expanded="false"
+                  className="ma__header__hamburger__search-access-button js-header-search-access-button"
+                >
+                  <span className="ma__visually-hidden">Access to search</span>
+                  <IconSearch />
+                </button>
+              )
+            }
           </div>
           {RenderedUtilityNav !== null && <RenderedUtilityNav items={utilityItems} UtilityItem={RenderedUtilityItem} narrow={false} />}
           <NavContainer logo={logo} mainNav={mainNav} utilityNav={utilityNav} navSearch={navSearch} className="ma__header__hamburger__nav-container" aria-hidden="true" />


### PR DESCRIPTION
When the NavSearch is set to null, the search icon button should not render on mobile

Before:
![Screen Shot 2021-03-08 at 12 28 11 PM](https://user-images.githubusercontent.com/5789411/110360011-301b7200-800c-11eb-820c-6c8e7e97448c.png)

After:
![Screen Shot 2021-03-08 at 12 42 15 PM](https://user-images.githubusercontent.com/5789411/110360065-3f022480-800c-11eb-974f-c80ceefbfb7a.png)
![Screen Shot 2021-03-08 at 12 42 04 PM](https://user-images.githubusercontent.com/5789411/110360075-41fd1500-800c-11eb-8e2c-4a7a9e4812f7.png)


