### PR TITLE
React/dp 20435 fix type ahead drop down

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,7 @@ common/autoinstallers/*/.npmrc
 
 # Distribution folder
 dist
+
+# yalc - used to symlink to and test local packages
+.yalc/
+yalc.lock

--- a/packages/react/src/components/forms/InputTextFuzzy/index.js
+++ b/packages/react/src/components/forms/InputTextFuzzy/index.js
@@ -19,7 +19,7 @@ class InputTextFuzzy extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      value: '',
+      value: this.props.selected || '',
       suggestions: []
     };
     const fuseOptions = this.props.fuseOptions;

--- a/packages/react/src/components/forms/InputTextFuzzy/index.js
+++ b/packages/react/src/components/forms/InputTextFuzzy/index.js
@@ -19,7 +19,7 @@ class InputTextFuzzy extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      value: this.props.selected || '',
+      value: '',
       suggestions: []
     };
     const fuseOptions = this.props.fuseOptions;

--- a/packages/react/src/components/forms/TypeAheadDropdown/TypeAheadDropdown.stories.js
+++ b/packages/react/src/components/forms/TypeAheadDropdown/TypeAheadDropdown.stories.js
@@ -32,11 +32,11 @@ TypeAheadDropdownExample.args = {
       minMatchCharLength: 1,
       maxPatternLength: 300
     },
+    defaultValue: '',
     onKeyDown: action('onKeyDown event'),
     onFocus: action('onFocus event'),
     onBlur: action('onBlur event'),
-    onSuggestionClick: action('onSuggestionClick called'),
-    renderDefaultSuggestion: true
+    onSuggestionClick: action('onSuggestionClick called')
   }
 };
 

--- a/packages/react/src/components/forms/TypeAheadDropdown/_index.scss
+++ b/packages/react/src/components/forms/TypeAheadDropdown/_index.scss
@@ -11,7 +11,6 @@
 
   &--boxed {
     position: absolute;
-    top: 45px;
     width: 100%;
     z-index: 100;
   }

--- a/packages/react/src/components/forms/TypeAheadDropdown/index.js
+++ b/packages/react/src/components/forms/TypeAheadDropdown/index.js
@@ -135,7 +135,7 @@ TypeAheadDropdown.propTypes = {
   /** Custom keydown callback */
   onKeyDown: PropTypes.func,
   /** Custom suggestion onClick callback */
-  onSuggestionClick: PropTypes.func,
+  onSuggestionClick: PropTypes.func
 
 };
 

--- a/packages/react/src/components/forms/TypeAheadDropdown/index.js
+++ b/packages/react/src/components/forms/TypeAheadDropdown/index.js
@@ -7,151 +7,147 @@
  * @requires module:@massds/mayflower-assets/scss/01-atoms/svg-icons
  * @requires module:@massds/mayflower-assets/scss/01-atoms/svg-loc-icons
  */
-import React from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import ButtonWithIcon from 'MayflowerReactButtons/ButtonWithIcon';
 import InputTextFuzzy from 'MayflowerReactForms/InputTextFuzzy';
 // eslint-disable-next-line import/no-unresolved
 import IconChevron from 'MayflowerReactBase/Icon/IconChevron';
 
-class TypeAheadDropdown extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      buttonText: this.props.dropdownButton.text,
-      buttonExpand: false
-    };
+const TypeAheadDropdown = (props) => {
+    const [buttonExpand, setButtonExpand] = useState(false);
+    const [buttonText, setButtonText] = useState(props.dropdownButton.text);
+    const [buttonClicked, setButtonClicked] = useState();
+    const buttonRef = useRef();
+    const wrapperRef = useRef();
 
-    this.wrapperRef = React.createRef();
-    this.setDropDownButtonRef = this.setDropDownButtonRef.bind(this);
-    this.handleRefMouseDown = this.handleRefMouseDown.bind(this);
+    // this.wrapperRef = React.createRef();
+    // this.setDropDownButtonRef = this.setDropDownButtonRef.bind(this);
+    // this.handleRefMouseDown = this.handleRefMouseDown.bind(this);
 
-    this.closeDropdown = this.closeDropdown.bind(this);
-    this.handleClick = this.handleClick.bind(this);
-    this.handleKeyDown = this.handleKeyDown.bind(this);
-    this.handleInputBlur = this.handleInputBlur.bind(this);
-    this.handleSelect = this.handleSelect.bind(this);
-    this.handleClickOutside = this.handleClickOutside.bind(this);
-  }
+    // closeDropdown = closeDropdown.bind(this);
+    // this.handleClick = this.handleClick.bind(this);
+    // this.handleKeyDown = this.handleKeyDown.bind(this);
+    // this.handleInputBlur = this.handleInputBlur.bind(this);
+    // this.handleSelect = this.handleSelect.bind(this);
+    // handleClickOutside = handleClickOutside.bind(this);
+  
 
-  componentDidMount() {
-    this.buttonClicked = false;
-
-    document.addEventListener('mousedown', this.handleClickOutside);
-    this.dropDownButtonRef.addEventListener('mousedown', this.handleRefMouseDown);
-  }
+  // componentDidMount() {
+  //   this.buttonClicked = false;
+  // }
 
   // eslint-disable-next-line camelcase
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    const selectedValue = nextProps.inputText.selected;
-    if (selectedValue !== undefined) {
-      this.setState({
-        buttonText: selectedValue,
-        buttonExpand: false
-      });
-    }
+  // UNSAFE_componentWillReceiveProps(nextProps) {
+  //   const selectedValue = nextProps.inputText.selected;
+  //   if (selectedValue !== undefined) {
+  //     setButtonText(selectedValue);
+  //     setButtonExpand(false);
+  //   }
+  // }
+  const handleRefMouseDown = () => {
+    setButtonClicked(true);
   }
 
-  componentDidUpdate() {
-    this.buttonClicked = false;
+  const handleClick = () => {
+    setButtonExpand(!buttonExpand);
   }
 
-  componentWillUnmount() {
-    document.removeEventListener('mousedown', this.handleClickOutside);
-    this.dropDownButtonRef.removeEventListener('mousedown', this.handleRefMouseDown);
-  }
-
-  handleRefMouseDown() {
-    this.buttonClicked = true;
-  }
-
-  handleClick() {
-    this.setState((prevState) => ({ buttonExpand: !prevState.buttonExpand }));
-  }
-
-  handleKeyDown(event) {
+  const handleKeyDown = (event) => {
     // If the user pressed escape, or pressed enter with nothing selected close
     // the panel.
     if ((event.key === 'Escape')
         || (event.key === 'Enter' && event.target.value === '')) {
-      this.closeDropdown();
+      closeDropdown();
     }
-    if (event.key === 'Escape' && this.dropDownButtonRef) {
-      this.dropDownButtonRef.focus();
+    if (event.key === 'Escape' && buttonRef) {
+      buttonRef.focus();
     }
-    if (typeof this.props.onKeyDown === 'function') {
-      this.props.onKeyDown(event);
-    }
-  }
-
-  handleInputBlur() {
-    if (!this.buttonClicked) {
-      this.closeDropdown();
+    if (typeof props.onKeyDown === 'function') {
+      props.onKeyDown(event);
     }
   }
 
-  handleSelect(event, { suggestion }) {
+  const handleInputBlur = () => {
+    if (buttonClicked) {
+      closeDropdown();
+    }
+  }
+
+  const handleSelect = (event, { suggestion }) => {
     // Stop the filters form submission if enter is pressed in the selector.
     event.preventDefault();
     // Update this component state and pass the event out to the calling code.
     const { text } = suggestion.item;
     if (text.length > 0) {
-      this.setState({
-        buttonText: text,
-        buttonExpand: false
-      });
-      if (typeof this.props.inputText.onSuggestionClick === 'function') {
-        this.props.inputText.onSuggestionClick(event, { suggestion });
+      setButtonText(text);
+      setButtonExpand(false);
+      if (typeof props.inputText.onSuggestionClick === 'function') {
+        props.inputText.onSuggestionClick(event, { suggestion });
       }
     }
   }
 
-  handleClickOutside(event) {
+  const handleClickOutside = (event) => {
     // Close the panel if the user clicks outside the component.
-    const node = this.wrapperRef.current;
+    const node = wrapperRef.current;
     if ((node && !node.contains(event.target))) {
-      if (this.state.buttonExpand) {
-        this.setState({ buttonExpand: false });
+      if (buttonExpand) {
+        setButtonExpand(false);
       }
     }
   }
 
-  setDropDownButtonRef(node) {
-    this.dropDownButtonRef = node;
+  const closeDropdown = () => {
+    setButtonExpand(false);
   }
 
-  closeDropdown() {
-    this.setState({ buttonExpand: false });
-  }
+  useEffect(() => {
+    const selectedValue = props.inputText.selected;
+    if (selectedValue !== undefined) {
+      setButtonText(selectedValue);
+      setButtonExpand(false);
+    }
+  }, [props.inputText.selected]);
 
-  render() {
-    const dropdownButton = {
-      onClick: this.handleClick,
-      setButtonRef: this.setDropDownButtonRef,
-      expanded: this.state.buttonExpand,
-      icon: <IconChevron height={20} width={20} />,
-      size: '',
-      ...this.props.dropdownButton
+  useEffect(() => {
+    setButtonClicked(false);
+    document.addEventListener('mousedown', handleClickOutside);
+    buttonRef.current.addEventListener('mousedown', handleRefMouseDown);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      buttonRef.current.removeEventListener('mousedown', handleRefMouseDown);
     };
-    dropdownButton.text = this.state.buttonText || dropdownButton.text;
+  });
 
-    const inputTextFuzzyProps = {
-      ...this.props.inputText,
-      onKeyDown: this.handleKeyDown,
-      onSuggestionClick: this.handleSelect,
-      onBlur: this.handleInputBlur,
-      autoFocusInput: true
-    };
 
-    return(
-      <div ref={this.wrapperRef}>
-        <ButtonWithIcon {...dropdownButton} />
-        {this.state.buttonExpand && (
-          <InputTextFuzzy {...inputTextFuzzyProps} />
-        )}
-      </div>
-    );
-  }
+
+  const dropdownButton = {
+    onClick: handleClick,
+    setButtonRef: buttonRef,
+    expanded: buttonExpand,
+    icon: <IconChevron height={20} width={20} />,
+    size: '',
+    ...props.dropdownButton
+  };
+  dropdownButton.text = buttonText || dropdownButton.text;
+
+  const inputTextFuzzyProps = {
+    ...props.inputText,
+    onKeyDown: handleKeyDown,
+    onSuggestionClick: handleSelect,
+    onBlur: handleInputBlur,
+    autoFocusInput: true
+  };
+
+  return(
+    <div ref={wrapperRef}>
+      <ButtonWithIcon {...dropdownButton} />
+      {buttonExpand && (
+        <InputTextFuzzy {...inputTextFuzzyProps} />
+      )}
+    </div>
+  );
 }
 
 TypeAheadDropdown.propTypes = {

--- a/packages/react/src/components/forms/TypeAheadDropdown/index.js
+++ b/packages/react/src/components/forms/TypeAheadDropdown/index.js
@@ -7,7 +7,7 @@
  * @requires module:@massds/mayflower-assets/scss/01-atoms/svg-icons
  * @requires module:@massds/mayflower-assets/scss/01-atoms/svg-loc-icons
  */
-import React, { useState, useRef, useEffect } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import ButtonWithIcon from 'MayflowerReactButtons/ButtonWithIcon';
 import InputTextFuzzy from 'MayflowerReactForms/InputTextFuzzy';
@@ -15,11 +15,11 @@ import InputTextFuzzy from 'MayflowerReactForms/InputTextFuzzy';
 import IconChevron from 'MayflowerReactBase/Icon/IconChevron';
 
 const TypeAheadDropdown = (props) => {
-  const [buttonExpand, setButtonExpand] = useState(false);
-  const [buttonText, setButtonText] = useState(props.dropdownButton.text);
-  const [buttonClicked, setButtonClicked] = useState();
-  const buttonRef = useRef();
-  const wrapperRef = useRef();
+  const [buttonExpand, setButtonExpand] = React.useState(false);
+  const [buttonText, setButtonText] = React.useState(props.dropdownButton.text);
+  const [buttonClicked, setButtonClicked] = React.useState();
+  const buttonRef = React.useRef();
+  const wrapperRef = React.useRef();
 
   const handleRefMouseDown = () => {
     setButtonClicked(true);
@@ -78,7 +78,8 @@ const TypeAheadDropdown = (props) => {
     setButtonExpand(false);
   };
 
-  useEffect(() => {
+  // update state from prop
+  React.useEffect(() => {
     const selectedValue = props.inputText.selected;
     if (selectedValue !== undefined) {
       setButtonText(selectedValue);
@@ -86,7 +87,7 @@ const TypeAheadDropdown = (props) => {
     }
   }, [props.inputText.selected]);
 
-  useEffect(() => {
+  React.useEffect(() => {
     setButtonClicked(false);
     document.addEventListener('mousedown', handleClickOutside);
     buttonRef.current.addEventListener('mousedown', handleRefMouseDown);

--- a/packages/react/src/components/forms/TypeAheadDropdown/index.js
+++ b/packages/react/src/components/forms/TypeAheadDropdown/index.js
@@ -134,10 +134,6 @@ TypeAheadDropdown.propTypes = {
   defaultValue: '',
   /** Custom keydown callback */
   onKeyDown: PropTypes.func,
-  /** Custom onFocus callback */
-  onFocus: PropTypes.func,
-  /** Custom onBlur callback */
-  onBlur: PropTypes.func,
   /** Custom suggestion onClick callback */
   onSuggestionClick: PropTypes.func,
 

--- a/packages/react/src/components/forms/TypeAheadDropdown/index.js
+++ b/packages/react/src/components/forms/TypeAheadDropdown/index.js
@@ -23,11 +23,11 @@ const TypeAheadDropdown = (props) => {
 
   const handleRefMouseDown = () => {
     setButtonClicked(true);
-  }
+  };
 
   const handleClick = () => {
     setButtonExpand(!buttonExpand);
-  }
+  };
 
   const handleKeyDown = (event) => {
     // If the user pressed escape, or pressed enter with nothing selected close
@@ -42,13 +42,13 @@ const TypeAheadDropdown = (props) => {
     if (typeof props.onKeyDown === 'function') {
       props.onKeyDown(event);
     }
-  }
+  };
 
   const handleInputBlur = () => {
     if (buttonClicked) {
       closeDropdown();
     }
-  }
+  };
 
   const handleSelect = (event, { suggestion }) => {
     // Stop the filters form submission if enter is pressed in the selector.
@@ -62,7 +62,7 @@ const TypeAheadDropdown = (props) => {
         props.inputText.onSuggestionClick(event, { suggestion });
       }
     }
-  }
+  };
 
   const handleClickOutside = (event) => {
     // Close the panel if the user clicks outside the component.
@@ -72,11 +72,11 @@ const TypeAheadDropdown = (props) => {
         setButtonExpand(false);
       }
     }
-  }
+  };
 
   const closeDropdown = () => {
     setButtonExpand(false);
-  }
+  };
 
   useEffect(() => {
     const selectedValue = props.inputText.selected;
@@ -90,7 +90,7 @@ const TypeAheadDropdown = (props) => {
     setButtonClicked(false);
     document.addEventListener('mousedown', handleClickOutside);
     buttonRef.current.addEventListener('mousedown', handleRefMouseDown);
-    return () => {
+    return() => {
       document.removeEventListener('mousedown', handleClickOutside);
       buttonRef.current.removeEventListener('mousedown', handleRefMouseDown);
     };
@@ -122,7 +122,7 @@ const TypeAheadDropdown = (props) => {
       )}
     </div>
   );
-}
+};
 
 TypeAheadDropdown.propTypes = {
   /** The props to set up the dropdown button */

--- a/packages/react/src/components/forms/TypeAheadDropdown/index.js
+++ b/packages/react/src/components/forms/TypeAheadDropdown/index.js
@@ -131,7 +131,7 @@ TypeAheadDropdown.propTypes = {
   /** The props to set up the inputTextFuzzy */
   inputText: PropTypes.shape(InputTextFuzzy.propTypes).isRequired,
   /** Default text value for the selection */
-  defaultValue: '',
+  defaultValue: PropTypes.string,
   /** Custom keydown callback */
   onKeyDown: PropTypes.func,
   /** Custom suggestion onClick callback */

--- a/packages/react/src/components/forms/TypeAheadDropdown/index.js
+++ b/packages/react/src/components/forms/TypeAheadDropdown/index.js
@@ -80,12 +80,12 @@ const TypeAheadDropdown = (props) => {
 
   // update state from prop
   React.useEffect(() => {
-    const selectedValue = props.inputText.selected;
-    if (selectedValue !== undefined) {
-      setButtonText(selectedValue);
+    const { defaultValue } = props;
+    if (defaultValue !== undefined) {
+      setButtonText(defaultValue);
       setButtonExpand(false);
     }
-  }, [props.inputText.selected]);
+  }, [props.defaultValue]);
 
   React.useEffect(() => {
     setButtonClicked(false);
@@ -130,8 +130,17 @@ TypeAheadDropdown.propTypes = {
   dropdownButton: PropTypes.shape(ButtonWithIcon.propTypes).isRequired,
   /** The props to set up the inputTextFuzzy */
   inputText: PropTypes.shape(InputTextFuzzy.propTypes).isRequired,
+  /** Default text value for the selection */
+  defaultValue: '',
   /** Custom keydown callback */
-  onKeyDown: PropTypes.func
+  onKeyDown: PropTypes.func,
+  /** Custom onFocus callback */
+  onFocus: PropTypes.func,
+  /** Custom onBlur callback */
+  onBlur: PropTypes.func,
+  /** Custom suggestion onClick callback */
+  onSuggestionClick: PropTypes.func,
+
 };
 
 export default TypeAheadDropdown;

--- a/packages/react/src/components/forms/TypeAheadDropdown/index.js
+++ b/packages/react/src/components/forms/TypeAheadDropdown/index.js
@@ -15,36 +15,12 @@ import InputTextFuzzy from 'MayflowerReactForms/InputTextFuzzy';
 import IconChevron from 'MayflowerReactBase/Icon/IconChevron';
 
 const TypeAheadDropdown = (props) => {
-    const [buttonExpand, setButtonExpand] = useState(false);
-    const [buttonText, setButtonText] = useState(props.dropdownButton.text);
-    const [buttonClicked, setButtonClicked] = useState();
-    const buttonRef = useRef();
-    const wrapperRef = useRef();
+  const [buttonExpand, setButtonExpand] = useState(false);
+  const [buttonText, setButtonText] = useState(props.dropdownButton.text);
+  const [buttonClicked, setButtonClicked] = useState();
+  const buttonRef = useRef();
+  const wrapperRef = useRef();
 
-    // this.wrapperRef = React.createRef();
-    // this.setDropDownButtonRef = this.setDropDownButtonRef.bind(this);
-    // this.handleRefMouseDown = this.handleRefMouseDown.bind(this);
-
-    // closeDropdown = closeDropdown.bind(this);
-    // this.handleClick = this.handleClick.bind(this);
-    // this.handleKeyDown = this.handleKeyDown.bind(this);
-    // this.handleInputBlur = this.handleInputBlur.bind(this);
-    // this.handleSelect = this.handleSelect.bind(this);
-    // handleClickOutside = handleClickOutside.bind(this);
-  
-
-  // componentDidMount() {
-  //   this.buttonClicked = false;
-  // }
-
-  // eslint-disable-next-line camelcase
-  // UNSAFE_componentWillReceiveProps(nextProps) {
-  //   const selectedValue = nextProps.inputText.selected;
-  //   if (selectedValue !== undefined) {
-  //     setButtonText(selectedValue);
-  //     setButtonExpand(false);
-  //   }
-  // }
   const handleRefMouseDown = () => {
     setButtonClicked(true);
   }
@@ -119,8 +95,6 @@ const TypeAheadDropdown = (props) => {
       buttonRef.current.removeEventListener('mousedown', handleRefMouseDown);
     };
   });
-
-
 
   const dropdownButton = {
     onClick: handleClick,


### PR DESCRIPTION
- convert TypeAheadDropdown into a functional component
- set default value prop separately for the TypeAheadDropDown and its child InputTextFuzzy component

Before: 
![image](https://user-images.githubusercontent.com/5789411/111182502-577ebb80-8585-11eb-8d01-8af55cc12e3a.png)


After:
![Screen Shot 2021-03-08 at 8 34 31 PM](https://user-images.githubusercontent.com/5789411/111182432-4a61cc80-8585-11eb-990a-c1c2d496d271.png)
