### PR TITLE
[Core] DP-21433 fix core footer data

### DIFF
--- a/changelogs/DP-21433.yml
+++ b/changelogs/DP-21433.yml
@@ -1,0 +1,5 @@
+Fixed:
+  - project: Core
+    component: Footer
+    description: Update footer data to match Mass.gov. (#1372 )
+    issue: DP-21433

--- a/packages/core/stories/components/Footer/Footer.data.js
+++ b/packages/core/stories/components/Footer/Footer.data.js
@@ -5,23 +5,23 @@ export default {
       id: 'FooterLinks1',
       links: [
         {
-          href: 'https://mass.gov/topics/living',
+          href: 'https://www.mass.gov/topics/living',
           text: 'Living'
         },
         {
-          href: 'https://mass.gov/topics/working',
+          href: 'https://www.mass.gov/topics/working',
           text: 'Working'
         },
         {
-          href: 'https://mass.gov/topics/learning',
+          href: 'https://www.mass.gov/topics/learning',
           text: 'Learning'
         },
         {
-          href: 'https://mass.gov/topics/exploring-massachusetts',
+          href: 'https://www.mass.gov/topics/exploring-massachusetts',
           text: 'Visiting & Exploring'
         },
         {
-          href: 'https://mass.gov/topics/your-government',
+          href: 'https://www.mass.gov/topics/your-government',
           text: 'Your Government'
         }
       ]
@@ -31,11 +31,11 @@ export default {
       id: 'FooterLinks2',
       links: [
         {
-          href: 'https://mass.gov/site-policies',
+          href: 'https://www.mass.gov/site-policies',
           text: 'Site Policies'
         },
         {
-          href: 'https://mass.gov/topics/public-records-requests',
+          href: 'https://www.mass.gov/topics/public-records-requests',
           text: 'Public Records Requests'
         }
       ]

--- a/packages/core/stories/components/Footer/Footer.data.js
+++ b/packages/core/stories/components/Footer/Footer.data.js
@@ -1,0 +1,44 @@
+export default {
+    "items": [
+      {
+        "heading": "Footer Primary Links",
+        "id": "FooterLinks1",
+        "links": [
+          {
+            "href": "https://mass.gov/topics/living",
+            "text": "Living"
+          },
+          {
+            "href": "https://mass.gov/topics/working",
+            "text": "Working"
+          },
+          {
+            "href": "https://mass.gov/topics/learning",
+            "text": "Learning"
+          },
+          {
+            "href": "https://mass.gov/topics/exploring-massachusetts",
+            "text": "Visiting & Exploring"
+          },
+          {
+            "href": "https://mass.gov/topics/your-government",
+            "text": "Your Government"
+          }
+        ]
+      },
+      {
+        "heading": "Footer Secondary Links",
+        "id": "FooterLinks2",
+        "links": [
+          {
+            "href": "https://mass.gov/site-policies",
+            "text": "Site Policies"
+          },
+          {
+            "href": "https://mass.gov/topics/public-records-requests",
+            "text": "Public Records Requests"
+          }
+        ]
+      }
+    ]
+  };

--- a/packages/core/stories/components/Footer/Footer.data.js
+++ b/packages/core/stories/components/Footer/Footer.data.js
@@ -1,44 +1,44 @@
 export default {
-    "items": [
-      {
-        "heading": "Footer Primary Links",
-        "id": "FooterLinks1",
-        "links": [
-          {
-            "href": "https://mass.gov/topics/living",
-            "text": "Living"
-          },
-          {
-            "href": "https://mass.gov/topics/working",
-            "text": "Working"
-          },
-          {
-            "href": "https://mass.gov/topics/learning",
-            "text": "Learning"
-          },
-          {
-            "href": "https://mass.gov/topics/exploring-massachusetts",
-            "text": "Visiting & Exploring"
-          },
-          {
-            "href": "https://mass.gov/topics/your-government",
-            "text": "Your Government"
-          }
-        ]
-      },
-      {
-        "heading": "Footer Secondary Links",
-        "id": "FooterLinks2",
-        "links": [
-          {
-            "href": "https://mass.gov/site-policies",
-            "text": "Site Policies"
-          },
-          {
-            "href": "https://mass.gov/topics/public-records-requests",
-            "text": "Public Records Requests"
-          }
-        ]
-      }
-    ]
-  };
+  items: [
+    {
+      heading: 'Footer Primary Links',
+      id: 'FooterLinks1',
+      links: [
+        {
+          href: 'https://mass.gov/topics/living',
+          text: 'Living'
+        },
+        {
+          href: 'https://mass.gov/topics/working',
+          text: 'Working'
+        },
+        {
+          href: 'https://mass.gov/topics/learning',
+          text: 'Learning'
+        },
+        {
+          href: 'https://mass.gov/topics/exploring-massachusetts',
+          text: 'Visiting & Exploring'
+        },
+        {
+          href: 'https://mass.gov/topics/your-government',
+          text: 'Your Government'
+        }
+      ]
+    },
+    {
+      heading: 'Footer Secondary Links',
+      id: 'FooterLinks2',
+      links: [
+        {
+          href: 'https://mass.gov/site-policies',
+          text: 'Site Policies'
+        },
+        {
+          href: 'https://mass.gov/topics/public-records-requests',
+          text: 'Public Records Requests'
+        }
+      ]
+    }
+  ]
+};

--- a/packages/core/stories/components/Footer/Footer.data.js
+++ b/packages/core/stories/components/Footer/Footer.data.js
@@ -5,23 +5,23 @@ export default {
       id: 'FooterLinks1',
       links: [
         {
-          href: 'https://www.mass.gov/topics/living',
+          href: 'https://mass.gov/topics/living',
           text: 'Living'
         },
         {
-          href: 'https://www.mass.gov/topics/working',
+          href: 'https://mass.gov/topics/working',
           text: 'Working'
         },
         {
-          href: 'https://www.mass.gov/topics/learning',
+          href: 'https://mass.gov/topics/learning',
           text: 'Learning'
         },
         {
-          href: 'https://www.mass.gov/topics/exploring-massachusetts',
+          href: 'https://mass.gov/topics/exploring-massachusetts',
           text: 'Visiting & Exploring'
         },
         {
-          href: 'https://www.mass.gov/topics/your-government',
+          href: 'https://mass.gov/topics/your-government',
           text: 'Your Government'
         }
       ]
@@ -31,11 +31,11 @@ export default {
       id: 'FooterLinks2',
       links: [
         {
-          href: 'https://www.mass.gov/site-policies',
+          href: 'https://mass.gov/site-policies',
           text: 'Site Policies'
         },
         {
-          href: 'https://www.mass.gov/topics/public-records-requests',
+          href: 'https://mass.gov/topics/public-records-requests',
           text: 'Public Records Requests'
         }
       ]

--- a/packages/core/stories/components/Footer/Footer.stories.js
+++ b/packages/core/stories/components/Footer/Footer.stories.js
@@ -5,6 +5,9 @@ import SiteLogo from '@massds/mayflower-react/dist/SiteLogo';
 import logo from '@massds/mayflower-assets/static/images/logo/stateseal.png';
 import { attachHTML } from '../../util/renderCode';
 
+import footerLinks from './Footer.data';
+console.log(footerLinks)
+
 const { STORYBOOK_CDN_PATH } = process.env;
 
 const footerBasic = (
@@ -88,64 +91,7 @@ const footerDuelLogo = (
 const footer = (
   <Footer
     backToTopButton={false}
-    footerLinks={{
-      items: [
-        {
-          heading: 'FooterLinks1',
-          id: 'FooterLinks1',
-          links: [
-            {
-              href: 'https://mass.gov/topics/living',
-              text: 'Living'
-            },
-            {
-              href: 'https://mass.gov/topics/working',
-              text: 'Working'
-            },
-            {
-              href: 'https://mass.gov/topics/learning',
-              text: 'Learning'
-            },
-            {
-              href: 'https://mass.gov/topics/visiting-exploring',
-              text: 'Visiting & Exploring'
-            },
-            {
-              href: 'https://mass.gov/topics/your-government',
-              text: 'Your Government'
-            }
-          ]
-        },
-        {
-          heading: 'FooterLinks2',
-          id: 'FooterLinks2',
-          links: [
-            {
-              href: 'https://www.mass.gov/site-policies',
-              text: 'Site Policies'
-            },
-            {
-              href: 'http://www.mass.gov/opendata/#/',
-              text: 'State Data'
-            },
-            {
-              href: 'https://www.mass.gov/topics/public-records-requests',
-              text: 'Public Records Requests'
-            }
-          ]
-        },
-        {
-          heading: 'FooterLinks3',
-          id: 'FooterLinks3',
-          links: [
-            {
-              href: 'https://www.mass.gov/feedback',
-              text: 'Feedback'
-            }
-          ]
-        }
-      ]
-    }}
+    footerLinks={footerLinks}
     footerLogo={{
       src: logo
     }}

--- a/packages/core/stories/components/Footer/Footer.stories.js
+++ b/packages/core/stories/components/Footer/Footer.stories.js
@@ -6,7 +6,6 @@ import logo from '@massds/mayflower-assets/static/images/logo/stateseal.png';
 import { attachHTML } from '../../util/renderCode';
 
 import footerLinks from './Footer.data';
-console.log(footerLinks)
 
 const { STORYBOOK_CDN_PATH } = process.env;
 


### PR DESCRIPTION
### Changelog
Fixed:
  - project: Core
    component: Footer
    description: Update footer data to match Mass.gov. (#1372 )
    issue: DP-21433

### To Test:
- [ ] `rush start:core`
- [ ] Check out the footer example 
- [ ] Compare the markup with Mass.gov Footer


---
Before:
https://mayflower.digital.mass.gov/core/index.html?path=/docs/components-footer--footer-example
![Screen Shot 2021-03-12 at 10 16 34 AM](https://user-images.githubusercontent.com/5789411/110959906-2b143680-831c-11eb-8261-25be0bdbe50a.png)

After:

![Screen Shot 2021-03-12 at 10 17 26 AM](https://user-images.githubusercontent.com/5789411/110959916-2e0f2700-831c-11eb-8d2c-ea005b75d684.png)
