### PR TITLE
Release 11.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Mayflower Release Notes
 All notable changes to this project will be documented in this file.
 
+## 11.4.1 (4/20/2021)
+### Fixed 
+- (Patternlab) [stickyTOC] DP-21686: Fix stickyTOC JS console error, which addresses the issue causing video fitwidth JS malfunction on info details page when TOC is not initiated. (#1392)
+
 ## 11.4.0 (4/12/2021)
 ### Changed 
 - (Patternlab) [Figure Caspio] DP-21332: Modified Caspio embed functionality to have flexible hostname.

--- a/changelogs/DP-21686.yml
+++ b/changelogs/DP-21686.yml
@@ -1,6 +1,0 @@
-Fixed:
-  - project: Patternlab
-    component: stickyTOC
-    description: Fix stickyTOC JS console error, which addresses the issue causing video fitwidth JS malfunction on info details page when TOC is not initiated. (#1392)
-    issue: DP-21686
-    impact: Patch

--- a/packages/core/.env
+++ b/packages/core/.env
@@ -1,4 +1,4 @@
-VERSION=11.4.0
+VERSION=11.4.1
 PKG=@massds/mayflower-assets
 STORYBOOK_CDN=https://unpkg.com/
 STORYBOOK_PKG=$PKG@$VERSION


### PR DESCRIPTION
## 11.4.1 (4/20/2021)
### Fixed 
- (Patternlab) [stickyTOC] DP-21686: Fix stickyTOC JS console error, which addresses the issue causing video fitwidth JS malfunction on info details page when TOC is not initiated. (#1392)