### PR TITLE
DP-21782 Location listing direction link context

### DIFF
--- a/changelogs/DP-21782.yml
+++ b/changelogs/DP-21782.yml
@@ -1,0 +1,6 @@
+Changed:
+  - project: Patternlab
+    component: LocationListing
+    description: Add labelContext to assets/js/templates/locationListingRow.html. (#1420)
+    issue: DP-21782
+    impact: Patch

--- a/packages/patternlab/styleguide/source/assets/js/templates/locationListingRow.html
+++ b/packages/patternlab/styleguide/source/assets/js/templates/locationListingRow.html
@@ -37,6 +37,9 @@
           <span class="ma__decorative-link">
             <a href="{{link.href}}" class="js-clickable-link">
               {{link.text}}&nbsp;
+              {{#if title.text}}
+              <span class="ma__visually-hidden"> to {{ title.text }}</span>
+              {{/if}}
               <svg aria-hidden="true" id="SvgjsSvg1000" xmlns="http://www.w3.org/2000/svg" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:svgjs="http://svgjs.com/svgjs" width="16" height="18" viewBox="0 0 16 18"><defs id="SvgjsDefs1001"></defs><path id="SvgjsPath1007" d="M983.721 1887.28L983.721 1887.28L986.423 1890L986.423 1890L986.423 1890L983.721 1892.72L983.721 1892.72L978.318 1898.17L975.617 1895.45L979.115 1891.92L971.443 1891.92L971.443 1888.0700000000002L979.103 1888.0700000000002L975.617 1884.5500000000002L978.318 1881.8300000000002Z " transform="matrix(1,0,0,1,-971,-1881)"></path></svg>
             </a>
           </span>


### PR DESCRIPTION
…ow.html

<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/develop/docs/for-developers/changelog-instructions.md)


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
In assets/js/templates/locationListingRow.html, set up to render `labelContext` just like  02-molecules/image-promo.twig/decorative-link.twig does for consistency as location listing is rendered by both templates.


## Related Issue / Ticket

- [JIRA issue](https://jira.mass.gov/browse/DP-21782)
- [Github issue]()

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Build a drupal site with this branch.
2. Go to a location listing page.
3. Check the Directions link in inspect for `labelContext` as "to LOCATION NAME" in `span.ma__visually-hidden`.
4. Refresh the page and check step 3 again.
5. Repeat step 4 to confirm its consistency.

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

*

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
