### PR TITLE
DP-21924 Upgrade core to Drupal 9

### DIFF
--- a/changelogs/DP-21924.yml
+++ b/changelogs/DP-21924.yml
@@ -1,0 +1,59 @@
+# Every PR must have a changelog. To create a changelog:
+# 1. Make a copy of this file and name it with the ticket number.
+# 2. Keep the original format of one of the examples at the bottom, and override each element of it using ___TEMPLATE___ for reference
+# 3. Remove all comments from the copied file
+
+#___CHANGE TYPES___
+# - Added for new features.
+# - Changed for changes in existing functionality.
+# - Deprecated for soon-to-be removed features.
+# - Removed for now removed features.
+# - Fixed for any bug fixes.
+# - Security in case of vulnerabilities.
+# e.g. Added
+
+#___PROJECT___
+# - Patternlab
+# - React
+# - Docs
+# e.g. React
+# e.g. React, Patternlab
+
+#___COMPONENT___
+# Component name(s) in `PascalCase`
+# e.g. Header
+# e.g. Form, InputSlider, InputTextTypeAhead
+
+#___DESCRIPTION___
+# PR description and PR number (append PR number with # to create a link to the PR in Github)
+# If you need multiple lines, start the first line with the following "|-" characters.
+# For any breaking changes, add a comment in the PR describing the necessary changes on the consumer side and link that comment in the description.
+#e.g. Adds apples to apple trees for admin apple pickers (#PR)
+
+#___ISSUE___
+# A Jira ticket or a Github issue number (append Github issue number with # to create a link to the issue in Github)
+# e.g. DP-12345 or #123
+
+#___IMPACT___
+# - Major impact when you make incompatible API changes,
+# - Minor impact when you add functionality in a backwards compatible manner, and
+# - Patch impact when you make backwards compatible bug fixes.
+# e.g. Minor
+# See https://semver.org/ for more info.
+
+
+#___TEMPLATE___
+# ChangeType [enter a valid option, see __CHANGE TYPES___ e.g. Added]:
+#  - project: Enter one or multiple (comma separated) valid project prefix(es) - see ___PROJECT___ e.g. React, Patternlab
+#    component: Enter one or multiple (comma separated) valid component name(s) - see ___COMPONENT___ e.g. Color
+#    description: Describe the change and add the PR number. see ___DESCRIPTION___ e.g. Adds apples to apple trees for admin apple pickers (#PR)
+#    issue: Add a Jira ticket or issue number, e.g. DP-12345 or 124
+#    impact: Enter a valid impact, e.g. Minor
+
+#___EXAMPLE___
+Changed:
+  - project: Patternlab
+    component: ContentTypes
+    description: Changed Twig syntax for drupal-9
+    issue: DP-21924
+    impact: Minor

--- a/packages/patternlab/styleguide/source/_patterns/04-templates/01-content-types/services.twig
+++ b/packages/patternlab/styleguide/source/_patterns/04-templates/01-content-types/services.twig
@@ -36,7 +36,7 @@
               {% include "@atoms/09-media/video.twig" %}
             {% endif %}
 
-            {% if flexibleLinkGroup is not defined or flexibleLinkGroup is null or flexibleLinkGroup is sameas(false) %}
+            {% if flexibleLinkGroup is not defined or flexibleLinkGroup is null or flexibleLinkGroup is same as(false) %}
                 {% if introPageContent.keyActions %}
                   {% set keyActions = introPageContent.keyActions %}
                   {% include "@organisms/by-author/key-actions.twig" %}
@@ -81,7 +81,7 @@
                 {% set actionFinder = doActionFinder.actionFinder %}
                 {% include "@organisms/by-author/action-finder.twig" %}
               {% endif %}
-              {% if flexibleLinkGroup is not defined or flexibleLinkGroup is null or flexibleLinkGroup is sameas(false) %}
+              {% if flexibleLinkGroup is not defined or flexibleLinkGroup is null or flexibleLinkGroup is same as(false) %}
                 {% if learnActionFinder %}
                   {% set actionFinder = learnActionFinder.actionFinder %}
                   {% include "@organisms/by-author/action-finder.twig" %}
@@ -93,12 +93,12 @@
               {% if mappedLocations %}
                 {% include "@organisms/by-author/mapped-locations.twig" %}
               {% endif %}
-              {% if flexibleLinkGroup is not defined or flexibleLinkGroup is null or flexibleLinkGroup is sameas(false) %}
+              {% if flexibleLinkGroup is not defined or flexibleLinkGroup is null or flexibleLinkGroup is same as(false) %}
                 {% if eventListing %}
                   {% include "@organisms/by-author/event-listing.twig" %}
                 {% endif %}
               {% endif %}
-              {% if flexibleLinkGroup is not defined or flexibleLinkGroup is null or flexibleLinkGroup is sameas(false) %}
+              {% if flexibleLinkGroup is not defined or flexibleLinkGroup is null or flexibleLinkGroup is same as(false) %}
                 {% if splitColumns %}
                   <div class="more-info-header">
                     <h2 class="ma__comp-heading">More Information</h2>


### PR DESCRIPTION
## Description
Drupal 9 uses Twig 2.  This  makes a slight syntax change that allows drupal to still work.

## Related Issue / Ticket

- [JIRA issue](https://jira.mass.gov/browse/DP-21924)
- [Github issue](https://github.com/massgov/openmass/pull/829)

## Steps to Test


1. Nothing should change.