### PR TITLE
[assets] fonts/ add versions and check

### DIFF
--- a/packages/assets/scss/00-base/_fonts.scss
+++ b/packages/assets/scss/00-base/_fonts.scss
@@ -17,24 +17,25 @@
 /////////////////////////////////////
 // Import fonts
 /* The fallback non-variable Noto Sans font */
+@supports not ( font-variation-settings: normal ) {
+  @font-face {
+    font-family: 'Noto Sans';
+    src:  url('#{$assets-path}/fonts/noto/Latin/NotoSans-Regular.eot?#iefix') format('embedded-opentype'),
+          url('#{$assets-path}/fonts/noto/Latin/NotoSans-Regular.woff2?version=1') format('woff2'),
+          url('#{$assets-path}/fonts/noto/Latin/NotoSans-Regular.woff') format('woff');
+    font-style: normal;
+    font-display: $fonts-display-global;
+  }
+  /* The fallback non-variable Noto Sans Italic font */
 
-@font-face {
-  font-family: 'Noto Sans';
-  src:  url('#{$assets-path}/fonts/noto/Latin/NotoSans-Regular.eot?#iefix') format('embedded-opentype'),
-        url('#{$assets-path}/fonts/noto/Latin/NotoSans-Regular.woff2') format('woff2'),
-        url('#{$assets-path}/fonts/noto/Latin/NotoSans-Regular.woff') format('woff');
-  font-style: normal;
-  font-display: $fonts-display-global;
-}
-/* The fallback non-variable Noto Sans Italic font */
-
-@font-face {
-  font-family: 'Noto Sans';
-  src:  url('#{$assets-path}/fonts/noto/Latin/NotoSans-Italic.eot?#iefix') format('embedded-opentype'),
-        url('#{$assets-path}/fonts/noto/Latin/NotoSans-Italic.woff2') format('woff2'),
-        url('#{$assets-path}/fonts/noto/Latin/NotoSans-Italic.woff') format('woff');
-  font-style: italic;
-  font-display: $fonts-display-global;
+  @font-face {
+    font-family: 'Noto Sans';
+    src:  url('#{$assets-path}/fonts/noto/Latin/NotoSans-Italic.eot?#iefix') format('embedded-opentype'),
+          url('#{$assets-path}/fonts/noto/Latin/NotoSans-Italic.woff2?version=1') format('woff2'),
+          url('#{$assets-path}/fonts/noto/Latin/NotoSans-Italic.woff') format('woff');
+    font-style: italic;
+    font-display: $fonts-display-global;
+  }
 }
 
 @supports ( font-variation-settings: normal ) {


### PR DESCRIPTION
![Screen Shot 2021-07-06 at 12 26 31 PM](https://user-images.githubusercontent.com/5789411/124660892-d1102180-de74-11eb-8853-45170ee8b918.png)


IE and some other older versions of browsers don't support `@support` of CSS.
If we add the check, which will prevent the fonts loaded twice on modern browsers, will not load Noto Sans on the browser versions highlighted in red:
https://caniuse.com/?search=%40support
![Screen Shot 2021-07-06 at 4 14 24 PM](https://user-images.githubusercontent.com/5789411/124661288-4976e280-de75-11eb-9804-e702eab32cba.png)
