### PR TITLE
Patternlab/dp 18737 datatable external review

### DIFF
--- a/packages/patternlab/styleguide/source/_patterns/01-atoms/09-media/figure.json
+++ b/packages/patternlab/styleguide/source/_patterns/01-atoms/09-media/figure.json
@@ -6,7 +6,8 @@
     "content": "",
     "title": {
       "text": "This is an option title",
-      "visible": true
+      "visible": true,
+      "level": ""
     },
     "caption": "This is an optional caption that can wrap to multiple lines.",
     "ariaLive": "",

--- a/packages/patternlab/styleguide/source/_patterns/01-atoms/09-media/figure.json
+++ b/packages/patternlab/styleguide/source/_patterns/01-atoms/09-media/figure.json
@@ -7,7 +7,7 @@
     "title": {
       "text": "This is an option title",
       "visible": true,
-      "level": ""
+      "level": 3
     },
     "caption": "This is an optional caption that can wrap to multiple lines.",
     "ariaLive": "",

--- a/packages/patternlab/styleguide/source/_patterns/01-atoms/09-media/figure.md
+++ b/packages/patternlab/styleguide/source/_patterns/01-atoms/09-media/figure.md
@@ -46,7 +46,12 @@ figure: {
       type: string (url) / required
   }
   title:
-    type: string
+    text: 
+      type: string / optional
+    visible: 
+      type: boolean / optional
+    level:
+      number / optional
   caption:
     type: string
 }

--- a/packages/patternlab/styleguide/source/_patterns/01-atoms/09-media/figure.twig
+++ b/packages/patternlab/styleguide/source/_patterns/01-atoms/09-media/figure.twig
@@ -3,6 +3,7 @@
 {% set wrapClass = not figure.wrap ? " ma__figure--no-wrap" : "" %}
 {% set skiplinkId = figure.skiplink ? "figure-" ~ random(9999) : "" %}
 {% set skiplinkText = figure.skiplink.text ? figure.skiplink.text : "graphic presentation" %}
+{% set titleLevel = figure.title.level ? "h" ~ figure.title.level : span %}
 
 <div class="ma__figure{{ alignmentClass }}{{ sizeClass }}{{ figure.class ? " "~ figure.class : " " }}{{ wrapClass }}">
 {% if figure.skiplink.add %}
@@ -13,9 +14,9 @@
   {% if figure.title.text and figure.title.visible %}
     {# screen reader or AT users get title from aria-label in <figure> in semantic manner.
     To avoid them to receive duplicate information, hide this title from them with aria-hidden. #}
-    <span class="ma__figure__title" aria-hidden="true">
+    <{{titleLevel}} class="ma__figure__title" aria-hidden="true">
       {{ figure.title.text }}
-    </span>
+    </{{titleLevel}}>
     {% endif %}
     {# Container for aria-live. Currently, only implemented with Caspio, but can be extended to any figure variations. #}
     {% if figure.ariaLive %}<div aria-live="{{ figure.ariaLive }}">{% endif %}

--- a/packages/patternlab/styleguide/source/_patterns/01-atoms/09-media/figure.twig
+++ b/packages/patternlab/styleguide/source/_patterns/01-atoms/09-media/figure.twig
@@ -3,7 +3,7 @@
 {% set wrapClass = not figure.wrap ? " ma__figure--no-wrap" : "" %}
 {% set skiplinkId = figure.skiplink ? "figure-" ~ random(9999) : "" %}
 {% set skiplinkText = figure.skiplink.text ? figure.skiplink.text : "graphic presentation" %}
-{% set titleLevel = figure.title.level ? "h" ~ figure.title.level : span %}
+{% set titleLevel = figure.title.level ? : 3 %}
 
 <div class="ma__figure{{ alignmentClass }}{{ sizeClass }}{{ figure.class ? " "~ figure.class : " " }}{{ wrapClass }}">
 {% if figure.skiplink.add %}
@@ -14,9 +14,15 @@
   {% if figure.title.text and figure.title.visible %}
     {# screen reader or AT users get title from aria-label in <figure> in semantic manner.
     To avoid them to receive duplicate information, hide this title from them with aria-hidden. #}
-    <{{titleLevel}} class="ma__figure__title" aria-hidden="true">
-      {{ figure.title.text }}
-    </{{titleLevel}}>
+      {% if figure.title.level %}
+        <h{{ titleLevel }} class="ma__figure__title" aria-hidden="true">
+            {{ figure.title.text }}
+        </h{{ titleLevel}}>
+      {% else %}
+        <span class="ma__figure__title" aria-hidden="true">
+          {{ figure.title.text }}
+        </span>
+      {% endif %}
     {% endif %}
     {# Container for aria-live. Currently, only implemented with Caspio, but can be extended to any figure variations. #}
     {% if figure.ariaLive %}<div aria-live="{{ figure.ariaLive }}">{% endif %}


### PR DESCRIPTION
Added:
  - project: Patternlab
    component: Figure
    description: Add `level` to `title` to allow rendering a heading as figure title. (#1446)
    issue: DP-18737
    impact: Minor
    
