### PR TITLE
Consolidate changelogs and update core version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Mayflower Release Notes
 All notable changes to this project will be documented in this file.
 
+## 11.10.0 (7/26/2021)
+### Changed 
+- (Patternlab) [EmergencyAlert, EmergencyHeader, HeaderAlerts] DP-22395: Implement new designs for EmergencyAlerts and HeaderAlerts (replacing HeaderAlert). (#1449)
+
 ## 11.9.0 (7/19/2021)
 ### Changed 
 - (Patternlab) [PageFlipper] DP-22292: Hide duplicate links in the component from assistive technology and keyboard users. (#1433)

--- a/changelogs/DP-22395.yml
+++ b/changelogs/DP-22395.yml
@@ -1,6 +1,0 @@
-Changed:
-  - project: Patternlab
-    component: EmergencyAlert, EmergencyHeader, HeaderAlerts
-    description: Implement new designs for EmergencyAlerts and HeaderAlerts (replacing HeaderAlert). (#1449)
-    issue: DP-22395
-    impact: Minor

--- a/packages/core/.env
+++ b/packages/core/.env
@@ -1,4 +1,4 @@
-VERSION=11.8.1
+VERSION=11.10.0
 PKG=@massds/mayflower-assets
 STORYBOOK_CDN=https://unpkg.com/
 STORYBOOK_PKG=$PKG@$VERSION


### PR DESCRIPTION
## 11.10.0 (7/26/2021)
### Changed 
- (Patternlab) [EmergencyAlert, EmergencyHeader, HeaderAlerts] DP-22395: Implement new designs for EmergencyAlerts and HeaderAlerts (replacing HeaderAlert). (#1449)