### PR TITLE
DP-22859 - response heigh issue with x-large

### DIFF
--- a/packages/patternlab/styleguide/source/assets/js/modules/imageFill.js
+++ b/packages/patternlab/styleguide/source/assets/js/modules/imageFill.js
@@ -21,6 +21,12 @@ export default (function (window, document, $, undefined) {
 
         // Make the image the full width of the wrapper.
         $thisMedia.css("width", wrapperWidth);
+        let iframe = $thisMedia.find('iframe');
+        if (iframe.length) {
+          setTimeout( function() {
+            iframe[0].contentWindow.postMessage('update', '*');
+          }, 300);
+        }
       }
     });
 


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/develop/docs/for-developers/changelog-instructions.md)


## Description
Send a iframe message to retrieve the latest iframe height

## Related Issue / Ticket

- [JIRA issue](https://massgov.atlassian.net/browse/DP-22859)
- [Github issue](https://github.com/massgov/mayflower/pull/1486)
