### PR TITLE
DP-22657 Migrate org page "What would you like to do" to sections

### DIFF
--- a/packages/patternlab/styleguide/source/assets/js/modules/accordions.js
+++ b/packages/patternlab/styleguide/source/assets/js/modules/accordions.js
@@ -54,7 +54,7 @@ export default (function (window,document,$,undefined) {
       $toggleLink.removeClass('ma__collapsible-content__toggle-all--collapsed');
     }
 
-    $('.js-accordion').each(function(index){
+    $('.ma__collapsible-content--extended .js-accordion').each(function(index){
       accordionToggle($(this), toggleStatus);
     });
   }
@@ -106,7 +106,7 @@ export default (function (window,document,$,undefined) {
     $link.attr('aria-expanded',open).attr('aria-controls', id);
 
     if(isExtended) {
-      let childs = $el.find('.ma__link-list__item, .ma__collapsible-content__body-item').length;
+      let childs = $el.find('.ma__collapsible-content__body-item a').length;
       $el.find('.ma__collapsible-header__title').append( `<div class="header__title__counter">(${childs})</div>`);
     }
 


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/develop/docs/for-developers/changelog-instructions.md)


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
Fixes counting logic of extended collapsible content component and also the "expand all" button.

## Related Issue / Ticket

- [JIRA issue](https://massgov.atlassian.net/browse/DP-22657)
- [Github issue]()

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Checkout this Mayflower branch paired with OpenMass `DP-22331_flex-orgs` branch.
2. Refresh your environment with `ahoy comi; ahoy comi; ahoy updatedb` 
3. Visit this page in your environment: https://massgovfeature3.prod.acquia-sites.com/orgs/executive-office-of-health-and-human-services.
4. Click "Collapse All" and validate that the featured topics below aren't affected, just the accordion.
5. Validate that the number of items displayed at the top right of the accordion is correct.

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

*

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
