### PR TITLE
DP-22983 Callout link component on org page not rendering correctly

### DIFF
--- a/changelogs/DP-22983.yml
+++ b/changelogs/DP-22983.yml
@@ -1,0 +1,59 @@
+# Every PR must have a changelog. To create a changelog:
+# 1. Make a copy of this file and name it with the ticket number.
+# 2. Keep the original format of one of the examples at the bottom, and override each element of it using ___TEMPLATE___ for reference
+# 3. Remove all comments from the copied file
+
+#___CHANGE TYPES___
+# - Added for new features.
+# - Changed for changes in existing functionality.
+# - Deprecated for soon-to-be removed features.
+# - Removed for now removed features.
+# - Fixed for any bug fixes.
+# - Security in case of vulnerabilities.
+# e.g. Added
+
+#___PROJECT___
+# - Patternlab
+# - React
+# - Docs
+# e.g. React
+# e.g. React, Patternlab
+
+#___COMPONENT___
+# Component name(s) in `PascalCase`
+# e.g. Header
+# e.g. Form, InputSlider, InputTextTypeAhead
+
+#___DESCRIPTION___
+# PR description and PR number (append PR number with # to create a link to the PR in Github)
+# If you need multiple lines, start the first line with the following "|-" characters.
+# For any breaking changes, add a comment in the PR describing the necessary changes on the consumer side and link that comment in the description.
+#e.g. Adds apples to apple trees for admin apple pickers (#PR)
+
+#___ISSUE___
+# A Jira ticket or a Github issue number (append Github issue number with # to create a link to the issue in Github)
+# e.g. DP-12345 or #123
+
+#___IMPACT___
+# - Major impact when you make incompatible API changes,
+# - Minor impact when you add functionality in a backwards compatible manner, and
+# - Patch impact when you make backwards compatible bug fixes.
+# e.g. Minor
+# See https://semver.org/ for more info.
+
+
+#___TEMPLATE___
+# ChangeType [enter a valid option, see __CHANGE TYPES___ e.g. Added]:
+#  - project: Enter one or multiple (comma separated) valid project prefix(es) - see ___PROJECT___ e.g. React, Patternlab
+#    component: Enter one or multiple (comma separated) valid component name(s) - see ___COMPONENT___ e.g. Color
+#    description: Describe the change and add the PR number. see ___DESCRIPTION___ e.g. Adds apples to apple trees for admin apple pickers (#PR)
+#    issue: Add a Jira ticket or issue number, e.g. DP-12345 or 124
+#    impact: Enter a valid impact, e.g. Minor
+
+#___EXAMPLE___
+Changed:
+  - project: Patternlab
+    component: ActionFinder
+    description: Added a new action finder compact variant to accomodate action links with no header or background color.
+    issue: DP-22983
+    impact: Minor

--- a/packages/assets/scss/03-organisms/_action-finder.scss
+++ b/packages/assets/scss/03-organisms/_action-finder.scss
@@ -322,4 +322,8 @@ $action-finder-border-color: mix(#fff, $c-primary,50%);
       }
     }
   }
+
+  &--compact {
+    background: none;
+  }
 }

--- a/packages/patternlab/styleguide/source/_patterns/03-organisms/by-author/action-finder-compact.md
+++ b/packages/patternlab/styleguide/source/_patterns/03-organisms/by-author/action-finder-compact.md
@@ -1,0 +1,5 @@
+### Description
+This is a variant of the [Action Finder](./?p=organisms-action-finder) showing an example with the compact variation.
+
+### How to generate
+* Set the `compact` variable to TRUE.

--- a/packages/patternlab/styleguide/source/_patterns/03-organisms/by-author/action-finder.twig
+++ b/packages/patternlab/styleguide/source/_patterns/03-organisms/by-author/action-finder.twig
@@ -5,10 +5,14 @@
   {% set noBgClass = "ma__action-finder--no-background" %}
 {% endif %}
 
+{% if actionFinder.compact %}
+  {% set modifierClass = "ma__action-finder--compact" %}
+{% endif %}
+
 {% if actionFinder.color %}
   {% set colorClass = "ma__action-finder--" ~ actionFinder.color %}
 {% endif %}
-<section class="ma__action-finder {{ noBgClass }} {{ colorClass }}" id="{{ actionFinder.id }}">
+<section class="ma__action-finder {{ noBgClass }} {{ colorClass }} {{ modifierClass }}" id="{{ actionFinder.id }}">
   {% if actionFinder.bgWide %}
     <style>
       #{{ actionFinder.id }} {
@@ -16,19 +20,21 @@
       }
 
       @media (min-width: 801px) {
-        #{{ actionFinder.id }} {
-          background-image: url('{{actionFinder.bgWide}}');
-        }
+      #{{ actionFinder.id }} {
+        background-image: url('{{actionFinder.bgWide}}');
+      }
       }
     </style>
   {% endif %}
   <div class="ma__action-finder__container">
-    <header class="ma__action-finder__header">
-      <h2 class="ma__action-finder__title">
-        {{ actionFinder.title }}
-        {% if actionFinder.contextPositionTop and actionFinder.titleContext %}<span class="visually-hidden"> {{ actionFinder.titleContext }}</span>{% endif %}
-      </h2>
-    </header>
+    {% if not actionFinder.compact %}
+      <header class="ma__action-finder__header">
+        <h2 class="ma__action-finder__title">
+          {{ actionFinder.title }}
+          {% if actionFinder.contextPositionTop and actionFinder.titleContext %}<span class="visually-hidden"> {{ actionFinder.titleContext }}</span>{% endif %}
+        </h2>
+      </header>
+    {% endif %}
     {% if actionFinder.featuredLinks %}
       {% if actionFinder.featuredHeading %}
         <h3 class="ma__action-finder__category">{{ actionFinder.featuredHeading }}{% if actionFinder.contextPositionTop == false and actionFinder.titleContext %}<span class="visually-hidden"> {{ actionFinder.titleContext }}</span>{% endif %}</h3>

--- a/packages/patternlab/styleguide/source/_patterns/03-organisms/by-author/action-finder~compact.json
+++ b/packages/patternlab/styleguide/source/_patterns/03-organisms/by-author/action-finder~compact.json
@@ -1,0 +1,24 @@
+{
+  "actionFinder": {
+    "id": "GUID831741781374893",
+    "compact":true,
+
+    "featuredLinks": [{
+      "image": "../../assets/images/placeholder/130x160.png",
+      "text": "Getting Outdoors",
+      "type": "",
+      "href": "#",
+      "label": "Guide:"
+    },{
+      "image": "",
+      "text": "Cancel or Transfer a Campsite Reservation",
+      "type": "external",
+      "href": "#"
+    },{
+      "image": "",
+      "text": "Find Horseback Riding Trails",
+      "type": "",
+      "href": "#"
+    }]
+  }
+}


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/develop/docs/for-developers/changelog-instructions.md)


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
Added a new "compact" variant to the Action Finder component to accommodate the organization section on OpenMass that doesn't use the component header and doesn't have a background color.
## Related Issue / Ticket

- [JIRA issue](https://massgov.atlassian.net/browse/DP-22983)


## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->



## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

*

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
