### PR TITLE
DP-22940 - Fix location page alignment of contact information header

### DIFF
--- a/changelogs/DP-22940.yml
+++ b/changelogs/DP-22940.yml
@@ -4,6 +4,6 @@
 # 3. Remove all comments from the copied file
   - project: Patternlab
     component: Sidebar
-    description: Fix the horizontal alignment on sidebar for locations. Fix small text-underline on locations.
+    description: Fix the horizontal alignment on sidebar for locations. Fix small text-underline on locations. #1513
     issue: DP-22940
     impact: Patch

--- a/changelogs/DP-22940.yml
+++ b/changelogs/DP-22940.yml
@@ -1,0 +1,9 @@
+# Every PR must have a changelog. To create a changelog:
+# 1. Make a copy of this file and name it with the ticket number.
+# 2. Keep the original format of one of the examples at the bottom, and override each element of it using ___TEMPLATE___ for reference
+# 3. Remove all comments from the copied file
+  - project: Patternlab
+    component: Sidebar
+    description: Fix the horizontal alignment on sidebar for locations. Fix small text-underline on locations.
+    issue: DP-22940
+    impact: Patch

--- a/packages/assets/scss/02-molecules/_map-leaflet.scss
+++ b/packages/assets/scss/02-molecules/_map-leaflet.scss
@@ -27,6 +27,13 @@
   display: flex;
   flex-direction: column;
 
+  &__link {
+
+    a {
+      text-decoration: none;
+    }
+  }
+
   &__map {
     height: 360px;
     z-index: 10;

--- a/packages/assets/scss/04-templates/_general.scss
+++ b/packages/assets/scss/04-templates/_general.scss
@@ -103,6 +103,10 @@
 .page-content + .sidebar {
   padding-top: 40px;
 
+  > .sidebar {
+    padding-top: 0;
+  }
+
   @media ($bp-small-min) {
     padding-top: 65px;
   }


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/develop/docs/for-developers/changelog-instructions.md)


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
Fix horizontal aligment on locations page.

## Related Issue / Ticket

- [JIRA issue](https://massgov.atlassian.net/browse/DP-22940)
- [Github issue](https://github.com/massgov/mayflower/pull/1513)
