### PR TITLE
DP-22983 Callout link component on org page not rendering correctly

### DIFF
--- a/changelogs/DP-22983.yml
+++ b/changelogs/DP-22983.yml
@@ -1,6 +1,6 @@
 Changed:
   - project: PatternLab
     component: ActionFinder
-    description: Adjusting action finder to not render the heading if there isn't a title and adds a background option.
+    description: Adjusting action finder to not render the heading if there isn't a title and adds a background option. (#1514)
     issue: DP-22983
     impact: Minor

--- a/changelogs/DP-22983.yml
+++ b/changelogs/DP-22983.yml
@@ -1,0 +1,6 @@
+Changed:
+  - project: PatternLab
+    component: ActionFinder
+    description: Adjusting action finder to not render the heading if there isn't a title and adds a background option.
+    issue: DP-22983
+    impact: Minor

--- a/packages/assets/scss/03-organisms/_action-finder.scss
+++ b/packages/assets/scss/03-organisms/_action-finder.scss
@@ -204,6 +204,13 @@ $action-finder-bp: 900px;
     text-align: left;
   }
 
+  &--clear-background {
+    background: none;
+
+    &:after {
+      content: none;
+    }
+  }
 }
 
 //theme

--- a/packages/patternlab/styleguide/source/_patterns/03-organisms/by-author/action-finder.md
+++ b/packages/patternlab/styleguide/source/_patterns/03-organisms/by-author/action-finder.md
@@ -30,6 +30,8 @@ actionFinder: {
     type: string / required
   generalHeading:
     type: string / required
+  noBgClass:
+    type: string / optional, defaults to `ma__action-finder--no-background` which shows up as a light gray background, to remove the background colors, pass in `ma__action-finder--clear-background`.
 
   seeAll: {
     type: decorativeLink / optional

--- a/packages/patternlab/styleguide/source/_patterns/03-organisms/by-author/action-finder.twig
+++ b/packages/patternlab/styleguide/source/_patterns/03-organisms/by-author/action-finder.twig
@@ -5,6 +5,10 @@
   {% set noBgClass = "ma__action-finder--no-background" %}
 {% endif %}
 
+{% if actionFinder.noBgClass %}
+  {% set noBgClass = actionFinder.noBgClass %}
+{% endif %}
+
 {% if actionFinder.color %}
   {% set colorClass = "ma__action-finder--" ~ actionFinder.color %}
 {% endif %}
@@ -23,12 +27,14 @@
     </style>
   {% endif %}
   <div class="ma__action-finder__container">
-    <header class="ma__action-finder__header">
-      <h2 class="ma__action-finder__title">
-        {{ actionFinder.title }}
-        {% if actionFinder.contextPositionTop and actionFinder.titleContext %}<span class="visually-hidden"> {{ actionFinder.titleContext }}</span>{% endif %}
-      </h2>
-    </header>
+    {% if actionFinder.title %}
+      <header class="ma__action-finder__header">
+        <h2 class="ma__action-finder__title">
+          {{ actionFinder.title }}
+          {% if actionFinder.contextPositionTop and actionFinder.titleContext %}<span class="visually-hidden"> {{ actionFinder.titleContext }}</span>{% endif %}
+        </h2>
+      </header>
+    {% endif %}
     {% if actionFinder.featuredLinks %}
       {% if actionFinder.featuredHeading %}
         <h3 class="ma__action-finder__category">{{ actionFinder.featuredHeading }}{% if actionFinder.contextPositionTop == false and actionFinder.titleContext %}<span class="visually-hidden"> {{ actionFinder.titleContext }}</span>{% endif %}</h3>


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/develop/docs/for-developers/changelog-instructions.md)


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
Adjusting action finder to not render the heading if there isn't a title and adds a background option.

## Related Issue / Ticket

- [JIRA issue](https://massgov.atlassian.net/browse/DP-22983)

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->


## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.
<img width="1405" alt="j-r-capture 2021-09-30 a la(s) 15 02 59" src="https://user-images.githubusercontent.com/141685/135507624-dbb2b013-5c97-45a4-8687-9e5b12b29bd9.png">


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

*

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
