### PR TITLE
Image component on org page not rendering correctly

### DIFF
--- a/changelogs/DP-22981.yml
+++ b/changelogs/DP-22981.yml
@@ -1,0 +1,6 @@
+Changed:
+  - project: PatternLab
+    component: Figure
+    description: Fixing image displaying when right aligned.
+    issue: DP-22981
+    impact: Minor

--- a/packages/assets/scss/01-atoms/_figure.scss
+++ b/packages/assets/scss/01-atoms/_figure.scss
@@ -147,6 +147,13 @@
     &--x-small,
     &--small {
       width: calc(50% - 15px);
+
+      &.ma__figure--no-wrap.ma__figure--right {
+        @media ($bp-small-min) {// 621~
+          margin-left: 50%;
+          padding-left: 0;
+        }
+      }
     }
   }
 
@@ -190,6 +197,13 @@
 
     @media ($bp-small-min) {// 621~
       width: calc(50% - 15px);
+    }
+
+   &.ma__figure--no-wrap.ma__figure--right {
+      @media ($bp-small-min) {// 621~
+        margin-left: 50%;
+        padding-left: 0;
+      }
     }
 
   }

--- a/packages/patternlab/styleguide/source/assets/js/modules/imageFill.js
+++ b/packages/patternlab/styleguide/source/assets/js/modules/imageFill.js
@@ -8,7 +8,7 @@ export default (function (window, document, $, undefined) {
 
   function mediaWidth() {
     // Define wrapper width for use.
-    var wrapperWidth = $("#main-content > .main-content--two").width();
+    var wrapperWidth = $("#main-content > .main-content--two").width(); console.log('restored');
 
     $(".ma__figure--full, .ma__iframe--full").each(function () {
       var $thisMedia = $(this);
@@ -20,7 +20,12 @@ export default (function (window, document, $, undefined) {
       if (thisPosition > sidebarHeight) {
 
         // Make the image the full width of the wrapper.
-        $thisMedia.css("width", wrapperWidth);
+        if (wrapperWidth) {
+          $thisMedia.css("width", wrapperWidth);
+        } else {
+          $thisMedia.parent('.ma__rich-text').css('padding-right', '0');
+        }
+
         let iframe = $thisMedia.find('iframe');
         if (iframe.length) {
           setTimeout( function() {

--- a/packages/patternlab/styleguide/source/assets/js/modules/imageFill.js
+++ b/packages/patternlab/styleguide/source/assets/js/modules/imageFill.js
@@ -8,7 +8,7 @@ export default (function (window, document, $, undefined) {
 
   function mediaWidth() {
     // Define wrapper width for use.
-    var wrapperWidth = $("#main-content > .main-content--two").width(); console.log('restored');
+    var wrapperWidth = $("#main-content > .main-content--two").width();
 
     $(".ma__figure--full, .ma__iframe--full").each(function () {
       var $thisMedia = $(this);


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/develop/docs/for-developers/changelog-instructions.md)


## Description

1. Images when are right aligned and not wrapped, are broken. 
2. Images in XL size are broken if aren't wrapped up by a `.main-content--two`.

### See:
1. https://massgovfeature3.prod.acquia-sites.com/info-details/qaginfo-details-image-in-section-right-align-with-no-wrap
<img width="1024" alt="j-r-capture 2021-10-04 a la(s) 17 35 08" src="https://user-images.githubusercontent.com/141685/135921264-22cdee77-606c-423b-b250-5bd678c80bba.png">

2. https://massgovfeature3.prod.acquia-sites.com/orgs/qag-organization-image-part-1
<img width="1024" alt="j-r-capture 2021-10-04 a la(s) 17 34 46" src="https://user-images.githubusercontent.com/141685/135921345-270af34a-7164-456b-bc3a-f998ed157555.png">


These changes fixes both issues.

## Related Issue / Ticket

- [JIRA issue](https://massgov.atlassian.net/browse/DP-22981)


## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1.

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

*

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
