### PR TITLE
DP-22982 Iframe, Caspio and Tableau components on org page not rendering correctly

### DIFF
--- a/packages/assets/scss/01-atoms/_figure.scss
+++ b/packages/assets/scss/01-atoms/_figure.scss
@@ -72,7 +72,7 @@
 
     // support pre-existing figure elements besides dataviz.
 
-    &--left:not(.ma__dataviz),
+    &--left:not(.ma__dataviz):not(.ma__iframe__container),
     &--align-left,
     &.align-left {
       float: left;
@@ -80,7 +80,7 @@
       width: 50%;
     }
 
-    &--right:not(.ma__dataviz),
+    &--right:not(.ma__dataviz):not(.ma__iframe__container),
     &--align-right,
     &.align-right {
       float: right;
@@ -164,7 +164,10 @@
 
     .page-content:not(.no-sidebar) &--x-small,
     .page-content:not(.no-sidebar) &--small {
-      width: calc(50% - 15px);
+
+      &:not(.ma__dataviz):not(.ma__iframe__container) {
+        width: calc(50% - 15px);
+      }
     }
   }
 
@@ -206,7 +209,7 @@
     }
 
     @media ($bp-small-min) and ($bp-large-max) {
-      width: calc(50% - 15px);
+        width: calc(50% - 15px);
     }
 
     @media ($bp-small-max) {
@@ -218,7 +221,9 @@
 
     @media ($bp-large-extended-min) {
 
-      width: calc(50% - 15px);
+      &:not(.ma__dataviz):not(.ma__iframe__container) {
+        width: calc(50% - 15px);
+      }
     }
   }
 
@@ -228,7 +233,9 @@
     width: 100%;
   }
 
-  .no-sidebar &--large {
+  .no-sidebar &--large,
+  &--large.ma__dataviz,
+  &--large.ma__iframe__container {
 
     @media ($bp-large-max) {
       width: 100%;
@@ -238,8 +245,10 @@
     }
 
     @media ($bp-large-min) {
-      width: 66.66%;
-      width: calc(100% / 3 * 2);
+      //&:not(.ma__dataviz):not(.ma__iframe__container) {
+        width: 66.66%;
+        width: calc(100% / 3 * 2);
+     // }
     }
   }
 
@@ -293,7 +302,9 @@
 
   // NO WRAP - Small
 
-  .no-sidebar &--no-wrap.ma__figure--right.ma__figure--small {
+  .no-sidebar &--no-wrap.ma__figure--right.ma__figure--small,
+  &--no-wrap.ma__figure--right.ma__figure--small.ma__dataviz,
+  &--no-wrap.ma__figure--right.ma__figure--small.ma__iframe__container {
 
     @media ($bp-small-min) {// 621~
 
@@ -304,7 +315,10 @@
 
   // NO WRAP - Medium
 
-  .no-sidebar &--no-wrap.ma__figure--right.ma__figure--medium {
+  .no-sidebar &--no-wrap.ma__figure--right.ma__figure--medium,
+  &--no-wrap.ma__figure--right.ma__figure--medium.ma__dataviz,
+  &--no-wrap.ma__figure--right.ma__figure--medium.ma__iframe__container {
+
 
     @media ($bp-small-min) {// 621~
 
@@ -320,6 +334,13 @@
 
       padding-left: 66.66%;
       padding-left: calc(100% / 3 * 2);
+    }
+  }
+
+  &--no-wrap.ma__figure--right.ma__figure--large.ma__dataviz,
+  &--no-wrap.ma__figure--right.ma__figure--large.ma__iframe__container {
+    @media ($bp-large-min) {
+      padding-left: calc(100% / 3);
     }
   }
 

--- a/packages/assets/scss/01-atoms/_figure.scss
+++ b/packages/assets/scss/01-atoms/_figure.scss
@@ -245,10 +245,8 @@
     }
 
     @media ($bp-large-min) {
-      //&:not(.ma__dataviz):not(.ma__iframe__container) {
-        width: 66.66%;
-        width: calc(100% / 3 * 2);
-     // }
+      width: 66.66%;
+      width: calc(100% / 3 * 2);
     }
   }
 
@@ -339,6 +337,7 @@
 
   &--no-wrap.ma__figure--right.ma__figure--large.ma__dataviz,
   &--no-wrap.ma__figure--right.ma__figure--large.ma__iframe__container {
+    
     @media ($bp-large-min) {
       padding-left: calc(100% / 3);
     }

--- a/packages/assets/scss/01-atoms/_figure.scss
+++ b/packages/assets/scss/01-atoms/_figure.scss
@@ -160,17 +160,6 @@
     }
   }
 
-  @media ($bp-large-min) {// 910<
-
-    .page-content:not(.no-sidebar) &--x-small,
-    .page-content:not(.no-sidebar) &--small {
-
-      &:not(.ma__dataviz):not(.ma__iframe__container) {
-        width: calc(50% - 15px);
-      }
-    }
-  }
-
   @media ($bp-large-min) and ($bp-large-extended) {// 911-1050
 
     .page-content:not(.no-sidebar) &--small {
@@ -319,7 +308,7 @@
 
 
     @media ($bp-small-min) {// 621~
-
+      width: 100%;
       padding-left: 50%;
     }
   }
@@ -337,7 +326,7 @@
 
   &--no-wrap.ma__figure--right.ma__figure--large.ma__dataviz,
   &--no-wrap.ma__figure--right.ma__figure--large.ma__iframe__container {
-    
+
     @media ($bp-large-min) {
       padding-left: calc(100% / 3);
     }


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/develop/docs/for-developers/changelog-instructions.md)


## Description
Adjusted these components for use with stacked rows wrapper.

## Related Issue / Ticket

- [JIRA issue](https://massgov.atlassian.net/browse/DP-22982)

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Checkout this branch, plus `feature/DP-22982_iframe-caspio-tableau` on openmass.
2. Edit an organization on OpenMass and add tableau, iframe or caspio components in "organization section" under "content" tab.
3. Compare with Info details pages, find links in the ticket.

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* Figure component

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
