### PR TITLE
DP-22982 Iframe, Caspio and Tableau components on org page not rendering correctly

### DIFF
--- a/changelogs/DP-22982.yml
+++ b/changelogs/DP-22982.yml
@@ -1,0 +1,11 @@
+Changed:
+  - project: PatternLab
+    component: StackedRowSection
+    description: Adding new modifier class option.
+    issue: DP-22982
+    impact: Minor
+  - project: PatternLab
+    component: RichText
+    description: Removing right padding if container has a .no-sidebar class.
+    issue: DP-22982
+    impact: Minor

--- a/changelogs/DP-22982.yml
+++ b/changelogs/DP-22982.yml
@@ -1,11 +1,11 @@
 Changed:
   - project: PatternLab
     component: StackedRowSection
-    description: Adding new modifier class option.
+    description: Adding new modifier class option. (#1518)
     issue: DP-22982
     impact: Minor
   - project: PatternLab
     component: RichText
-    description: Removing right padding if container has a .no-sidebar class.
+    description: Removing right padding if container has a .no-sidebar class. (#1518)
     issue: DP-22982
     impact: Minor

--- a/packages/assets/scss/01-atoms/_figure.scss
+++ b/packages/assets/scss/01-atoms/_figure.scss
@@ -72,7 +72,7 @@
 
     // support pre-existing figure elements besides dataviz.
 
-    &--left:not(.ma__dataviz),
+    &--left:not(.ma__dataviz):not(.ma__iframe__container),
     &--align-left,
     &.align-left {
       float: left;
@@ -80,7 +80,7 @@
       width: 50%;
     }
 
-    &--right:not(.ma__dataviz),
+    &--right:not(.ma__dataviz):not(.ma__iframe__container),
     &--align-right,
     &.align-right {
       float: right;
@@ -164,7 +164,10 @@
 
     .page-content:not(.no-sidebar) &--x-small,
     .page-content:not(.no-sidebar) &--small {
-      width: calc(50% - 15px);
+
+      &:not(.ma__dataviz):not(.ma__iframe__container) {
+        width: calc(50% - 15px);
+      }
     }
   }
 
@@ -206,7 +209,7 @@
     }
 
     @media ($bp-small-min) and ($bp-large-max) {
-      width: calc(50% - 15px);
+        width: calc(50% - 15px);
     }
 
     @media ($bp-small-max) {
@@ -218,7 +221,9 @@
 
     @media ($bp-large-extended-min) {
 
-      width: calc(50% - 15px);
+      &:not(.ma__dataviz):not(.ma__iframe__container) {
+        width: calc(50% - 15px);
+      }
     }
   }
 
@@ -228,7 +233,9 @@
     width: 100%;
   }
 
-  .no-sidebar &--large {
+  .no-sidebar &--large,
+  &--large.ma__dataviz,
+  &--large.ma__iframe__container {
 
     @media ($bp-large-max) {
       width: 100%;
@@ -238,8 +245,10 @@
     }
 
     @media ($bp-large-min) {
-      width: 66.66%;
-      width: calc(100% / 3 * 2);
+      //&:not(.ma__dataviz):not(.ma__iframe__container) {
+        width: 66.66%;
+        width: calc(100% / 3 * 2);
+     // }
     }
   }
 
@@ -293,7 +302,9 @@
 
   // NO WRAP - Small
 
-  .no-sidebar &--no-wrap.ma__figure--right.ma__figure--small {
+  .no-sidebar &--no-wrap.ma__figure--right.ma__figure--small,
+  &--no-wrap.ma__figure--right.ma__figure--small.ma__dataviz,
+  &--no-wrap.ma__figure--right.ma__figure--small.ma__iframe__container {
 
     @media ($bp-small-min) {// 621~
 
@@ -304,7 +315,10 @@
 
   // NO WRAP - Medium
 
-  .no-sidebar &--no-wrap.ma__figure--right.ma__figure--medium {
+  .no-sidebar &--no-wrap.ma__figure--right.ma__figure--medium,
+  &--no-wrap.ma__figure--right.ma__figure--medium.ma__dataviz,
+  &--no-wrap.ma__figure--right.ma__figure--medium.ma__iframe__container {
+
 
     @media ($bp-small-min) {// 621~
 
@@ -320,6 +334,13 @@
 
       padding-left: 66.66%;
       padding-left: calc(100% / 3 * 2);
+    }
+  }
+
+  &--no-wrap.ma__figure--right.ma__figure--large.ma__dataviz,
+  &--no-wrap.ma__figure--right.ma__figure--large.ma__iframe__container {
+    @media ($bp-large-min) {
+      padding-left: calc(100% / 3);
     }
   }
 

--- a/packages/assets/scss/01-atoms/_figure.scss
+++ b/packages/assets/scss/01-atoms/_figure.scss
@@ -245,10 +245,8 @@
     }
 
     @media ($bp-large-min) {
-      //&:not(.ma__dataviz):not(.ma__iframe__container) {
-        width: 66.66%;
-        width: calc(100% / 3 * 2);
-     // }
+      width: 66.66%;
+      width: calc(100% / 3 * 2);
     }
   }
 
@@ -339,6 +337,7 @@
 
   &--no-wrap.ma__figure--right.ma__figure--large.ma__dataviz,
   &--no-wrap.ma__figure--right.ma__figure--large.ma__iframe__container {
+    
     @media ($bp-large-min) {
       padding-left: calc(100% / 3);
     }

--- a/packages/assets/scss/01-atoms/_figure.scss
+++ b/packages/assets/scss/01-atoms/_figure.scss
@@ -160,17 +160,6 @@
     }
   }
 
-  @media ($bp-large-min) {// 910<
-
-    .page-content:not(.no-sidebar) &--x-small,
-    .page-content:not(.no-sidebar) &--small {
-
-      &:not(.ma__dataviz):not(.ma__iframe__container) {
-        width: calc(50% - 15px);
-      }
-    }
-  }
-
   @media ($bp-large-min) and ($bp-large-extended) {// 911-1050
 
     .page-content:not(.no-sidebar) &--small {
@@ -319,7 +308,7 @@
 
 
     @media ($bp-small-min) {// 621~
-
+      width: 100%;
       padding-left: 50%;
     }
   }
@@ -337,7 +326,7 @@
 
   &--no-wrap.ma__figure--right.ma__figure--large.ma__dataviz,
   &--no-wrap.ma__figure--right.ma__figure--large.ma__iframe__container {
-    
+
     @media ($bp-large-min) {
       padding-left: calc(100% / 3);
     }

--- a/packages/assets/scss/03-organisms/_rich-text.scss
+++ b/packages/assets/scss/03-organisms/_rich-text.scss
@@ -26,7 +26,14 @@ $heading-indent: $gutter;
   .main-content--full .page-content > &__container,
   .main-content--full .page-content > & {
 
+    // By default richt text have a right padding, unless a .no-sidebar class is added to the section container.
     @include ma-container('restricted');
+  }
+
+  .main-content--full .no-sidebar .page-content > & {
+    
+    // Use the .no-sidebar class to overide the right padding.
+    @include ma-container();
   }
 
   .ma__split-columns__column > &__container,
@@ -39,11 +46,6 @@ $heading-indent: $gutter;
 
   .ma__comp-heading + & {
     margin-top: 0;
-  }
-  
-  .main-content--full .no-sidebar .page-content > & {
-
-    @include ma-container();
   }
 
   .page-content.ma__announcement__page-content &__container & {

--- a/packages/assets/scss/03-organisms/_rich-text.scss
+++ b/packages/assets/scss/03-organisms/_rich-text.scss
@@ -40,7 +40,12 @@ $heading-indent: $gutter;
   .ma__comp-heading + & {
     margin-top: 0;
   }
- 
+  
+  .main-content--full .no-sidebar .page-content > & {
+
+    @include ma-container();
+  }
+
   .page-content.ma__announcement__page-content &__container & {
 
     @include ma-component-spacing;

--- a/packages/assets/scss/03-organisms/_rich-text.scss
+++ b/packages/assets/scss/03-organisms/_rich-text.scss
@@ -40,7 +40,7 @@ $heading-indent: $gutter;
   .ma__comp-heading + & {
     margin-top: 0;
   }
-
+ 
   .page-content.ma__announcement__page-content &__container & {
 
     @include ma-component-spacing;

--- a/packages/patternlab/styleguide/source/_patterns/03-organisms/by-author/stacked-row-section.md
+++ b/packages/patternlab/styleguide/source/_patterns/03-organisms/by-author/stacked-row-section.md
@@ -7,7 +7,7 @@ This is a row of content used in the Stacked Row Template
 
 ### Pattern Contains
 * Comp Heading
-* Any pattern can be rendered in the Page Content and Right Rail sections by setting the 'path' variable to the location of the pattern and setting the 'data' variable to container the data object of that pattern.  
+* Any pattern can be rendered in the Page Content and Right Rail sections by setting the 'path' variable to the location of the pattern and setting the 'data' variable to container the data object of that pattern.
   * {% include content.path with content.data %}
   * {% include sidebar.path with sidebar.data %}
 
@@ -17,25 +17,28 @@ This is a row of content used in the Stacked Row Template
 ### Usage Guidelines
 * The ID value is used as an anchor tag when the Jump Links pattern is added as a table of contents (see guide pages)
 * Set `borderless` to true to remove the top border when there are multiple stacked rows.
+* Set any extra class to be included on the section wrapper using `modifier`.
 
 ### Variables
 ~~~
 stackedRowSection: {
-  borderless: 
+  borderless:
     type: boolean / optional (defaults to false),
   title:
     type: string / optional,
-  id: 
+  id:
     type: string (unique per page) / optional
+  modifier:
+    type: string / optional
   pageContent: [{
-    path: 
+    path:
       type: string / required,
     data: {
       type: object / required
     }
   }],
   sideBar: (optional) [{
-    path: 
+    path:
       type: string / required,
     data: {
       type: object / required

--- a/packages/patternlab/styleguide/source/_patterns/03-organisms/by-author/stacked-row-section.twig
+++ b/packages/patternlab/styleguide/source/_patterns/03-organisms/by-author/stacked-row-section.twig
@@ -1,6 +1,6 @@
 {% set stackedRowRestriction = stackedRowSection.sideBar|length ? '' : ' ma__stacked-row--restricted' %}
 {% set stackedRowBorderless = stackedRow.borderless ? ' ma__stacked-row__section--borderless' : ''  %}
-
+{% set stackedRowModifier = stackedRow.modifier ? ' ' ~ stackedRow.modifier : ''  %}
 {# Allow overriding the content container classes as needed. #}
 {% if externalSidebar is defined and externalSidebar == true %}
   {% set mainContentClass = '' %}
@@ -8,7 +8,7 @@
   {% set mainContentClass = stackedRowSection.sideBar|length ? ' main-content--two' : ' main-content--full' %}
 {% endif %}
 
-<section class="ma__stacked-row__section {{ stackedRowBorderless }}{{ stackedRowRestriction }}">
+<section class="ma__stacked-row__section {{ stackedRowBorderless }}{{ stackedRowRestriction }}{{ stackedRowModifier }}">
   {% block stackRowTitle %}
     {% if stackedRowSection.title %}
       <div class="ma__stacked-row__container">


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/develop/docs/for-developers/changelog-instructions.md)


## Description
Adds a new `modifier` variable to `stacked-row-section` to where OpenMass is passing `no-sidebar`. This makes rich text to use a regular ma-container (instead of "restricted")

## Related Issue / Ticket

- [JIRA issue](https://massgov.atlassian.net/browse/DP-22982)


## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1.

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

*

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
