### PR TITLE
Pattenrlab/ Key message fix halfImage check

### DIFF
--- a/changelogs/DP-24018.yml
+++ b/changelogs/DP-24018.yml
@@ -51,7 +51,7 @@
 #    impact: Enter a valid impact, e.g. Minor
 
 #___EXAMPLE___
-Changed:
+Fixed:
   - project: Patternlab
     component: KeyMessage
     description: Fix the halfImage check that result in overlapping content on promo page. (#1588) 

--- a/changelogs/DP-24018.yml
+++ b/changelogs/DP-24018.yml
@@ -1,0 +1,59 @@
+# Every PR must have a changelog. To create a changelog:
+# 1. Make a copy of this file and name it with the ticket number.
+# 2. Keep the original format of one of the examples at the bottom, and override each element of it using ___TEMPLATE___ for reference
+# 3. Remove all comments from the copied file
+
+#___CHANGE TYPES___
+# - Added for new features.
+# - Changed for changes in existing functionality.
+# - Deprecated for soon-to-be removed features.
+# - Removed for now removed features.
+# - Fixed for any bug fixes.
+# - Security in case of vulnerabilities.
+# e.g. Added
+
+#___PROJECT___
+# - Patternlab
+# - React
+# - Docs
+# e.g. React
+# e.g. React, Patternlab
+
+#___COMPONENT___
+# Component name(s) in `PascalCase`
+# e.g. Header
+# e.g. Form, InputSlider, InputTextTypeAhead
+
+#___DESCRIPTION___
+# PR description and PR number (append PR number with # to create a link to the PR in Github)
+# If you need multiple lines, start the first line with the following "|-" characters.
+# For any breaking changes, add a comment in the PR describing the necessary changes on the consumer side and link that comment in the description.
+#e.g. Adds apples to apple trees for admin apple pickers (#PR)
+
+#___ISSUE___
+# A Jira ticket or a Github issue number (append Github issue number with # to create a link to the issue in Github)
+# e.g. DP-12345 or #123
+
+#___IMPACT___
+# - Major impact when you make incompatible API changes,
+# - Minor impact when you add functionality in a backwards compatible manner, and
+# - Patch impact when you make backwards compatible bug fixes.
+# e.g. Minor
+# See https://semver.org/ for more info.
+
+
+#___TEMPLATE___
+# ChangeType [enter a valid option, see __CHANGE TYPES___ e.g. Added]:
+#  - project: Enter one or multiple (comma separated) valid project prefix(es) - see ___PROJECT___ e.g. React, Patternlab
+#    component: Enter one or multiple (comma separated) valid component name(s) - see ___COMPONENT___ e.g. Color
+#    description: Describe the change and add the PR number. see ___DESCRIPTION___ e.g. Adds apples to apple trees for admin apple pickers (#PR)
+#    issue: Add a Jira ticket or issue number, e.g. DP-12345 or 124
+#    impact: Enter a valid impact, e.g. Minor
+
+#___EXAMPLE___
+Changed:
+  - project: Patternlab
+    component: KeyMessage
+    description: Fix the halfImage check that result in overlapping content on promo page. (#1588) 
+    issue: DP-24018
+    impact: Patch

--- a/packages/patternlab/styleguide/source/_patterns/03-organisms/by-template/key-message.md
+++ b/packages/patternlab/styleguide/source/_patterns/03-organisms/by-template/key-message.md
@@ -24,6 +24,9 @@ keyMessage: {
   bgImage: 
     type: url / optional
     description: Url to an image for the background.
+  halfImage: 
+    type: boolean / optional
+    description: set the banner background to half the regular height. Defaults to false. 
   mobileBgImage:
     type: url / optional
     description: Url to an image for the background on mobile screen.

--- a/packages/patternlab/styleguide/source/_patterns/03-organisms/by-template/key-message.twig
+++ b/packages/patternlab/styleguide/source/_patterns/03-organisms/by-template/key-message.twig
@@ -40,9 +40,6 @@
   var blckid = "blck{{ id }}";
   var halfImage = `{{ keyMessage.halfImage }}` // this returns '1' for true, '' or '0' for false or undefined. 
 
-  console.log(halfImage)
-  console.log(typeof halfImage)
-
   function marginSet() {
     var block = document.getElementById(blckid);
     var mainContent = document.getElementById("main-content");

--- a/packages/patternlab/styleguide/source/_patterns/03-organisms/by-template/key-message.twig
+++ b/packages/patternlab/styleguide/source/_patterns/03-organisms/by-template/key-message.twig
@@ -38,7 +38,10 @@
 
   var id = "{{ id }}";
   var blckid = "blck{{ id }}";
-  var halfImage = `{{ keyMessage.halfImage }}`
+  var halfImage = `{{ keyMessage.halfImage }}` // this returns '1' for true, '' or '0' for false or undefined. 
+
+  console.log(halfImage)
+  console.log(typeof halfImage)
 
   function marginSet() {
     var block = document.getElementById(blckid);

--- a/packages/patternlab/styleguide/source/_patterns/03-organisms/by-template/key-message.twig
+++ b/packages/patternlab/styleguide/source/_patterns/03-organisms/by-template/key-message.twig
@@ -52,7 +52,7 @@
     // The block is usually bigger than its wrapper.
     // The block is usually moved a few pixels from top.
     // separationAtBottom is the distance from the content below the key message.
-    if (halfImage) {
+    if (halfImage && halfImage !== '0') {
       var sectionHeight = keyMessageSection ? keyMessageSection.clientHeight : 0;
       const blockBottomOffset = blockHeight + block.parentNode.offsetTop
       const isBlockBottomLower = blockBottomOffset > sectionHeight;
@@ -76,6 +76,7 @@
     marginSet();
   };
   window.addEventListener("resize", marginSet);
+
 </script>
 {% endif %}
 


### PR DESCRIPTION
Fixed:
  - project: Patternlab
    component: KeyMessage
    description: Fix the halfImage check that result in overlapping content on promo page. (#1588) 
    issue: DP-24018
    impact: Patch

Locally, the halfImage value returns "", but on mass.gov/respectfully, it returns "0", which in turn breaks the margin. 
<img width="530" alt="Screen Shot 2022-02-03 at 1 36 17 PM" src="https://user-images.githubusercontent.com/5789411/152407296-c105404a-123c-4eb2-a142-ca61e7bd4975.png">

