### PR TITLE
DP-9177 a11y rules of court header

### DIFF
--- a/changelogs/DP-9177.yml
+++ b/changelogs/DP-9177.yml
@@ -1,6 +1,12 @@
 Changed:
   - project: Patternlab
     component: PageHeader
-    description: Semantically set up page category info. (#)
+    description: Semantically set up page category info. (#1617)
+    issue: DP-9177
+    impact: Patch
+
+  - project: Patternlab
+    component: RulesOfCourt
+    description: Add contextual info to comp headings. (#1617)
     issue: DP-9177
     impact: Patch

--- a/changelogs/DP-9177.yml
+++ b/changelogs/DP-9177.yml
@@ -1,0 +1,6 @@
+Changed:
+  - project: Patternlab
+    component: PageHeader
+    description: Semantically set up page category info. (#)
+    issue: DP-9177
+    impact: Patch

--- a/packages/assets/scss/03-organisms/_page-header.scss
+++ b/packages/assets/scss/03-organisms/_page-header.scss
@@ -130,6 +130,21 @@ $page-header-widget-width: 350px;
     text-transform: uppercase;
   }
 
+  &__subCategory {
+    padding-bottom: 15px;
+    color: $c-font-base;
+
+    @include ma-heading(3);
+
+    @include ma-comp-heading($c-primary-alt);
+
+    @include ma-border-decorative;
+
+    &:after {
+      width: 1.85em; // ma-underline-decorative override
+    }
+  }
+
   &__title {
     margin-bottom: .4em;
 

--- a/packages/patternlab/styleguide/source/_patterns/03-organisms/by-template/page-header.twig
+++ b/packages/patternlab/styleguide/source/_patterns/03-organisms/by-template/page-header.twig
@@ -50,26 +50,31 @@
       </div>
     {% endif %}
     {% if pageHeader.category %}
-      <div class="ma__page-header__category">
-        {{ pageHeader.category }}
+      <div id="page-category" aria-hidden="true">
+        <div class="ma__page-header__category">
+          <span class="visually-hidden">This page is under the category of </span>
+          {{ pageHeader.category }}
+        </div>
+      {% if pageHeader.subCategory %}
+        <div class="ma__page-header__subCategory">
+          <span class="visually-hidden">the sub category of </span>
+          {{ pageHeader.subCategory.title }}
+        </div>
+      {% endif %}
       </div>
     {% endif %}
 
-    {% if pageHeader.subCategory %}
-      <div class="ma__page-header__subCategory">
-        {% set subCategoryLevel = pageHeader.subCategory.level ?: 3 %}
-        {% set compHeading = pageHeader.subCategory|merge({'level':(subCategoryLevel)}) %}
-        {% include "@atoms/04-headings/comp-heading.twig" %}
-      </div>
-    {% endif %}
     {% if pageHeader.nested %}
-        <h1 class="ma__page-header__title">{% if prefix %}<span class="visually-hidden">{{ prefix }}&nbsp;</span>{% endif %}{{pageHeader.title}}
+      <h1 class="ma__page-header__title" {% if pageHeader.category %}aria-describedby="page-category"{% endif %}>
+	      {{pageHeader.title}}
+
         {% if pageHeader.subTitle %}
           <div class="ma__page-header__sub-title">{{pageHeader.subTitle}}</div>
         {% endif %}
         </h1>
     {% else %}
-      <h1 class="ma__page-header__title">{% if prefix %}<span class="visually-hidden">{{ prefix }}&nbsp;</span>{% endif %}{{pageHeader.title}}
+      <h1 class="ma__page-header__title" {% if pageHeader.category %}aria-describedby="page-category"{% endif %}>
+        {{pageHeader.title}}
       </h1>
       {% if pageHeader.subTitle %}
         <div class="ma__page-header__sub-title">{{pageHeader.subTitle}}</div>

--- a/packages/patternlab/styleguide/source/_patterns/05-pages/rules-of-court.json
+++ b/packages/patternlab/styleguide/source/_patterns/05-pages/rules-of-court.json
@@ -210,6 +210,7 @@
     "formDownloads": {
       "compHeading": {
         "title": "Downloads",
+        "titleContext": "for The Name of a Court Rule",
         "sub": false,
         "color": "",
         "id": "downloads",
@@ -264,6 +265,7 @@
       "viewSpecific": false,
       "compHeading": {
         "title": "Contact",
+        "titleContext": "for The Name of a Court Rule",
         "sub": false,
         "color": "",
         "id": "contact",
@@ -399,6 +401,7 @@
       "viewSpecific": true,
       "compHeading": {
         "title": "Contact",
+        "titleContext": "for The Name of a Court Rule",
         "sub": false,
         "color": "",
         "id": "",
@@ -436,7 +439,8 @@
     },
     "pressListing": {
       "sidebarHeading": {
-        "title": "Related"
+        "title": "Related",
+        "titleContext": "to The Name of a Court Rule"
       },
       "items": [
         {
@@ -479,7 +483,8 @@
     },
     "eventListing": {
       "sidebarHeading": {
-        "title": "Events"
+        "title": "Events",
+        "titleContext": "for The Name of a Court Rule"
       },
       "events": [
         {


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/develop/docs/for-developers/changelog-instructions.md)


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
- Restructure the page category info. 
       - Remove `h3` from the sub category.
       - Add contextual info to the category and sub category for screen reader users.
       - Set up an association between the page title and the category info.
- Enable screen reader users to get the page category info when the page title gets announced.


## Related Issue / Ticket

- [JIRA issue](https://massgov.atlassian.net/browse/DP-9177)
- [Github issue](https://github.com/massgov/openmass/pull/1452/)

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Go to https://mayflower.digital.mass.gov/patternlab/b/patternlab/DP-9177_a11y-rules-of-court-header/?p=pages-rules-of-court.
2. Inspect the markup of the page header.
     - The page category info is wrapped by `div#page-category`.
     - `div#page-category` has `aria-hidden="true"` to avoid getting announced repeatedly as screen reader users going through the header area.
     - `div.ma__page-header__category` has the contextual info "This page is under the category of " as visually hidden text.
     - `div.ma__page-header__subCategory` has the contextual info "the sub category of" as visually hidden text.
     - `H1` has `aria-describedby="page-category"` to associate the page title with the category info.  It lets screen readers announce the category info when the page title is announced.
```
<section class="ma__page-header ma__page-header--has-optional-content">
  <div class="ma__page-header__content">
    <div id="page-category" aria-hidden="true">
      <div class="ma__page-header__category">
        <span class="visually-hidden">This page is under the category of </span>
        Rule of Court Sample Page
      </div>
      <div class="ma__page-header__subCategory">
        <span class="visually-hidden">the sub category of </span>
        Rule of Court Optional Sub-category
      </div>
    </div>

    <h1 class="ma__page-header__title" aria-describedby="page-category">The Name of a Court Rule</h1>
  </div>
</section>
```
3. Check the sub category's visual matches its prod. version.
3. [optional] Browse the header area with a screen reader and find the page category info gets announced with the page title.

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

*

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
