### PR TITLE
DP-24976 remove heading style for figure title

### DIFF
--- a/changelogs/DP-24976.yml
+++ b/changelogs/DP-24976.yml
@@ -1,0 +1,6 @@
+Fixed:
+  - project: Assets
+    component: Figure
+    description: Remove figure title style override. (#1638)
+    issue: DP-24976
+    impact: Patch

--- a/packages/assets/scss/01-atoms/_figure.scss
+++ b/packages/assets/scss/01-atoms/_figure.scss
@@ -101,11 +101,6 @@ $figures-gutter: 20px;
     width: 100%;
   }
 
-  &__title {
-
-    @include ma-h2;
-  }
-
   &__caption {
     font-size: $fonts-smaller;
     font-style: italic;


### PR DESCRIPTION
figure title is all styled as H2, resulting in the H2 section heading and H3 CSV title looking visually the same. 

Fixed:
  - project: Assets
    component: Figure
    description: Remove figure title style override. (#1638)
    issue: DP-24976
    impact: Patch


Before:
<img width="868" alt="Screen Shot 2022-06-03 at 2 32 02 PM" src="https://user-images.githubusercontent.com/5789411/171925148-6b816f74-356f-493b-b83d-5cbb5ba054db.png">


After:
<img width="868" alt="Screen Shot 2022-06-03 at 2 26 39 PM" src="https://user-images.githubusercontent.com/5789411/171924830-ad7d07ee-a554-4e8d-bcfe-8009bf4677bf.png">
