### PR TITLE
[React] Tabs ssr bug

### DIFF
--- a/packages/assets/build/scss/tabs.scss
+++ b/packages/assets/build/scss/tabs.scss
@@ -1,0 +1,1 @@
+@use '03-organisms/tab-container';

--- a/packages/react/src/components/organisms/TabContainer/index.js
+++ b/packages/react/src/components/organisms/TabContainer/index.js
@@ -79,10 +79,14 @@ class TabContainer extends React.Component {
       const newProps = {
         active: this.state.activeTab === this.state.tabIds.get(index),
         tabIdent: this.state.tabIds.get(index),
-        tabRef: this.state.tabRefs[this.state.tabIds.get(index)]
+        tabRef: this.state.tabRefs[this.state.tabIds.get(index)],
+        tabBodyRef: this.tabBodyRef
       };
       return React.cloneElement(child, newProps, child.props.children);
     });
+
+    // console.log(this.state)
+    console.log(this.tabBodyRef)
     return(
       <TabContext.Provider value={this.state}>
         <div className={classes}>

--- a/packages/react/src/components/organisms/TabContainer/tab-body.js
+++ b/packages/react/src/components/organisms/TabContainer/tab-body.js
@@ -5,12 +5,16 @@ import { Portal } from 'react-portal/es';
 class TabBody extends React.Component {
   constructor(props) {
     super(props);
+    // console.log(props)
     this.state = {
-      nodeList: []
+      nodeList: [this.props.tabBodyRef.current] || []
     };
+    // console.log('set state: ' + global.MutationObserver)
     if (global.MutationObserver) {
       this.observer = new MutationObserver((mutations) => {
         const tabContainer = document.getElementById(this.props.tabContainerBodyId);
+        console.log('mutated!!!!')
+        console.log(mutations)
         mutations.forEach((mutation) => {
           if (!mutation.target) {
             return;
@@ -23,15 +27,19 @@ class TabBody extends React.Component {
         });
       });
     }
+    this.observer.observe(document, { attributes: true, childList: true, subtree: true });
   }
 
   componentDidMount() {
     const nodeList = document.getElementById(this.props.tabContainerBodyId);
     if (nodeList) {
+      console.log('rendered!!!!!')
       // eslint-disable-next-line react/no-did-mount-set-state
       this.setState({ nodeList: [nodeList] });
     }
+    // console.log('did mount: ' + global.MutationObserver)
     if (global.MutationObserver) {
+      console.log('mounted!!!!!')
       this.observer.observe(document, { attributes: true, childList: true, subtree: true });
     }
   }
@@ -43,7 +51,9 @@ class TabBody extends React.Component {
   }
 
   render() {
-    if (this.state.nodeList.length > 0 && this.props.active) {
+    // console.log('state: ' +this.state.nodeList)
+    console.log(this.props.tabBodyRef.current)
+    if (Array.isArray(this.state.nodeList) && this.state.nodeList.length > 0 && this.props.active) {
       return(
         <Portal node={this.state.nodeList[0]}>
           {this.props.children}

--- a/packages/react/src/components/organisms/TabContainer/tab.js
+++ b/packages/react/src/components/organisms/TabContainer/tab.js
@@ -60,7 +60,7 @@ class Tab extends React.Component {
 
   render() {
     const { tabIdent, active, tabRef } = this.props;
-    const { setActiveTab, activeTab } = this.context;
+    const { setActiveTab, activeTab, tabBodyRef, tabContainerBodyId } = this.context;
     const tabClasses = classNames({
       'ma__tab-title': true,
       'ma__tab-title--active': active
@@ -79,7 +79,7 @@ class Tab extends React.Component {
       onKeyDown: this.handleKeyDown,
       id: tabIdent,
       'aria-selected': active,
-      'aria-controls': this.context.tabContainerBodyId,
+      'aria-controls': tabContainerBodyId,
       role: 'tab',
       ref: tabRef,
       tabIndex: active ? 0 : -1
@@ -90,7 +90,7 @@ class Tab extends React.Component {
           <button type="button" {...buttonProps}>{this.props.title}</button>
         </li>
         {global.window && (
-          <TabBody active={activeTab === tabIdent} tabContainerBodyId={this.context.tabContainerBodyId}>
+          <TabBody active={activeTab === tabIdent} tabContainerBodyId={tabContainerBodyId} tabBodyRef={tabBodyRef}>
             {this.props.children}
           </TabBody>
         )}


### PR DESCRIPTION
There's an issue when server-side rendering the Tab component in Mayflower react.

In Gatsby build (SSR) -  
![tabs-ssr-bug](https://user-images.githubusercontent.com/5789411/188222916-6bdb4dd6-85bf-484a-a988-93212da7aed0.gif)

When the page is refreshed, the tabs are not showing any content. 

This is because, in `TabBody` `ComponentDidMount`, it's using document.getElementById to get elements that are not yet rendered in DOM. When server-side rendered, the state was never set when the component was initially mounted. Subsequent changes to the DOM makes the tabs content show up, because it was using `MutationObserver` to track the changes and set the state. 

I have set up a testing repo to demonstrate the issue and to enable a better debugging environment linking to local Mayflower for SSR. 

https://github.com/clairesunstudio/mayflower-ssr-tabs

You can see on initial load, the "rendered" log was never triggered:
<img width="1770" alt="Screen Shot 2022-09-02 at 2 27 52 PM" src="https://user-images.githubusercontent.com/5789411/188223203-f8afe117-a449-4787-889a-91b520627d4c.png">

But when you alter a component on the page, the Tab component re-renders with the content.
<img width="1144" alt="Screen Shot 2022-09-02 at 2 04 40 PM" src="https://user-images.githubusercontent.com/5789411/188223995-79032e0f-b7f3-4ae9-8f71-ffb124080d06.png">

So the issue lies with the setState in componentDidMount life cycle in SSR


Related MF PR:
https://github.com/EOANF/budget/pull/306/files

