### PR TITLE
DP-26366: Make the title customizable on the `ResultsHeading` component.

### DIFF
--- a/changelogs/DP-26366.yml
+++ b/changelogs/DP-26366.yml
@@ -76,7 +76,7 @@ Added:
 
   - project: React
     component: ResultsHeading
-    description: Make the title customizable. (#1699)
+    description: Make the title customizable, let the caller hide it completely. (#1699)
     issue: DP-26366
     impact: Minor
 

--- a/changelogs/DP-26366.yml
+++ b/changelogs/DP-26366.yml
@@ -74,6 +74,12 @@ Added:
     issue: DP-26366
     impact: Minor
 
+  - project: React
+    component: ResultsHeading
+    description: Make the title customizable. (#1699)
+    issue: DP-26366
+    impact: Minor
+
 Changed:
   - project: React, Site
     component: Address, Email, EventTime, PhoneNumber, GenTeaser, RichText

--- a/packages/react/src/components/molecules/ResultsHeading/index.js
+++ b/packages/react/src/components/molecules/ResultsHeading/index.js
@@ -19,11 +19,11 @@ import Tags from 'MayflowerReactMolecules/Tags';
 
 function getTitle(resultsHeading) {
   if (resultsHeading.title !== undefined) {
-    return resultsHeading.title
+    return resultsHeading.title;
   }
 
   const resultsHeadingTotal = resultsHeading.totalResults ? ` of ${resultsHeading.totalResults} for: ` : '';
-  return `Showing results ${resultsHeading.numResults}${resultsHeadingTotal}`;
+  return`Showing results ${resultsHeading.numResults}${resultsHeadingTotal}`;
 }
 
 const ResultsHeading = (resultsHeading) => {
@@ -31,7 +31,7 @@ const ResultsHeading = (resultsHeading) => {
     'ma__results-heading js-results-heading',
     resultsHeading.className
   );
-  const title = getTitle(resultsHeading)
+  const title = getTitle(resultsHeading);
   const { tags } = resultsHeading;
   const selectBoxProps = resultsHeading.selectBox;
   const buttonToggleProps = resultsHeading.buttonToggle;
@@ -66,7 +66,7 @@ ResultsHeading.propTypes = {
   numResults: PropTypes.string,
   /** The total count of results */
   totalResults: PropTypes.string,
-  /** The title to display instead the auto-generated one.*/
+  /** The title to display instead the auto-generated one. */
   title: PropTypes.string,
   /** The sort input type as ButtonToggle */
   buttonToggle: PropTypes.shape(ButtonToggle.propTypes),

--- a/packages/react/src/components/molecules/ResultsHeading/index.js
+++ b/packages/react/src/components/molecules/ResultsHeading/index.js
@@ -17,13 +17,21 @@ import ButtonToggle from 'MayflowerReactButtons/ButtonToggle';
 import SelectBox from 'MayflowerReactForms/SelectBox';
 import Tags from 'MayflowerReactMolecules/Tags';
 
+function getTitle(resultsHeading) {
+  if (resultsHeading.title !== undefined) {
+    return resultsHeading.title
+  }
+
+  const resultsHeadingTotal = resultsHeading.totalResults ? ` of ${resultsHeading.totalResults} for: ` : '';
+  return `Showing results ${resultsHeading.numResults}${resultsHeadingTotal}`;
+}
+
 const ResultsHeading = (resultsHeading) => {
   const classes = classNames(
     'ma__results-heading js-results-heading',
     resultsHeading.className
   );
-  const resultsHeadingTotal = resultsHeading.totalResults ? ` of ${resultsHeading.totalResults} for: ` : '';
-  const resultsHeadingTitle = `Showing results ${resultsHeading.numResults}${resultsHeadingTotal}`;
+  const title = getTitle(resultsHeading)
   const { tags } = resultsHeading;
   const selectBoxProps = resultsHeading.selectBox;
   const buttonToggleProps = resultsHeading.buttonToggle;
@@ -31,7 +39,7 @@ const ResultsHeading = (resultsHeading) => {
     <div className={classes}>
       <div className="ma__results-heading__container">
         <div className="ma__results-heading__title">
-          {resultsHeadingTitle}
+          {title}
         </div>
         {tags && (
           <Tags {...tags} />
@@ -58,6 +66,8 @@ ResultsHeading.propTypes = {
   numResults: PropTypes.string,
   /** The total count of results */
   totalResults: PropTypes.string,
+  /** The title to display instead the auto-generated one.*/
+  title: PropTypes.string,
   /** The sort input type as ButtonToggle */
   buttonToggle: PropTypes.shape(ButtonToggle.propTypes),
   /** The sort input type as SelectBox */

--- a/packages/react/src/components/molecules/ResultsHeading/index.js
+++ b/packages/react/src/components/molecules/ResultsHeading/index.js
@@ -18,6 +18,7 @@ import SelectBox from 'MayflowerReactForms/SelectBox';
 import Tags from 'MayflowerReactMolecules/Tags';
 
 function getTitle(resultsHeading) {
+  // Check for `undefined` specifically to let the caller hide the title completely with an empty string.
   if (resultsHeading.title !== undefined) {
     return resultsHeading.title;
   }
@@ -38,9 +39,11 @@ const ResultsHeading = (resultsHeading) => {
   return(
     <div className={classes}>
       <div className="ma__results-heading__container">
-        <div className="ma__results-heading__title">
-          {title}
-        </div>
+        { title && (
+          <div className="ma__results-heading__title">
+            {title}
+          </div>
+        )}
         {tags && (
           <Tags {...tags} />
         )}
@@ -66,7 +69,7 @@ ResultsHeading.propTypes = {
   numResults: PropTypes.string,
   /** The total count of results */
   totalResults: PropTypes.string,
-  /** The title to display instead the auto-generated one. */
+  /** The title to display instead the auto-generated one. Pass empty string to hide the title element completely. */
   title: PropTypes.string,
   /** The sort input type as ButtonToggle */
   buttonToggle: PropTypes.shape(ButtonToggle.propTypes),


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/develop/docs/for-developers/changelog-instructions.md)

## Description
The title could be more flexible. The default one doesn't work well for our case, e.g. it adds the ` for:` suffix even without any tags.

## Related Issue / Ticket

- [JIRA issue](https://massgov.atlassian.net/browse/DP-26366)

