### PR TITLE
Docs/formstack theme fix date picker

### DIFF
--- a/changelogs/DP-26811.yml
+++ b/changelogs/DP-26811.yml
@@ -4,3 +4,9 @@ Changed:
     description: Update Mayflower theme. (#1720)
     issue: DP-26811
     impact: Patch
+Fixed:
+  - project: Starters
+    component: Formstack
+    description: Fix date picker. (#1725)
+    issue: DP-26811
+    impact: Patch

--- a/packages/starters/formstack/mayflower-theme.css
+++ b/packages/starters/formstack/mayflower-theme.css
@@ -377,12 +377,17 @@ div[fs-field-type="datetime"] .fieldset-content:after {
 /* but lift it one z level so it's still clickable */  
 .fsBody .ui-datepicker-trigger {
     position: absolute;
-    top: 0;
-    margin-left: 0;
+    top: 13px;
+    margin-left: 11px;
     height: 42px;
     opacity: 0;
     cursor: pointer;
     z-index: 1;
+}
+
+.fsBody .always-ltr {
+    position: absolute;
+    opacity: 0;
 }
 
 .fsCurrency.fsCurrencyPrefix {

--- a/packages/starters/formstack/mayflower-theme.css
+++ b/packages/starters/formstack/mayflower-theme.css
@@ -384,10 +384,9 @@ div[fs-field-type="datetime"] .fieldset-content:after {
     cursor: pointer;
     z-index: 1;
 }
-
+/* Hide this span that renders hidden time fields, which affects the date picker layout */  
 .fsBody .always-ltr {
-    position: absolute;
-    opacity: 0;
+    display: none !important;
 }
 
 .fsCurrency.fsCurrencyPrefix {


### PR DESCRIPTION
Before:
<img width="528" alt="Screen Shot 2023-01-11 at 9 34 40 AM" src="https://user-images.githubusercontent.com/5789411/211864853-7ef271e5-9d1f-4a1e-82f4-c24d8e804bd0.png">

After:
<img width="609" alt="Screen Shot 2023-01-11 at 11 41 34 AM" src="https://user-images.githubusercontent.com/5789411/211864870-01cc7d9c-dcbe-4cc1-98f6-3b06b93f974e.png">

https://massgov.formstack.com/forms/mitc_facility_access_form

The icon should be interactive and opens up a date picker. The time inputs should not be rendered. There seemed to be a change in the formstack template `.always-ltr` that's throwing off the layout. Hide this span that renders hidden time fields, which affects the date picker layout and adjust the overlaying position of the icons fixed the issue