### PR TITLE
DP-25865: Switch CircleCI to use OIDC for AWS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,7 +228,7 @@ jobs:
       - when:
           condition:
             matches:
-              pattern: "^[0-9]+\.[0-9]+\.[0-9]+$"
+              pattern: '^[0-9]+\.[0-9]+\.[0-9]+$'
               value: << pipeline.git.tag >>
           steps:
             - aws-cli/setup:
@@ -271,7 +271,7 @@ jobs:
       - when:
           condition:
             matches:
-              pattern: "^[0-9]+\.[0-9]+\.[0-9]+$"
+              pattern: '^[0-9]+\.[0-9]+\.[0-9]+$'
               value: << pipeline.git.tag >>
           steps:
             - aws-cli/setup:
@@ -395,7 +395,7 @@ jobs:
       - when:
           condition:
             matches:
-              pattern: "^[0-9]+\.[0-9]+\.[0-9]+$"
+              pattern: '^[0-9]+\.[0-9]+\.[0-9]+$'
               value: << pipeline.git.tag >>
           steps:
             - aws-cli/setup:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,12 +87,8 @@ jobs:
       - *no_host_check
       - add_ssh_keys
       - *configure_git
-      - run:
-          name: 'Install AWS'
-          command: |
-            curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-            unzip awscliv2.zip
-            sudo ./aws/install
+      - aws-cli/setup:
+          role-arn: $AWS_DEPLOYMENT_ROLE_ARN
       - run:
           name: 'Deploy Artifact Branch'
           command: |
@@ -114,7 +110,7 @@ jobs:
             fi
       - run:
           name: 'Deploy S3 Branch'
-          command: aws s3 sync packages/patternlab/styleguide/public "s3://mayflower.digital.mass.gov/patternlab/b/$CIRCLE_BRANCH"
+          command: aws s3 sync packages/patternlab/styleguide/public "s3://mayflower.digital.mass.gov/patternlab/b/$CIRCLE_BRANCH" --profile default
 
   patternlab_deploy_tag:
     <<: *patternlab_defaults
@@ -124,12 +120,8 @@ jobs:
       - add_ssh_keys
       - *configure_git
       - *configure_npm
-      - run:
-          name: 'Install AWS'
-          command: |
-            curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-            unzip awscliv2.zip
-            sudo ./aws/install
+      - aws-cli/setup:
+          role-arn: $AWS_DEPLOYMENT_ROLE_ARN
       - run:
           name: 'Deploy Artifact Tag'
           command: |
@@ -161,10 +153,10 @@ jobs:
       - run:
           name: 'Deploy S3 Tag'
           command: |
-            aws s3 sync packages/patternlab/styleguide/public "s3://mayflower.digital.mass.gov/patternlab/v/$CIRCLE_TAG"
+            aws s3 sync packages/patternlab/styleguide/public "s3://mayflower.digital.mass.gov/patternlab/v/$CIRCLE_TAG" --profile default
             if [[ "$CIRCLE_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
               # Use cp instead of sync for root copy.  sync lists all keys and is too slow.
-              aws s3 cp --recursive packages/patternlab/styleguide/public/ "s3://mayflower.digital.mass.gov/patternlab"
+              aws s3 cp --recursive packages/patternlab/styleguide/public/ "s3://mayflower.digital.mass.gov/patternlab" --profile default
             fi
 
   react_build_storybook:
@@ -232,19 +224,22 @@ jobs:
             else
               echo "Skipping NPM publish - $CIRCLE_TAG already exists"
             fi
-      - run: |
-          # Only sync to S3 for stable tags.
-          if [[ "$CIRCLE_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            sudo apt-get update --allow-releaseinfo-change && sudo apt-get -y -qq install awscli
-          fi
-      - run: |
-          # Only sync to S3 for stable tags.
-          if [[ "$CIRCLE_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            cd packages/react
-            aws s3 sync storybook-static s3://mayflower.digital.mass.gov/react --delete
-            aws configure set preview.cloudfront true
-            aws cloudfront create-invalidation --distribution-id $AWS_DISTRIBUTION_ID --paths '/react*'
-          fi
+      # Only sync to S3 for stable tags.
+      - when:
+          condition:
+            matches:
+              pattern: "^[0-9]+\.[0-9]+\.[0-9]+$"
+              value: << pipeline.git.tag >>
+          steps:
+            - aws-cli/setup:
+                role-arn: $AWS_DEPLOYMENT_ROLE_ARN
+            - run: |
+                cd packages/react
+                # Don't delete until new files have been copied
+                aws s3 sync storybook-static s3://mayflower.digital.mass.gov/react --profile default
+                aws s3 sync storybook-static s3://mayflower.digital.mass.gov/react --delete --profile default
+                aws configure set preview.cloudfront true --profile default
+                aws cloudfront create-invalidation --distribution-id $AWS_DISTRIBUTION_ID --paths '/react*' --profile default
 
 
   core_build_storybook:
@@ -272,27 +267,33 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/code
-      - run: |
-          # Only sync to S3 for stable tags.
-          if [[ "$CIRCLE_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            sudo apt-get update --allow-releaseinfo-change && sudo apt-get -y -qq install awscli
-            cd packages/core
-            aws s3 sync storybook-static "s3://mayflower.digital.mass.gov/core/v/$CIRCLE_TAG" --delete
-            # Use cp instead of sync for root copy.  sync lists all keys and is too slow.
-            aws s3 cp --recursive storybook-static "s3://mayflower.digital.mass.gov/core"
-            aws configure set preview.cloudfront true
-            aws cloudfront create-invalidation --distribution-id $AWS_DISTRIBUTION_ID --paths '/core*'
-          fi
+      # Only sync to S3 for stable tags.
+      - when:
+          condition:
+            matches:
+              pattern: "^[0-9]+\.[0-9]+\.[0-9]+$"
+              value: << pipeline.git.tag >>
+          steps:
+            - aws-cli/setup:
+                role-arn: $AWS_DEPLOYMENT_ROLE_ARN
+            - run: |
+                cd packages/core
+                aws s3 sync storybook-static "s3://mayflower.digital.mass.gov/core/v/$CIRCLE_TAG" --delete --profile default
+                # Use cp instead of sync for root copy.  sync lists all keys and is too slow.
+                aws s3 cp --recursive storybook-static "s3://mayflower.digital.mass.gov/core"
+                aws configure set preview.cloudfront true
+                aws cloudfront create-invalidation --distribution-id $AWS_DISTRIBUTION_ID --paths '/core*'
 
   core_deploy_branch:
     <<: *patternlab_defaults
     steps:
       - attach_workspace:
           at: ~/code
+      - aws-cli/setup:
+          role-arn: $AWS_DEPLOYMENT_ROLE_ARN
       - run: |
-          sudo apt-get update --allow-releaseinfo-change && sudo apt-get -y -qq install awscli
           cd packages/core
-          aws s3 sync storybook-static "s3://mayflower.digital.mass.gov/core/b/$CIRCLE_BRANCH" --delete
+          aws s3 sync storybook-static "s3://mayflower.digital.mass.gov/core/b/$CIRCLE_BRANCH" --delete --profile default
           aws configure set preview.cloudfront true
           aws cloudfront create-invalidation --distribution-id $AWS_DISTRIBUTION_ID --paths "/core/b*"
 
@@ -390,19 +391,20 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/code
-      - run: |
-          # Only sync to S3 for stable tags.
-          if [[ "$CIRCLE_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            sudo apt-get update --allow-releaseinfo-change && sudo apt-get -y -qq install awscli
-          fi
-      - run: |
-          # Only sync to S3 for stable tags.
-          if [[ "$CIRCLE_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            cd packages/site
-            aws s3 sync public s3://mayflower.digital.mass.gov/home --delete
-            aws configure set preview.cloudfront true
-            aws cloudfront create-invalidation --distribution-id $AWS_DISTRIBUTION_ID --paths '/home*'
-          fi
+      # Only sync to S3 for stable tags.
+      - when:
+          condition:
+            matches:
+              pattern: "^[0-9]+\.[0-9]+\.[0-9]+$"
+              value: << pipeline.git.tag >>
+          steps:
+            - aws-cli/setup:
+                role-arn: $AWS_DEPLOYMENT_ROLE_ARN
+            - run: |
+                cd packages/site
+                aws s3 sync public s3://mayflower.digital.mass.gov/home --delete
+                aws configure set preview.cloudfront true
+                aws cloudfront create-invalidation --distribution-id $AWS_DISTRIBUTION_ID --paths '/home*'
 
 workflows:
   version: 2
@@ -427,6 +429,7 @@ workflows:
           requires: [patternlab_build]
           filters:
             branches: { ignore: /(docs|react\/|site\/|core\/).*/ }
+          context: aws_oidc
       - patternlab_test:
           requires: [patternlab_build]
           filters:
@@ -454,6 +457,7 @@ workflows:
           requires: [core_build_storybook]
           filters:
             branches: { ignore: /(docs|patternlab\/|site\/|react\/).*/ }
+          context: aws_oidc
 
   ## Release branch automation every Monday at 1:00 p.m. ET "00 18 * * 1"
   ## Auto release is disabled - the new mayflower - openmass doesn't require weekly mayflower release
@@ -507,6 +511,7 @@ workflows:
           filters:
             branches: { ignore: /.*/ }
             tags: { only: /.*/ }
+          context: aws_oidc
       - react_build_storybook:
           requires: [build]
           filters:
@@ -517,6 +522,7 @@ workflows:
           filters:
             branches: { ignore: /.*/ }
             tags: { only: /.*/ }
+          context: aws_oidc
       - assets_deploy_tag:
           requires: [react_build_storybook]
           filters:
@@ -532,6 +538,7 @@ workflows:
           filters:
             branches: { ignore: /.*/ }
             tags: { only: /.*/ }
+          context: aws_oidc
       - core_build_storybook:
           requires: [build]
           filters:
@@ -542,3 +549,4 @@ workflows:
           filters:
             branches: { ignore: /.*/ }
             tags: { only: /.*/ }
+          context: aws_oidc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -238,8 +238,6 @@ jobs:
                 role-arn: $AWS_DEPLOYMENT_ROLE_ARN
             - run: |
                 cd packages/react
-                # Don't delete until new files have been copied
-                aws s3 sync storybook-static s3://mayflower.digital.mass.gov/react --profile default
                 aws s3 sync storybook-static s3://mayflower.digital.mass.gov/react --delete --profile default
                 aws configure set preview.cloudfront true --profile default
                 aws cloudfront create-invalidation --distribution-id $AWS_DISTRIBUTION_ID --paths '/react*' --profile default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,9 @@ backstop_defaults: &backstop_defaults
   docker:
     - image: cimg/node:14.15.2
 
+orbs:
+  aws-cli: circleci/aws-cli@3.1.4
+
 jobs:
   build:
     <<: *patternlab_defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -281,9 +281,9 @@ jobs:
                 cd packages/core
                 aws s3 sync storybook-static "s3://mayflower.digital.mass.gov/core/v/$CIRCLE_TAG" --delete --profile default
                 # Use cp instead of sync for root copy.  sync lists all keys and is too slow.
-                aws s3 cp --recursive storybook-static "s3://mayflower.digital.mass.gov/core"
-                aws configure set preview.cloudfront true
-                aws cloudfront create-invalidation --distribution-id $AWS_DISTRIBUTION_ID --paths '/core*'
+                aws s3 cp --recursive storybook-static "s3://mayflower.digital.mass.gov/core" --profile default
+                aws configure set preview.cloudfront true --profile default
+                aws cloudfront create-invalidation --distribution-id $AWS_DISTRIBUTION_ID --paths '/core*' --profile default
 
   core_deploy_branch:
     <<: *patternlab_defaults
@@ -295,8 +295,8 @@ jobs:
       - run: |
           cd packages/core
           aws s3 sync storybook-static "s3://mayflower.digital.mass.gov/core/b/$CIRCLE_BRANCH" --delete --profile default
-          aws configure set preview.cloudfront true
-          aws cloudfront create-invalidation --distribution-id $AWS_DISTRIBUTION_ID --paths "/core/b*"
+          aws configure set preview.cloudfront true --profile default
+          aws cloudfront create-invalidation --distribution-id $AWS_DISTRIBUTION_ID --paths "/core/b*" --profile default
 
   auto_changelog:
     <<: *react_defaults
@@ -403,9 +403,9 @@ jobs:
                 role-arn: $AWS_DEPLOYMENT_ROLE_ARN
             - run: |
                 cd packages/site
-                aws s3 sync public s3://mayflower.digital.mass.gov/home --delete
-                aws configure set preview.cloudfront true
-                aws cloudfront create-invalidation --distribution-id $AWS_DISTRIBUTION_ID --paths '/home*'
+                aws s3 sync public s3://mayflower.digital.mass.gov/home --delete --profile default
+                aws configure set preview.cloudfront true --profile default
+                aws cloudfront create-invalidation --distribution-id $AWS_DISTRIBUTION_ID --paths '/home*' --profile default
 
 workflows:
   version: 2

--- a/changelogs/DP-25865.yml
+++ b/changelogs/DP-25865.yml
@@ -1,0 +1,6 @@
+Changed:
+  - project: CircleCI
+    component: CircleCI
+    description: Switch CircleCI to use OIDC for AWS (#1732)
+    issue: DP-25865
+    impact: Patch


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/develop/docs/for-developers/changelog-instructions.md)


## Description
This PR switches from using AWS keys for deployment to OIDC. The AWS roles used in the deployment have also been restricted in terms of the CloudFront distributions they can access.

## Related Issue / Ticket

- [JIRA issue](https://massgov.atlassian.net/browse/DP-25865)

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Deploy to AWS and ensure the deployment works correctly.

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

* Once this is deployed, we can delete the AWS keys from CircleCI. We can also remove the `--profile default` from all of the AWS commands in the build, as it is only needed to override the use of the environment variables.

#### Today I learned...
- https://circleci.com/docs/openid-connect-tokens/
