### PR TITLE
Docs/dp 27044 formstack theme remove custom calendar icon

### DIFF
--- a/changelogs/DP-27044.yml
+++ b/changelogs/DP-27044.yml
@@ -1,0 +1,59 @@
+# Every PR must have a changelog. To create a changelog:
+# 1. Make a copy of this file and name it with the ticket number.
+# 2. Keep the original format of one of the examples at the bottom, and override each element of it using ___TEMPLATE___ for reference
+# 3. Remove all comments from the copied file
+
+#___CHANGE TYPES___
+# - Added for new features.
+# - Changed for changes in existing functionality.
+# - Deprecated for soon-to-be removed features.
+# - Removed for now removed features.
+# - Fixed for any bug fixes.
+# - Security in case of vulnerabilities.
+# e.g. Added
+
+#___PROJECT___
+# - Patternlab
+# - React
+# - Docs
+# e.g. React
+# e.g. React, Patternlab
+
+#___COMPONENT___
+# Component name(s) in `PascalCase`
+# e.g. Header
+# e.g. Form, InputSlider, InputTextTypeAhead
+
+#___DESCRIPTION___
+# PR description and PR number (append PR number with # to create a link to the PR in Github)
+# If you need multiple lines, start the first line with the following "|-" characters.
+# For any breaking changes, add a comment in the PR describing the necessary changes on the consumer side and link that comment in the description.
+#e.g. Adds apples to apple trees for admin apple pickers (#PR)
+
+#___ISSUE___
+# A Jira ticket or a Github issue number (append Github issue number with # to create a link to the issue in Github)
+# e.g. DP-12345 or #123
+
+#___IMPACT___
+# - Major impact when you make incompatible API changes,
+# - Minor impact when you add functionality in a backwards compatible manner, and
+# - Patch impact when you make backwards compatible bug fixes.
+# e.g. Minor
+# See https://semver.org/ for more info.
+
+
+#___TEMPLATE___
+# ChangeType [enter a valid option, see __CHANGE TYPES___ e.g. Added]:
+#  - project: Enter one or multiple (comma separated) valid project prefix(es) - see ___PROJECT___ e.g. React, Patternlab
+#    component: Enter one or multiple (comma separated) valid component name(s) - see ___COMPONENT___ e.g. Color
+#    description: Describe the change and add the PR number. see ___DESCRIPTION___ e.g. Adds apples to apple trees for admin apple pickers (#PR)
+#    issue: Add a Jira ticket or issue number, e.g. DP-12345 or 124
+#    impact: Enter a valid impact, e.g. Minor
+
+#___EXAMPLE___
+Fixed:
+  - project: Starters
+    component: Formstack
+    description: Fix mayflower theme date picker calendar icon with a helptext enter. Remove the custom icon and style the default formstack icon. (#1737)
+    issue: DP-27044
+    impact: Patch

--- a/packages/starters/formstack/mayflower-theme.css
+++ b/packages/starters/formstack/mayflower-theme.css
@@ -352,9 +352,12 @@ div[fs-field-type="checkbox"] div.fieldset-content{
 
 /* calendar icon. */
 .fsBody .fsForm .ui-datepicker-trigger {
+    position: relative;
     filter: grayscale(1);
     width: 22px;
     height: 22px !important;
+    top: 5px;
+    margin-left: 0;
 }
 
 .fsCurrency.fsCurrencyPrefix {

--- a/packages/starters/formstack/mayflower-theme.css
+++ b/packages/starters/formstack/mayflower-theme.css
@@ -350,45 +350,11 @@ div[fs-field-type="checkbox"] div.fieldset-content{
     font-family: "Noto Sans VF","Noto Sans","Helvetica","Arial",sans-serif;
 }
 
-/* For the calendar icon. */
-/* Flex collapses the width of the  parent to it's children. */
-div[fs-field-type="datetime"] fieldset {
-    display: flex;
-}
-/* Then the inner div needs relative context for the absolute icon. */
-div[fs-field-type="datetime"] .fieldset-content {
-    position: relative;
-}
-/* Position new calendar icon pseudo parent div. */
-.fsBody .fsForm .fsCalendar {
-    position: initial !important;
-    /* Garatee spacing between the date fields and the time fields . */
-    height: 10px;
-}
-/* Add the new icon at the bottom z-index. */
-.fsBody .fsForm .fsCalendar:after {
-    content: '';
-    position: absolute;
-    right: -40px;
-    top: 0;
-    display: block;
-    height: 42px;
-    width: 42px;
-    background-image: url(https://unpkg.com/@massds/mayflower@10.2.0/assets/images/icons/date-picker.svg);
-    background-position: center;
-    background-repeat: no-repeat;
-    z-index: 0;
-}
-/* Last, hide the old icon with opacity 
-/* but lift it one z level so it's still clickable */  
-.fsBody .ui-datepicker-trigger {
-    position: absolute;
-    top: 13px;
-    margin-left: 11px;
-    height: 42px;
-    opacity: 0;
-    cursor: pointer;
-    z-index: 1;
+/* calendar icon. */
+.fsBody .fsForm .ui-datepicker-trigger {
+    filter: grayscale(1);
+    width: 22px;
+    height: 22px !important;
 }
 
 .fsCurrency.fsCurrencyPrefix {


### PR DESCRIPTION
Fixed:
  - project: Starters
    component: Formstack
    description: Fix mayflower theme date picker calendar icon with a helptext enter. Remove the custom icon and style the default formstack icon. (#1737)
    issue: DP-27044
    impact: Patch


https://www.mass.gov/forms/governors-office-scheduling-requests
https://www.mass.gov/forms/hurley-and-lindemann-buildings-loading-dockcontractor-access-form