### PR TITLE
DP-26574: Allow background positioning to be added to illustrated headers

### DIFF
--- a/changelogs/DP-24477.yml
+++ b/changelogs/DP-24477.yml
@@ -1,0 +1,3 @@
+Fixed:
+  - description: Passes background positioning information to illustrated header background images
+    issue: DP-24477

--- a/changelogs/DP-24477.yml
+++ b/changelogs/DP-24477.yml
@@ -1,3 +1,0 @@
-Fixed:
-  - description: Passes background positioning information to illustrated header background images (#1750)
-    issue: DP-24477

--- a/changelogs/DP-24477.yml
+++ b/changelogs/DP-24477.yml
@@ -1,3 +1,3 @@
 Fixed:
-  - description: Passes background positioning information to illustrated header background images
+  - description: Passes background positioning information to illustrated header background images (#1750)
     issue: DP-24477

--- a/changelogs/DP-26574.yml
+++ b/changelogs/DP-26574.yml
@@ -1,0 +1,6 @@
+Fixed:
+  - project: Patternlab
+    component: IllustratedHeader
+    description: Passes background positioning information to illustrated header background images (#1750)
+    issue: DP-26574
+    impact: Patch

--- a/packages/patternlab/styleguide/source/_patterns/03-organisms/by-template/illustrated-header.twig
+++ b/packages/patternlab/styleguide/source/_patterns/03-organisms/by-template/illustrated-header.twig
@@ -38,6 +38,11 @@
         }
       }
       {% endif %}
+      {% if illustratedHeader.bgPositionX and illustratedHeader.bgPositionY %}
+      .ma__illustrated-header__image {
+        background-position: {{ illustratedHeader.bgPositionX }} {{ illustratedHeader.bgPositionY }};
+      }
+      {% endif %}
     </style>
     <div class="ma__illustrated-header__image">
     </div>


### PR DESCRIPTION
## Description
See https://github.com/massgov/openmass/pull/1920

## Related Issue / Ticket

- [JIRA issue](https://massgov.atlassian.net/browse/DP-26574)

## Steps to Test
See other PR

## Screenshots
![Screenshot from 2023-03-08 11-47-57](https://user-images.githubusercontent.com/345613/223707220-f565cf67-38cb-4785-b1bd-efd894d534a9.png)

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

* Illustrated Header
