### PR TITLE
DP-26227 [a11y] image credit

### DIFF
--- a/changelogs/DP-26227.yml
+++ b/changelogs/DP-26227.yml
@@ -1,0 +1,6 @@
+Changed:
+  - project: Patternlab
+    component: BannerCredit
+    description: Restructure image credit component for semantics. (#1751)
+    issue: DP-26227
+    impact: Patch

--- a/packages/assets/scss/02-molecules/_banner-credit.scss
+++ b/packages/assets/scss/02-molecules/_banner-credit.scss
@@ -34,6 +34,13 @@
 
 .ma__banner-credit {
 
+  .ma__banner-credit__container {
+    // reset default styles for dl
+    dt, dd {
+      margin: 0;
+    }
+  }
+
   &__icon {
 
     & > svg {

--- a/packages/patternlab/styleguide/source/_patterns/02-molecules/banner-credit.json
+++ b/packages/patternlab/styleguide/source/_patterns/02-molecules/banner-credit.json
@@ -2,6 +2,7 @@
   "bannerCredit": {
     "imageName": "Name of image",
     "imageAuthor": "Taken by Somebody",
-    "icon": ""
+    "icon": "",
+    "ariaHidden": true
   }
 }

--- a/packages/patternlab/styleguide/source/_patterns/02-molecules/banner-credit.md
+++ b/packages/patternlab/styleguide/source/_patterns/02-molecules/banner-credit.md
@@ -7,11 +7,13 @@ This pattern is used to provide credit for a banner image.
 ### Variables
 ~~~
 bannerCredit: {
-  imageName: 
+  imageName:
     type: string / required,
-  imageAuthor: 
+  imageAuthor:
     type: string / required,
   icon:
-    type: string (path to icon) / optional
+    type: string (path to icon) / optional,
+  ariaHidden:
+    type: boolean / required
 }
 ~~~

--- a/packages/patternlab/styleguide/source/_patterns/02-molecules/banner-credit.twig
+++ b/packages/patternlab/styleguide/source/_patterns/02-molecules/banner-credit.twig
@@ -1,4 +1,4 @@
-<div class="ma__banner-credit">
+<div class="ma__banner-credit" aria-hidden="true">
   <dl class="ma__banner-credit__container">
     <dt class="ma__banner-credit__icon">
       <span class="ma__visually-hidden">Credit for the banner image</span>

--- a/packages/patternlab/styleguide/source/_patterns/02-molecules/banner-credit.twig
+++ b/packages/patternlab/styleguide/source/_patterns/02-molecules/banner-credit.twig
@@ -1,4 +1,4 @@
-<div class="ma__banner-credit" aria-hidden="true">
+<div class="ma__banner-credit" {{ bannerCredit.ariaHidden ? 'aria-hidden="true"' : '' }}>
   <dl class="ma__banner-credit__container">
     <dt class="ma__banner-credit__icon">
       <span class="ma__visually-hidden">Credit for the banner image</span>

--- a/packages/patternlab/styleguide/source/_patterns/02-molecules/banner-credit.twig
+++ b/packages/patternlab/styleguide/source/_patterns/02-molecules/banner-credit.twig
@@ -1,10 +1,11 @@
 <div class="ma__banner-credit">
-  <div class="ma__banner-credit__container">
-    <div class="ma__banner-credit__icon">
+  <dl class="ma__banner-credit__container">
+    <dt class="ma__banner-credit__icon">
+      <span class="ma__visually-hidden">Credit for the banner image</span>
       {% set iconPath = bannerCredit.icon ? : "marker-outline" %}
       {{ icon(iconPath) }}
-    </div>
-    <div class="ma__banner-credit__image-name">{{ bannerCredit.imageName }}</div>
-    <div class="ma__banner-credit__image-author">{{ bannerCredit.imageAuthor }}</div>
-  </div>
+    </dt>
+    <dd class="ma__banner-credit__image-name">{{ bannerCredit.imageName }}</dd>
+    <dd class="ma__banner-credit__image-author">{{ bannerCredit.imageAuthor }}</dd>
+  </dl>
 </div>


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/develop/docs/for-developers/changelog-instructions.md)


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
- Add a title/heading for image credit to make sense for screen reader users what's the information is about.
- Restructure the image credit component to semantically make sense the component content.

## Related Issue / Ticket

- [JIRA issue](https://massgov.atlassian.net/browse/DP-26227)
- [Github issue]()

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Go to home page and check markup for the banner image credit.
2. Find:
      - `.ma__banner-credit__container` is set up as `dt`.
      - `.ma__banner-credit__icon` is set up as `dt` and it contain a title/heading "Credit for the banner image" for the image credit as visually hidden text for screen reader users.
      - `.ma__banner-credit__image-name` and `.ma__banner-credit__image-author` are set up as `dd` for above `dt`.
 3. Find no visual changes.

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

*

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
