### PR TITLE
DP-26304 [SI-a11y] Empty aira-label with decorative element

### DIFF
--- a/changelogs/DP-26304.yml
+++ b/changelogs/DP-26304.yml
@@ -1,0 +1,6 @@
+Changed:
+  - project: Patternlab
+    component: pressTeaser
+    description: Set up a condition to determine whether span with background image to be an image element or not. (#1752)
+    issue: DP-26304
+    impact: Patch

--- a/packages/patternlab/styleguide/source/_patterns/02-molecules/press-teaser.twig
+++ b/packages/patternlab/styleguide/source/_patterns/02-molecules/press-teaser.twig
@@ -5,9 +5,7 @@
     <a
       class="ma__press-teaser__image"
       href="{{ pressTeaser.title.href }}"
-    {% if pressTeaser.title.text %}
       title="{{ pressTeaser.title.text }}">
-    {% endif %}
       {% set image = pressTeaser.image %}
       <span
       {% if image.alt %}

--- a/packages/patternlab/styleguide/source/_patterns/02-molecules/press-teaser.twig
+++ b/packages/patternlab/styleguide/source/_patterns/02-molecules/press-teaser.twig
@@ -2,14 +2,16 @@
 
 <section class="ma__press-teaser {{ imageClass }}">
   {% if pressTeaser.image %}
-    <a 
+    <a
       class="ma__press-teaser__image"
-      href="{{ pressTeaser.title.href }}" 
+      href="{{ pressTeaser.title.href }}"
       title="{{ pressTeaser.title.text }}">
       {% set image = pressTeaser.image %}
-      <span 
-        aria-label="{{ image.alt }}" 
+      <span
+      {% if image.alt %}
+        aria-label="{{ image.alt }}"
         role="img"
+      {% endif %}
         style="background-image: url('{{ image.src }}')">
       </span>
     </a>

--- a/packages/patternlab/styleguide/source/_patterns/02-molecules/press-teaser.twig
+++ b/packages/patternlab/styleguide/source/_patterns/02-molecules/press-teaser.twig
@@ -5,7 +5,9 @@
     <a
       class="ma__press-teaser__image"
       href="{{ pressTeaser.title.href }}"
+    {% if pressTeaser.title.text %}
       title="{{ pressTeaser.title.text }}">
+    {% endif %}
       {% set image = pressTeaser.image %}
       <span
       {% if image.alt %}

--- a/packages/patternlab/styleguide/source/_patterns/05-pages/organization.json
+++ b/packages/patternlab/styleguide/source/_patterns/05-pages/organization.json
@@ -1020,7 +1020,7 @@
                   "eyebrow": "News Article",
                   "title": {
                     "href": "#",
-                    "text": "Tree House Brweing Co. Expands Its Horizons",
+                    "text": "",
                     "info": "",
                     "property": ""
                   },

--- a/packages/patternlab/styleguide/source/_patterns/05-pages/organization.json
+++ b/packages/patternlab/styleguide/source/_patterns/05-pages/organization.json
@@ -982,7 +982,7 @@
                 {
                   "image": {
                     "src": "/assets/images/placeholder/statehouse.png",
-                    "alt": "placeholder image",
+                    "alt": "",
                     "width": "400",
                     "height": "225",
                     "href": "#"

--- a/packages/patternlab/styleguide/source/_patterns/05-pages/organization.json
+++ b/packages/patternlab/styleguide/source/_patterns/05-pages/organization.json
@@ -1020,7 +1020,7 @@
                   "eyebrow": "News Article",
                   "title": {
                     "href": "#",
-                    "text": "",
+                    "text": "Tree House Brweing Co. Expands Its Horizons",
                     "info": "",
                     "property": ""
                   },


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
For the press teaser, currently its image link, which is a linked `span` with a background image, doesn't have `aria-label` (= empty) since its `a` has title for the link label.  The `span` is also overridden with `role="img"`, which is not necessary in this case.

- Set up a condition to add `aria-label` and `role="img"` only when `image.alt` value is available.
- Set up a condition to add `title` for the link label on `a` only `pressTeaser.title.text` is available.

The org page press teasers don't have `alt` value, so the `span` stays as a generic container with its background image and no `aria-label`.  No override to be an image element.

In case the component is used differently and the background image has information to deliver,  the `span` is presented as an image element with its `aria-label` value.  

3 patterns for the link label can be set up:
- title value on `a`
- aria-label on `span role="img"`
- title value on `a` + aria-label on `span role="img"`


## Related Issue / Ticket

- [JIRA issue](https://massgov.atlassian.net/browse/DP-26304)
- [Github issue]()

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Go to the Recent news & announcements section on /patterns/05-pages-organization/05-pages-organization.html
2. Inspect the teaser component for:
    - [Sample 1] no alt value:  no `aria-label` and `role="img"` on `span`
    - [Sample 2] no title value:  no `title` on `a`, `aria-label` and `role="img"` on `span`
    - [Sample 3] title + alt:  `title` on `a`, `aria-label` and `role="img"` on `span` (screen readers announce both)

3. Find no visual changes.

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

*

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
