### PR TITLE
DP-27921 Sticky TOC aria attribute

### DIFF
--- a/changelogs/DP-27921.yml
+++ b/changelogs/DP-27921.yml
@@ -1,0 +1,6 @@
+Fixed :
+  - project: Patternlab
+    component: StickyTOC
+    description: Correct spelling for aria-controls. (#1764)
+    issue: DP-27921
+    impact: Patch

--- a/packages/patternlab/styleguide/source/_patterns/03-organisms/by-template/sticky-toc.twig
+++ b/packages/patternlab/styleguide/source/_patterns/03-organisms/by-template/sticky-toc.twig
@@ -26,7 +26,7 @@
         </div>
       </nav>
       <div class="ma__sticky-toc__footer">
-        <button type="button" class="js-sticky-toc__toggle-items"  aria-haspopup="true" aria-expanded="false" aria-conrole="sticky-toc">Show More<span class="ma__visually-hidden">Table of contents</span></span>
+        <button type="button" class="js-sticky-toc__toggle-items"  aria-haspopup="true" aria-expanded="false" aria-controls="sticky-toc">Show More<span class="ma__visually-hidden">Table of contents</span></span>
         </button>
       </div>
     </div>


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/develop/docs/for-developers/changelog-instructions.md)


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
Correct the misspelled aria attribute `aria-controls` on the show more button in the sticky TOC.  

## Related Issue / Ticket

- [JIRA issue](https://massgov.atlassian.net/browse/DP-27921)
- [Github issue]()

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1.  Go to a page with TOC with show more button.
2. Inspect the `button.js-sticky-toc__toggle-items`.  Find `aria-contols`.

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

*

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
