### PR TITLE
Patternlab/dp 27968 fix download link sr text

### DIFF
--- a/changelogs/DP-27968.yml
+++ b/changelogs/DP-27968.yml
@@ -1,6 +1,6 @@
 Changed:
   - project: Patternlab
-    component: DownloadLink
+    component: DownloadLink, DownloadLinkMultilang
     description: Fix screen reader text. (#1770)
     issue: DP-27968
     impact: Patch

--- a/changelogs/DP-27968.yml
+++ b/changelogs/DP-27968.yml
@@ -1,0 +1,6 @@
+Changed:
+  - project: Patternlab
+    component: DownloadLink
+    description: Fix screen reader text. (#1770)
+    issue: DP-27968
+    impact: Patch

--- a/packages/patternlab/styleguide/source/_patterns/02-molecules/download-link-multilang.twig
+++ b/packages/patternlab/styleguide/source/_patterns/02-molecules/download-link-multilang.twig
@@ -14,7 +14,7 @@
       <a
         class="ma__download-link__file-link"
         href="{{ downloadLink.decorativeLink.href}}">
-        <span class="visually-hidden">Open {{ downloadLink.format }} file{% if downloadLink.size %}, {{ downloadLink.size }},{% endif %} for</span>
+        <span class="visually-hidden">Open {{ downloadLink.format }} file{% if downloadLink.size %}, {{ downloadLink.size }}{% endif %}, </span>
           {{ downloadLink.decorativeLink.text }}
       </a>
       {% if downloadLink.format or downloadLink.size or downloadLink.language %}

--- a/packages/patternlab/styleguide/source/_patterns/02-molecules/download-link.twig
+++ b/packages/patternlab/styleguide/source/_patterns/02-molecules/download-link.twig
@@ -14,7 +14,7 @@
       <a
         class="ma__download-link__file-link"
         href="{{ downloadLink.decorativeLink.href}}">
-        <span class="visually-hidden">Open {{ downloadLink.format }} file{% if downloadLink.size %}, {{ downloadLink.size }},{% endif %} </span>
+        <span class="visually-hidden">Open {{ downloadLink.format }} file{% if downloadLink.size %}, {{ downloadLink.size }}{% endif %}, </span>
           {{ downloadLink.decorativeLink.text }}
       </a>
       {% if downloadLink.format or downloadLink.size %}

--- a/packages/patternlab/styleguide/source/_patterns/02-molecules/download-link.twig
+++ b/packages/patternlab/styleguide/source/_patterns/02-molecules/download-link.twig
@@ -14,7 +14,7 @@
       <a
         class="ma__download-link__file-link"
         href="{{ downloadLink.decorativeLink.href}}">
-        <span class="visually-hidden">Open {{ downloadLink.format }} file{% if downloadLink.size %}, {{ downloadLink.size }},{% endif %} for</span>
+        <span class="visually-hidden">Open {{ downloadLink.format }} file{% if downloadLink.size %}, {{ downloadLink.size }},{% endif %} </span>
           {{ downloadLink.decorativeLink.text }}
       </a>
       {% if downloadLink.format or downloadLink.size %}


### PR DESCRIPTION
Changed:
  - project: Patternlab
    component: DownloadLink
    description: Fix screen reader text. (#1770)
    issue: DP-27968
    impact: Patch


UAT: https://mayflower.digital.mass.gov/patternlab/b/patternlab/DP-27968-fix-download-link-sr-text/?p=molecules-download-link-as-generic