### PR TITLE
[React] fix Hamburger SSR error

### DIFF
--- a/changelogs/DP-27950.yml
+++ b/changelogs/DP-27950.yml
@@ -1,0 +1,6 @@
+Fixed:
+  - project: React
+    component: HamburgerNav
+    description: Fix reference error - cannot access "RenderedUtilityItem" before initialization. (#1777)
+    issue: DP-27950
+    impact: Patch

--- a/packages/react/src/components/molecules/HamburgerNav/index.js
+++ b/packages/react/src/components/molecules/HamburgerNav/index.js
@@ -30,6 +30,11 @@ const HamburgerNav = ({
   let utilityNav = null;
   let mainNav = null;
   const RenderedNavSearch = getFallbackComponent(NavSearch, HamburgerNavSearch);
+  const RenderedLogo = getFallbackComponent(Logo, HamburgerSiteLogo);
+  // If UtilityItem is undefined, UtilityNav will fallback to HamburgerUtilityItem.
+  const RenderedUtilityItem = getFallbackComponent(UtilityItem, HamburgerUtilityItem);
+  // If NavItem is undefined, HamburgerMainNav falls back to HamburgerNavItem.
+  const RenderedNavItem = getFallbackComponent(NavItem, HamburgerNavItem);
   if (isMobileWindow) {
     RenderedUtilityNav = getFallbackComponent(UtilityNav, HamburgerUtilityNav);
     mainNav = (RenderedMainNav !== null ? <RenderedMainNav NavItem={RenderedNavItem} items={mainItems} /> : null);
@@ -41,11 +46,6 @@ const HamburgerNav = ({
     navSearch = (RenderedNavSearch !== null ? <RenderedNavSearch /> : null);
     mainNav = (RenderedMainNav !== null ? <RenderedMainNav NavItem={RenderedNavItem} items={mainItems} /> : null);
   }
-  const RenderedLogo = getFallbackComponent(Logo, HamburgerSiteLogo);
-  // If UtilityItem is undefined, UtilityNav will fallback to HamburgerUtilityItem.
-  const RenderedUtilityItem = getFallbackComponent(UtilityItem, HamburgerUtilityItem);
-  // If NavItem is undefined, HamburgerMainNav falls back to HamburgerNavItem.
-  const RenderedNavItem = getFallbackComponent(NavItem, HamburgerNavItem);
   const logo = (RenderedLogo !== null ? <RenderedLogo /> : null);
   const menuButtonRef = React.useRef();
   const alertOffset = React.useRef();


### PR DESCRIPTION
Fixed:
  - project: React
    component: HamburgerNav
    description: Fix reference error - cannot access "RenderedUtilityItem" before initialization. (#1777)
    issue: DP-27950
    impact: Patch

<img width="1058" alt="Screen Shot 2023-05-04 at 12 50 14 PM" src="https://user-images.githubusercontent.com/5789411/236272217-7c1b89ca-6a72-430d-852c-af5afd0a0087.png">



To test the fix locally:
1. In the Mayflower repo:
   1. cd into the react package, run `yalc publish`
2. In the budget repo:
   1. cd into the shared-ui directory
   2. run `yalc add @massds/mayflower-react`
   3. run yarn commands at the root
  