### PR TITLE
Refactor `TabContainer` global calls

### DIFF
--- a/changelogs/DP-27950.yml
+++ b/changelogs/DP-27950.yml
@@ -1,6 +1,6 @@
 Fixed:
   - project: React
-    component: UnorderedList
-    description: Fix React required type warning. (#1786)
+    component: TabContainer
+    description: Refactor TabContainer global calls. (#1783)
     issue: DP-27950
     impact: Patch

--- a/packages/react/.eslintrc.json
+++ b/packages/react/.eslintrc.json
@@ -2,6 +2,9 @@
     "env": {
         "browser": true
     },
+    "globals": {
+        "globalThis": true
+    },
     "extends": "airbnb",
     "parser": "babel-eslint",
     "plugins": ["@sayari"],
@@ -11,7 +14,7 @@
         "comma-dangle": ["error", "never"],
         "keyword-spacing": ["error", { "overrides": {
             "return": { "after": false }
-            } }],
+        } }],
         "max-len": ["off", { "code": 100 }],
         "no-shadow": ["warn"],
         "no-eval": ["warn"],

--- a/packages/react/src/components/atoms/buttons/ButtonWithIcon/index.js
+++ b/packages/react/src/components/atoms/buttons/ButtonWithIcon/index.js
@@ -68,7 +68,7 @@ ButtonWithIcon.propTypes = {
     // Either a function
     PropTypes.func,
     // Or the instance of a DOM native element (see the note about SSR)
-    PropTypes.shape({ current: PropTypes.object })
+    PropTypes.shape({ current: PropTypes.element })
   ]),
   // Button text.
   text: PropTypes.string,

--- a/packages/react/src/components/forms/FeedbackForm/index.js
+++ b/packages/react/src/components/forms/FeedbackForm/index.js
@@ -31,6 +31,7 @@ export default class FeedbackForm extends React.Component {
     /** A ref object as created by React.createRef(). Will be applied to the form element. */
     formRef: PropTypes.oneOfType([
       PropTypes.func,
+      // eslint-disable-next-line react/forbid-prop-types
       PropTypes.shape({ current: PropTypes.any })
     ]),
     /** A function whose return value is displayed after a successful form submission. */

--- a/packages/react/src/components/forms/InputTextFuzzy/index.js
+++ b/packages/react/src/components/forms/InputTextFuzzy/index.js
@@ -221,7 +221,16 @@ InputTextFuzzy.propTypes = {
     PropTypes.object
   ])).isRequired,
   /** An array of objects representing all searchable values. */
-  options: PropTypes.arrayOf(PropTypes.object).isRequired,
+  options: PropTypes.arrayOf(PropTypes.shape({
+    label: PropTypes.string,
+    id: PropTypes.string,
+    // eslint-disable-next-line react/forbid-prop-types
+    options: PropTypes.any,
+    keys: PropTypes.arrayOf(PropTypes.string),
+    selected: PropTypes.string,
+    placeholder: PropTypes.string,
+    onChange: PropTypes.func
+  })).isRequired,
   /** Any Fusejs options to override the default options set in this component.
    * API doc: https://fusejs.io/api/options.html
    *

--- a/packages/react/src/components/molecules/Breadcrumb/item.js
+++ b/packages/react/src/components/molecules/Breadcrumb/item.js
@@ -7,6 +7,10 @@ import PropTypes from 'prop-types';
 
 const CurrentItem = ({ currentPage }) => (<a href="/" aria-current="page" onClick={(e) => e.preventDefault()}>{currentPage}</a>);
 
+CurrentItem.propTypes = {
+  currentPage: PropTypes.string
+};
+
 const BreadcrumbItem = (props) => {
   // eslint-disable-next-line react/prop-types
   const { children, currentPage } = props;

--- a/packages/react/src/components/molecules/HamburgerNav/index.js
+++ b/packages/react/src/components/molecules/HamburgerNav/index.js
@@ -103,11 +103,6 @@ const HamburgerNav = ({
         hamburgerMenuContainer.style.height = `calc(100vh - ${heightAboveMenuContainer}px)`;
       }
       if (menuOverlay) {
-        let overlayOffset = heightAboveMenuContainer;
-        const width = body.clientWidth;
-        if (width > 840) {
-          overlayOffset -= 1;
-        }
         menuOverlay.classList.add('overlay-open');
         menuOverlay.onclick = () => {
           closeMenu();

--- a/packages/react/src/components/molecules/HeaderNav/index.js
+++ b/packages/react/src/components/molecules/HeaderNav/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import propTypes from 'prop-types';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import NavContainer from 'MayflowerReactMolecules/NavContainer';
 import SiteLogo from 'MayflowerReactMedia/SiteLogo';
@@ -42,32 +42,32 @@ const HeaderNav = ({
 };
 HeaderNav.propTypes = {
   /** An uninstantiated component which handles displaying the utility nav. */
-  UtilityNav: propTypes.elementType,
+  UtilityNav: PropTypes.elementType,
   /** An uninstantiated component which handles displaying individual items within the utility nav. */
-  UtilityItem: propTypes.elementType,
+  UtilityItem: PropTypes.elementType,
   /** An uninstantiated component which handles displaying menu portion of the header. */
-  MainNav: propTypes.elementType,
+  MainNav: PropTypes.elementType,
   /** An uninstantiated component which handles displaying individual menu items within the menu. */
-  NavItem: propTypes.elementType,
+  NavItem: PropTypes.elementType,
   /** An uninstantiated component which handles displaying the site logo. */
-  Logo: propTypes.elementType,
+  Logo: PropTypes.elementType,
   /** An uninstantiated component which handles search functionality. */
-  NavSearch: propTypes.elementType,
+  NavSearch: PropTypes.elementType,
   /** An uninstantiated component which handles displaying the menu button on mobile. */
-  ButtonContainer: propTypes.elementType,
+  ButtonContainer: PropTypes.elementType,
   /** An array of items used to create the menu. */
-  mainItems: propTypes.arrayOf(propTypes.shape({
-    href: propTypes.string,
-    text: propTypes.string,
+  mainItems: PropTypes.arrayOf(PropTypes.shape({
+    href: PropTypes.string,
+    text: PropTypes.string,
     // Active main nav item eccentuated with an styled underline
-    active: propTypes.bool,
-    subNav: propTypes.arrayOf(propTypes.shape({
-      href: propTypes.string,
-      text: propTypes.string
+    active: PropTypes.bool,
+    subNav: PropTypes.arrayOf(PropTypes.shape({
+      href: PropTypes.string,
+      text: PropTypes.string
     }))
   })),
   /** An array of uninstantiated components to render within the utility navigation.  */
-  utilityItems: propTypes.arrayOf(propTypes.elementType)
+  utilityItems: PropTypes.arrayOf(PropTypes.elementType)
 };
 
 export const HeaderButtonContainer = () => {
@@ -152,6 +152,9 @@ export const HeaderLogo = () => {
     },
     siteName: 'Mass.gov',
     title: 'Mass.gov homepage',
+    // TODO fix this error instead of supressing it.
+    // Adding this to propTypes causes an error.
+    // eslint-disable-next-line react/prop-types
     Wrapper: ({ children }) => (<div className="ma__header__logo">{children}</div>)
   };
   return(
@@ -177,6 +180,10 @@ export const HeaderNavSearch = ({ narrow = false }) => {
     </div>
   );
 };
+HeaderNavSearch.propTypes = {
+  narrow: PropTypes.bool
+};
+
 // For whatever reason, Header has a different nav search for mobile.
 export const HeaderMobileNavSearch = () => (
   <div className="ma__header__nav-search js-header__nav-search">
@@ -196,7 +203,7 @@ export const HeaderUtilityItem = ({ children }) => (
   </li>
 );
 HeaderUtilityItem.propTypes = {
-  children: propTypes.node
+  children: PropTypes.node
 };
 export const HeaderUtilityNav = ({ UtilityItem, items = [], narrow = true }) => {
   const RenderedUtilityItem = getFallbackComponent(UtilityItem, HeaderUtilityItem);
@@ -219,11 +226,11 @@ export const HeaderUtilityNav = ({ UtilityItem, items = [], narrow = true }) => 
 };
 HeaderUtilityNav.propTypes = {
   /** An uninstantiated component which handles displaying individual items within the utility nav. */
-  UtilityItem: propTypes.elementType,
+  UtilityItem: PropTypes.elementType,
   /** An array of uninstantiated components to render within the utility navigation.  */
-  items: propTypes.arrayOf(propTypes.elementType),
+  items: PropTypes.arrayOf(PropTypes.elementType),
   /** A boolean representing when the UtilityNav is being displayed within a narrow screen. */
-  narrow: propTypes.bool
+  narrow: PropTypes.bool
 };
 
 export const HeaderContainer = ({
@@ -241,9 +248,9 @@ export const HeaderContainer = ({
 };
 HeaderContainer.propTypes = {
   /** An uninstantiated component which handles displaying the site logo. */
-  Logo: propTypes.elementType,
+  Logo: PropTypes.elementType,
   /** An uninstantiated component which handles search functionality. */
-  NavSearch: propTypes.elementType
+  NavSearch: PropTypes.elementType
 };
 
 export default HeaderNav;

--- a/packages/react/src/components/molecules/HeaderNav/main-nav.js
+++ b/packages/react/src/components/molecules/HeaderNav/main-nav.js
@@ -276,6 +276,7 @@ HeaderNavItem.propTypes = {
   show: propTypes.func,
   href: propTypes.string,
   text: propTypes.string,
+  active: propTypes.bool,
   mainNav: propTypes.shape({
     /* eslint-disable-next-line react/forbid-prop-types */
     current: propTypes.object

--- a/packages/react/src/components/organisms/Header/utility-items.js
+++ b/packages/react/src/components/organisms/Header/utility-items.js
@@ -5,6 +5,7 @@ import DecorativeLink from 'MayflowerReactLinks/DecorativeLink';
 import IconBuilding from 'MayflowerReactBase/Icon/IconBuilding';
 import IconLogin from 'MayflowerReactBase/Icon/IconLogin';
 import useWindowWidth from 'MayflowerReactComponents/hooks/use-window-width';
+import nanoid from 'nanoid';
 import UtilityNavData from './UtilityNav.data';
 
 const PanelItem = ({
@@ -189,8 +190,8 @@ const PanelItem = ({
                 </div>
               )}
               <ul className="ma__utility-panel__items">
-                { links.length > 0 && links.map((link, i) => (
-                  <li className="ma__utility-panel__item js-clickable" key={`util_panel_item_${i}`}>
+                { links.length > 0 && links.map((link) => (
+                  <li className="ma__utility-panel__item js-clickable" key={`util_panel_item_${nanoid()}`}>
                     <DecorativeLink {...link} />
                   </li>
                 ))}
@@ -208,7 +209,11 @@ PanelItem.propTypes = {
   CustomIcon: propTypes.elementType,
   description: propTypes.string,
   ariaLabel: propTypes.string,
-  links: propTypes.arrayOf(propTypes.object)
+  links: propTypes.arrayOf(propTypes.shape({
+    text: propTypes.string,
+    href: propTypes.string,
+    type: propTypes.string
+  }))
 };
 
 export const LoginItem = ({
@@ -229,7 +234,11 @@ LoginItem.propTypes = {
   data: propTypes.shape({
     panel: propTypes.shape({
       description: propTypes.string,
-      links: propTypes.arrayOf(propTypes.object)
+      links: propTypes.arrayOf(propTypes.shape({
+        href: propTypes.string,
+        text: propTypes.string,
+        type: propTypes.string
+      }))
     }),
     text: propTypes.string,
     ariaLabel: propTypes.string

--- a/packages/react/src/components/organisms/LinkList/index.js
+++ b/packages/react/src/components/organisms/LinkList/index.js
@@ -12,6 +12,7 @@ import PropTypes from 'prop-types';
 import CompHeading from 'MayflowerReactHeadings/CompHeading';
 import Paragraph from 'MayflowerReactText/Paragraph';
 import DecorativeLink from 'MayflowerReactLinks/DecorativeLink';
+import nanoid from 'nanoid';
 
 const LinkList = (props) => {
   const {
@@ -44,11 +45,11 @@ const LinkList = (props) => {
                 <DecorativeLink {...link} />
               </li>
             ))}
-            {links.slice(halfLength, length).map((link, index) => (
+            {links.slice(halfLength, length).map((link) => (
               /* eslint-disable-next-line react/no-array-index-key */
               <li
                 className="ma__link-list__item item-right"
-                key={index + halfLength}
+                key={nanoid()}
               >
                 <DecorativeLink {...link} />
               </li>

--- a/packages/react/src/components/organisms/PageHeaderAddons/index.js
+++ b/packages/react/src/components/organisms/PageHeaderAddons/index.js
@@ -8,7 +8,6 @@ import PropTypes from 'prop-types';
 
 // import child components
 import Paragraph from 'MayflowerReactText/Paragraph';
-import PublishState from 'MayflowerReactText/PublishState';
 
 const PageHeaderAddons = (pageHeader) => {
   const {

--- a/packages/react/src/components/organisms/TabContainer/tab-body.js
+++ b/packages/react/src/components/organisms/TabContainer/tab-body.js
@@ -8,7 +8,7 @@ class TabBody extends React.Component {
     this.state = {
       nodeList: []
     };
-    if (global.MutationObserver) {
+    if (globalThis.MutationObserver) {
       this.observer = new MutationObserver((mutations) => {
         const tabContainer = document.getElementById(this.props.tabContainerBodyId);
         mutations.forEach((mutation) => {
@@ -31,13 +31,13 @@ class TabBody extends React.Component {
       // eslint-disable-next-line react/no-did-mount-set-state
       this.setState({ nodeList: [nodeList] });
     }
-    if (global.MutationObserver) {
+    if (globalThis.MutationObserver) {
       this.observer.observe(document, { attributes: true, childList: true, subtree: true });
     }
   }
 
   componentWillUnmount() {
-    if (global.MutationObserver) {
+    if (globalThis.MutationObserver) {
       this.observer.disconnect();
     }
   }

--- a/packages/react/src/components/organisms/TabContainer/tab.js
+++ b/packages/react/src/components/organisms/TabContainer/tab.js
@@ -89,7 +89,7 @@ class Tab extends React.Component {
         <li role="presentation" className={tabClasses}>
           <button type="button" {...buttonProps}>{this.props.title}</button>
         </li>
-        {global.window && (
+        {String(globalThis) === '[object Window]' && (
           <TabBody active={activeTab === tabIdent} tabContainerBodyId={this.context.tabContainerBodyId}>
             {this.props.children}
           </TabBody>


### PR DESCRIPTION
## Description
Switch to `globalThis` instead of using the Node only `global`, the browser only `window`, or relying on transpiling. This keeps global value access consistent across environments.

See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis

This fixes fatal errors in either the server environment or the browser, depending on which global is chosen.

## Related Issue / Ticket
n/a

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. Checkout the PR locally
2. Link Mayflower React to a site that does both SSR and browser rendering of `<TabContainer>` and `<Tab>`.
3. Observe there are no fatal build errors