### PR TITLE
DP-28265 Add a space between the document size and the title to be rendered

### DIFF
--- a/changelogs/DP-28265.yml
+++ b/changelogs/DP-28265.yml
@@ -1,0 +1,6 @@
+Changed:
+  - project: Patternlab
+    component: Download link
+    description: Add a space between the file size and the fiel title to be rendered in Firefox. (#1785)
+    issue: DP-28265
+    impact: Patch

--- a/packages/patternlab/styleguide/source/_patterns/02-molecules/download-link-multilang.twig
+++ b/packages/patternlab/styleguide/source/_patterns/02-molecules/download-link-multilang.twig
@@ -14,7 +14,7 @@
       <a
         class="ma__download-link__file-link"
         href="{{ downloadLink.decorativeLink.href}}">
-        <span class="visually-hidden">Open {{ downloadLink.format }} file{% if downloadLink.size %}, {{ downloadLink.size }}{% endif %}, </span>
+        <span class="visually-hidden">Open {{ downloadLink.format }} file{% if downloadLink.size %}, {{ downloadLink.size }}{% endif %},&nbsp;</span>
           {{ downloadLink.decorativeLink.text }}
       </a>
       {% if downloadLink.format or downloadLink.size or downloadLink.language %}

--- a/packages/patternlab/styleguide/source/_patterns/02-molecules/download-link.twig
+++ b/packages/patternlab/styleguide/source/_patterns/02-molecules/download-link.twig
@@ -14,7 +14,7 @@
       <a
         class="ma__download-link__file-link"
         href="{{ downloadLink.decorativeLink.href}}">
-        <span class="visually-hidden">Open {{ downloadLink.format }} file{% if downloadLink.size %}, {{ downloadLink.size }}{% endif %}, </span>
+        <span class="visually-hidden">Open {{ downloadLink.format }} file{% if downloadLink.size %}, {{ downloadLink.size }}{% endif %},&nbsp;</span>
           {{ downloadLink.decorativeLink.text }}
       </a>
       {% if downloadLink.format or downloadLink.size %}


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/develop/docs/for-developers/changelog-instructions.md)


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
Add a space between the file size and the fiel title to be rendered in Firefox.

## Related Issue / Ticket

- [JIRA issue](https://massgov.atlassian.net/browse/DP-28265)
- [Github issue]()

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1. In Firefox, go to the download link in molecules.
2. Check the markup and find a space is rendered  after the document size and the closing tag.

## Screenshots
Before
<img width="1072" alt="ff" src="https://github.com/massgov/mayflower/assets/9633303/aa870bfa-a6c2-48e5-919f-279e097385b2">

After
<img width="1010" alt="Mass_Gov" src="https://github.com/massgov/mayflower/assets/9633303/67431f63-7e95-461f-a706-cc740d06790b">



## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

*

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
