### PR TITLE
Fix `UnorderedList` type error

### DIFF
--- a/changelogs/DP-27950.yml
+++ b/changelogs/DP-27950.yml
@@ -1,0 +1,6 @@
+Fixed:
+  - project: React
+    component: UnorderedList
+    description: Fix React required type warning. (#1786)
+    issue: DP-27950
+    impact: Patch

--- a/packages/react/src/components/atoms/lists/UnorderedList/index.js
+++ b/packages/react/src/components/atoms/lists/UnorderedList/index.js
@@ -10,9 +10,9 @@ const UnorderedList = (props) => subList(props);
 UnorderedList.propTypes = {
   /** The text displayed. */
   sublist: PropTypes.arrayOf(PropTypes.shape({
-    text: PropTypes.string.required,
+    text: PropTypes.string.isRequired,
     sublist: PropTypes.arrayOf(PropTypes.shape({
-      text: PropTypes.string.required
+      text: PropTypes.string.isRequired
     }))
   }))
 };


### PR DESCRIPTION
## Description
The `.required` method doesn't seem to exist, while `.isRequired` does.

## Related Issue / Ticket
n/a

## Steps to Test
1. Import the `<UnorderedList>` component and pass it a `sublist`
2. Confirm there is no `sublist` type React error in the browser console