### PR TITLE
React/dp 27961 fix main nav keyboard navigation

### DIFF
--- a/changelogs/DP-27961.yml
+++ b/changelogs/DP-27961.yml
@@ -1,0 +1,6 @@
+Fixed:
+  - project: React
+    component: HeaderNav
+    description: A11y - fix keyboard navigation skipping the first submenu item. (#1791)
+    issue: DP-27961
+    impact: Patch

--- a/packages/react/src/components/molecules/HeaderNav/main-nav.js
+++ b/packages/react/src/components/molecules/HeaderNav/main-nav.js
@@ -171,8 +171,8 @@ export const HeaderNavItem = React.memo(({
             focusIndexInDropdown = dropdownLinksLength - 1;
           } else {
             focusIndexInDropdown = 0;
-          }  
-          $dropdownLinks[focusIndexInDropdown].focus(); 
+          }
+          $dropdownLinks[focusIndexInDropdown].focus();
         } else {
           // Adjust index of active menu item based on performed action.
           focusIndexInDropdown += (action.up ? -1 : 1);

--- a/packages/react/src/components/molecules/HeaderNav/main-nav.js
+++ b/packages/react/src/components/molecules/HeaderNav/main-nav.js
@@ -137,7 +137,7 @@ export const HeaderNavItem = React.memo(({
       // Easy access to the key that was pressed.
       const keycode = e.keyCode;
       const action = {
-        skip: keycode === 9, // tab
+        tab: keycode === 9, // tab
         close: keycode === 27, // esc
         left: keycode === 37, // left arrow
         right: keycode === 39, // right arrow
@@ -154,7 +154,7 @@ export const HeaderNavItem = React.memo(({
         $link.classList.add(hasFocus);
         $otherLinks.forEach((link) => link.classList.remove(hasFocus));
       }
-      if (action.skip && dropdownLinksLength === (focusIndexInDropdown + 1)) {
+      if (action.tab && dropdownLinksLength === (focusIndexInDropdown + 1)) {
         if (isItemOpen) {
           hide();
         }

--- a/packages/react/src/components/molecules/HeaderNav/main-nav.js
+++ b/packages/react/src/components/molecules/HeaderNav/main-nav.js
@@ -162,12 +162,9 @@ export const HeaderNavItem = React.memo(({
         $link.classList.remove(hasFocus);
         return;
       }
-      // Navigate into or within a submenu. This is needed on up/down actions
-      // (unless the menu is flipped and closed) and when using the right arrow
-      // while the menu is flipped and submenu is closed.
-      if (((action.up || action.down) && !(menuFlipped && !isItemOpen))
-          || (action.right && menuFlipped && !isItemOpen)) {
-        // Open pull down menu if necessary.
+      // Navigate into or within a submenu using the up/down arrow keys.
+      if (action.up || action.down) {
+        // Open submenu if it's not open already.
         if (!isItemOpen && !$link.classList.contains(hasFocus)) {
           show({ index });
           if (action.up) {

--- a/packages/react/src/components/molecules/HeaderNav/main-nav.js
+++ b/packages/react/src/components/molecules/HeaderNav/main-nav.js
@@ -170,22 +170,19 @@ export const HeaderNavItem = React.memo(({
         // Open pull down menu if necessary.
         if (!isItemOpen && !$link.classList.contains(hasFocus)) {
           show({ index });
-        }
-        // Adjust index of active menu item based on performed action.
-        focusIndexInDropdown += (action.up ? -1 : 1);
-        // If the menu is flipped, skip the last item in each submenu. Otherwise,
-        // skip the first item. This is done by repeating the index adjustment.
-        if (menuFlipped) {
-          if (focusIndexInDropdown === dropdownLinksLength - 1) {
-            focusIndexInDropdown += (action.up ? -1 : 1);
-          }
-        } else if (focusIndexInDropdown === 0 || focusIndexInDropdown >= dropdownLinksLength) {
+          if (action.up) {
+            focusIndexInDropdown = dropdownLinksLength - 1;
+          } else {
+            focusIndexInDropdown = 0;
+          }  
+          $dropdownLinks[focusIndexInDropdown].focus(); 
+        } else {
+          // Adjust index of active menu item based on performed action.
           focusIndexInDropdown += (action.up ? -1 : 1);
+          // Wrap around if at the end of the submenu.
+          focusIndexInDropdown = ((focusIndexInDropdown % dropdownLinksLength) + dropdownLinksLength) % dropdownLinksLength;
+          $dropdownLinks[focusIndexInDropdown].focus();
         }
-
-        // Wrap around if at the end of the submenu.
-        focusIndexInDropdown = ((focusIndexInDropdown % dropdownLinksLength) + dropdownLinksLength) % dropdownLinksLength;
-        $dropdownLinks[focusIndexInDropdown].focus();
       }
       // Close menu and return focus to menubar
       if (action.close || (menuFlipped && action.left)) {

--- a/packages/react/src/components/molecules/HeaderNav/main-nav.js
+++ b/packages/react/src/components/molecules/HeaderNav/main-nav.js
@@ -137,16 +137,17 @@ export const HeaderNavItem = React.memo(({
       // Easy access to the key that was pressed.
       const { key, code } = e;
       const action = {
-        tab: key === "Tab", // tab
-        esc: key === "Esc" || key === "Escape", // esc
-        left: key === "Left" || key === "ArrowLeft", // left arrow
-        right: key === "Right" || key === "ArrowRight", // right arrow
-        up: key === "Up" || key === "ArrowUp", // up arrow
-        down: key === "Down" || key === "ArrowDown", // down arrow
-        space: key === " " || code === "Space", // space
-        enter: key === "Enter" // enter
+        tab: key === 'Tab', // tab
+        esc: key === 'Esc' || key === 'Escape', // esc
+        left: key === 'Left' || key === 'ArrowLeft', // left arrow
+        right: key === 'Right' || key === 'ArrowRight', // right arrow
+        up: key === 'Up' || key === 'ArrowUp', // up arrow
+        down: key === 'Down' || key === 'ArrowDown', // down arrow
+        space: key === ' ' || code === 'Space', // space
+        enter: key === 'Enter' // enter
       };
-        // Default behavior is prevented for all actions except 'skip'.
+
+      // Default behavior is prevented for all actions except 'tab'.
       if (action.esc || action.left || action.right || action.up || action.down) {
         e.preventDefault();
       }

--- a/packages/react/src/components/molecules/HeaderNav/main-nav.js
+++ b/packages/react/src/components/molecules/HeaderNav/main-nav.js
@@ -135,19 +135,19 @@ export const HeaderNavItem = React.memo(({
       const dropdownLinksLength = $dropdownLinks.length;
       let focusIndexInDropdown = Array.from($dropdownLinks).findIndex((link) => link === $focusedElement);
       // Easy access to the key that was pressed.
-      const keycode = e.keyCode;
+      const { key, code } = e;
       const action = {
-        tab: keycode === 9, // tab
-        close: keycode === 27, // esc
-        left: keycode === 37, // left arrow
-        right: keycode === 39, // right arrow
-        up: keycode === 38, // up arrow
-        down: keycode === 40, // down arrow
-        space: keycode === 32, // space
-        enter: keycode === 13 // enter
+        tab: key === "Tab", // tab
+        esc: key === "Esc" || key === "Escape", // esc
+        left: key === "Left" || key === "ArrowLeft", // left arrow
+        right: key === "Right" || key === "ArrowRight", // right arrow
+        up: key === "Up" || key === "ArrowUp", // up arrow
+        down: key === "Down" || key === "ArrowDown", // down arrow
+        space: key === " " || code === "Space", // space
+        enter: key === "Enter" // enter
       };
         // Default behavior is prevented for all actions except 'skip'.
-      if (action.close || action.left || action.right || action.up || action.down) {
+      if (action.esc || action.left || action.right || action.up || action.down) {
         e.preventDefault();
       }
       if (action.enter || action.space) {
@@ -182,7 +182,7 @@ export const HeaderNavItem = React.memo(({
         }
       }
       // Close menu and return focus to menubar
-      if (action.close || (menuFlipped && action.left)) {
+      if (action.esc || (menuFlipped && action.left)) {
         if (isItemOpen) {
           hide();
         }


### PR DESCRIPTION
Main Nav keyboard and screen reader navigation issues:
1. Skipping the first submenu item

Before:
![main-nav-keyboard-nav-before](https://github.com/massgov/mayflower/assets/5789411/ff33c3e0-c452-4e50-99c3-bfda26586c2e)

After:
![main-nav-keyboard-nav](https://github.com/massgov/mayflower/assets/5789411/c0dada0c-cf0c-4f1d-b94b-02f8e5d78547)
