### PR TITLE
[React] DP-29028 allow extra attributes passed to CalloutLink anchor tag

### DIFF
--- a/changelogs/DP-29028.yml
+++ b/changelogs/DP-29028.yml
@@ -1,0 +1,6 @@
+Added:
+  - project: React
+    component: CalloutLink
+    description: Add `achorAttributes` prop to allow passing additional attributes to the anchor link. (#1825)
+    issue: DP-29028
+    impact: Minor

--- a/packages/react/src/components/molecules/CalloutLink/CalloutLink.stories.js
+++ b/packages/react/src/components/molecules/CalloutLink/CalloutLink.stories.js
@@ -12,6 +12,9 @@ CalloutLinkExample.storyName = 'Default';
 CalloutLinkExample.args = {
   text: 'Link to another page',
   href: '',
+  anchorAttributes: {
+    ['data-index']: 'promo.1'
+  },
   info: 'this will be the tooltip text on hover',
   description: '',
   eyebrow: '',

--- a/packages/react/src/components/molecules/CalloutLink/index.js
+++ b/packages/react/src/components/molecules/CalloutLink/index.js
@@ -16,7 +16,7 @@ const CalloutLink = (calloutLink) => {
 
   return(
     <div className={classNames}>
-      <a href={calloutLink.href} title={calloutLink.info}>
+      <a href={calloutLink.href} title={calloutLink.info} {...calloutLink.anchorAttributes}>
         { (calloutLink.eyebrow || calloutLink.time) && (
           <div className="ma__callout-link__header">
             <span className="ma__callout-link__eyebrow">{calloutLink.eyebrow}</span>
@@ -42,6 +42,8 @@ CalloutLink.propTypes = {
   text: PropTypes.string.isRequired,
   /** The link the callout is going to */
   href: PropTypes.string.isRequired,
+  /** All other attributes of the a tag */
+  anchorAttributes: PropTypes.object,
   /** Add more information about the link */
   info: PropTypes.string,
   /** Add description text under the title text */


### PR DESCRIPTION
Added:
  - project: React
    component: CalloutLink
    description: Add `achorAttributes` prop to allow passing additional attributes to the anchor link. (#1825)
    issue: DP-29028
    impact: Minor

This allows adding data attribute to CalloutLink a tag to enable GTM tracking