### PR TITLE
Patternlab/dp 31561 add names to forms

### DIFF
--- a/changelogs/DP-31561.yml
+++ b/changelogs/DP-31561.yml
@@ -1,0 +1,12 @@
+Added:
+  - project: Patternlab
+    component: FieldSubmit
+    description: Add hiddenInputs field. (#1866)
+    issue: DP-31561
+    impact: Patch
+  - project: Patternlab
+    component: FieldSubmit,HeaderSearch,SearchBannerForm,SearchBoxWithLinks
+    description: Add name attribute to form elements. (#1866)
+    issue: DP-31561
+    impact: Patch
+

--- a/packages/patternlab/styleguide/source/_data/utilityNav.json
+++ b/packages/patternlab/styleguide/source/_data/utilityNav.json
@@ -46,6 +46,7 @@
                       "fieldSubmit": {
                         "isForm": true,
                         "action": "https://search.mass.gov/",
+                        "hiddenInputs": "<input type='hidden' tabindex='-1' name='formstackFormSchemaVersion' value='4'><input type='hidden' tabindex='-1' name='formstackFormRendererVersion' value='master'><input type='hidden' tabindex='-1' name='form' value='5560495'><input type='hidden' tabindex='-1' name='viewkey' value='WKfdPIXNKO'><input type='hidden' tabindex='-1' name='password' value=''><input type='hidden' tabindex='-1' name='hidden_fields' value=''><input type='hidden' tabindex='-1' name='_submit' value='1'><input type='hidden' tabindex='-1' name='incomplete' value=''><input type='hidden' tabindex='-1' name='incomplete_email' value=''><input type='hidden' tabindex='-1' name='incomplete_password' value=''><input type='hidden' tabindex='-1' name='latitude' value=''><input type='hidden' tabindex='-1' name='longitude' value=''><input id='fsUserAgent' type='hidden' tabindex='-1' name='fsUserAgent' value='Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Mobile Safari/537.36'>",
                         "name": "userWay-signup-form",
                         "labelText": "If we can email you to ask about your experience with this feature, please add your email.",
                         "inputText": {

--- a/packages/patternlab/styleguide/source/_data/utilityNav.json
+++ b/packages/patternlab/styleguide/source/_data/utilityNav.json
@@ -46,6 +46,7 @@
                       "fieldSubmit": {
                         "isForm": true,
                         "action": "https://search.mass.gov/",
+                        "name": "userWay-signup-form",
                         "labelText": "If we can email you to ask about your experience with this feature, please add your email.",
                         "inputText": {
                           "required": false,

--- a/packages/patternlab/styleguide/source/_patterns/02-molecules/forms/field-submit.json
+++ b/packages/patternlab/styleguide/source/_patterns/02-molecules/forms/field-submit.json
@@ -5,6 +5,7 @@
     "name": "constrast-settings",
     "action": "https://search.mass.gov/",
     "labelText": "Filter by city, town or zipcode",
+    "hiddenInputs": "<input type='hidden' tabindex='-1' name='formstackFormSchemaVersion' value='4'>",
     "inputText": {
       "required": false,
       "id": "filter-by-location",

--- a/packages/patternlab/styleguide/source/_patterns/02-molecules/forms/field-submit.json
+++ b/packages/patternlab/styleguide/source/_patterns/02-molecules/forms/field-submit.json
@@ -2,6 +2,7 @@
   "fieldSubmit": {
     "isForm": true,
     "id": "test",
+    "name": "constrast-settings",
     "action": "https://search.mass.gov/",
     "labelText": "Filter by city, town or zipcode",
     "inputText": {

--- a/packages/patternlab/styleguide/source/_patterns/02-molecules/forms/field-submit.md
+++ b/packages/patternlab/styleguide/source/_patterns/02-molecules/forms/field-submit.md
@@ -1,10 +1,30 @@
+### Description
+Labelled input with inline submit button
+
 ### Status
 * Obsolete as of 5.0.0
 * In use by utilityNav
 
-Description: Labelled input with inline submit button
+### Used in
+- [@organisms/utility-nav](/?p=organisms-utility-nav)
 
-## State: Alpha
 
-### Used in:
-- [@organisms/by-author-location-listing](/?p=organisms-location-listing)
+### Variables
+~~~
+fieldSubmits: {
+  isForm: 
+    type: boolean / optional (whether as a form or a fieldset)
+  id: 
+    type: string / optional (form id)
+  name: 
+    type: string / optional (form name)
+  action: 
+    type: string / optional (form action)
+  labelText: 
+    type: string / required
+  inputText
+    type: inputText / required
+  buttonSearch
+    type: buttonSearch / required
+}
+~~~

--- a/packages/patternlab/styleguide/source/_patterns/02-molecules/forms/field-submit.md
+++ b/packages/patternlab/styleguide/source/_patterns/02-molecules/forms/field-submit.md
@@ -26,5 +26,7 @@ fieldSubmits: {
     type: inputText / required
   buttonSearch
     type: buttonSearch / required
+  hiddenInputs
+    type: HTML string / optional
 }
 ~~~

--- a/packages/patternlab/styleguide/source/_patterns/02-molecules/forms/field-submit.md
+++ b/packages/patternlab/styleguide/source/_patterns/02-molecules/forms/field-submit.md
@@ -15,9 +15,9 @@ fieldSubmits: {
   isForm: 
     type: boolean / optional (whether as a form or a fieldset)
   id: 
-    type: string / optional (form id)
+    type: string / optional (form or fieldset id)
   name: 
-    type: string / optional (form name)
+    type: string / optional (form or fieldset name)
   action: 
     type: string / optional (form action)
   labelText: 

--- a/packages/patternlab/styleguide/source/_patterns/02-molecules/forms/field-submit.twig
+++ b/packages/patternlab/styleguide/source/_patterns/02-molecules/forms/field-submit.twig
@@ -5,6 +5,7 @@
   {% if fieldSubmit.id %} id={{ fieldSubmit.id }} {% endif %}
   {% if fieldSubmit.name %} name={{ fieldSubmit.name }} {% endif %}
 >
+  {{ fieldSubmit.hiddenInputs }}
 {% else %}
 <fieldset 
   class="ma__field-submit"

--- a/packages/patternlab/styleguide/source/_patterns/02-molecules/forms/field-submit.twig
+++ b/packages/patternlab/styleguide/source/_patterns/02-molecules/forms/field-submit.twig
@@ -1,5 +1,10 @@
 {% if fieldSubmit.isForm %}
-<form class="ma__field-submit" action={{ fieldSubmit.action }} {% if fieldSubmit.id %} id={{ fieldSubmit.id }} {% endif %}>
+<form
+  class="ma__field-submit"
+  action={{ fieldSubmit.action }}
+  {% if fieldSubmit.id %} id={{ fieldSubmit.id }} {% endif %}
+  {% if fieldSubmit.name %} name={{ fieldSubmit.name }} {% endif %}
+>
 {% else %}
 <fieldset class="ma__field-submit">
 {% endif %}

--- a/packages/patternlab/styleguide/source/_patterns/02-molecules/forms/field-submit.twig
+++ b/packages/patternlab/styleguide/source/_patterns/02-molecules/forms/field-submit.twig
@@ -5,7 +5,7 @@
   {% if fieldSubmit.id %} id={{ fieldSubmit.id }} {% endif %}
   {% if fieldSubmit.name %} name={{ fieldSubmit.name }} {% endif %}
 >
-  {{ fieldSubmit.hiddenInputs }}
+  {{ fieldSubmit.hiddenInputs|raw }}
 {% else %}
 <fieldset 
   class="ma__field-submit"

--- a/packages/patternlab/styleguide/source/_patterns/02-molecules/forms/field-submit.twig
+++ b/packages/patternlab/styleguide/source/_patterns/02-molecules/forms/field-submit.twig
@@ -6,7 +6,11 @@
   {% if fieldSubmit.name %} name={{ fieldSubmit.name }} {% endif %}
 >
 {% else %}
-<fieldset class="ma__field-submit">
+<fieldset 
+  class="ma__field-submit"
+  {% if fieldSubmit.id %} id={{ fieldSubmit.id }} {% endif %}
+  {% if fieldSubmit.name %} name={{ fieldSubmit.name }} {% endif %}
+>
 {% endif %}
   {% if fieldSubmit.labelText %}
     {# A custom label for layout purposes #}

--- a/packages/patternlab/styleguide/source/_patterns/02-molecules/header-search.twig
+++ b/packages/patternlab/styleguide/source/_patterns/02-molecules/header-search.twig
@@ -1,7 +1,7 @@
 {% set hasSuggestions = headerSearch.hasSuggestions %}
 {% set suggestedScopes = headerSearch.suggestedScopes %}
 <div class="ma__header-search">
-  <form role="search" action="https://search.mass.gov/" class="ma__form js-header-search-form">
+  <form role="search" action="https://search.mass.gov/" class="ma__form js-header-search-form" name="header-search">
     <label
         for="{{headerSearch.id}}"
         class="ma__header-search__label">{{headerSearch.label}}</label>

--- a/packages/patternlab/styleguide/source/_patterns/02-molecules/search-banner-form.twig
+++ b/packages/patternlab/styleguide/source/_patterns/02-molecules/search-banner-form.twig
@@ -1,7 +1,7 @@
 {# backward compatible with v5.6 - data object used to start with the form namespace #}
 {% set form = searchBannerForm ? : form.content %}
 
-<form role="search" class="ma__search-banner__form" action="{{ form.action }}">
+<form role="search" class="ma__search-banner__form" action="{{ form.action }}" name="banner-search">
   <div class="ma__search-banner__input">
     {% set inputText = form.inputText %}
     {% include "@atoms/03-forms/input-text.twig" %}

--- a/packages/patternlab/styleguide/source/_patterns/03-organisms/by-author/feedback-form.twig
+++ b/packages/patternlab/styleguide/source/_patterns/03-organisms/by-author/feedback-form.twig
@@ -16,7 +16,7 @@
         <h2 class="ma__feedback-form__title">{{feedbackForm.title}}</h2>
         <p class="ma__feedback-form__description">{{feedbackForm.description}}</p>
       </header>
-      <form action="#" class="ma__form ma__form--light">
+      <form action="#" class="ma__form ma__form--light" name="feedback-form">
         <div class="ma__feedback-form__name">
           {% set inputText = feedbackForm.inputText %}
           {% include "@atoms/03-forms/input-text.twig" %}

--- a/packages/patternlab/styleguide/source/_patterns/03-organisms/by-template/search-box-with-links.json
+++ b/packages/patternlab/styleguide/source/_patterns/03-organisms/by-template/search-box-with-links.json
@@ -3,6 +3,7 @@
     "form": {
       "headingText": "Search for data",
       "submitText": "SEARCH",
+      "name": "data-search",
       "visuallyHiddenText": "Enter a subject or search term",
       "actionUrl": "/",
       "inputName": "title",

--- a/packages/patternlab/styleguide/source/_patterns/03-organisms/by-template/search-box-with-links.md
+++ b/packages/patternlab/styleguide/source/_patterns/03-organisms/by-template/search-box-with-links.md
@@ -13,7 +13,8 @@ This Pattern shows a Search box with links.
       "headingText": "Search for data",
       "submitText": "SEARCH",
       "visuallyHiddenText": "Enter a subject or search term",
-      "actionUrl": "/"
+      "actionUrl": "/",
+      "name": "data-search"
     },
 
     "secondary": {

--- a/packages/patternlab/styleguide/source/_patterns/03-organisms/by-template/search-box-with-links.twig
+++ b/packages/patternlab/styleguide/source/_patterns/03-organisms/by-template/search-box-with-links.twig
@@ -1,5 +1,11 @@
 <div class="ma__search-box-with-links">
-	<form role="search" class="ma__search-box-with-links__form" action="{{ searchBoxWithLinks.form.actionUrl }}" method="get">
+	<form role="search" class="ma__search-box-with-links__form"
+	action="{{ searchBoxWithLinks.form.actionUrl }}"
+	method="get"
+	{% if searchBoxWithLinks.form.name %}
+		name="{{searchBoxWithLinks.form.name}}"
+	{% endif %}
+	>
 		<h3>{{ searchBoxWithLinks.form.headingText }}</h3>
 
 		<div class="ma__keyword-search js-keyword-search">


### PR DESCRIPTION
Added:
  - project: Patternlab
    component: FieldSubmit
    description: Add hiddenInputs field. (#1866)
    issue: DP-31561
    impact: Patch
  - project: Patternlab
    component: FieldSubmit,HeaderSearch,SearchBannerForm,SearchBoxWithLinks
    description: Add name attribute to form elements. (#1866)
    issue: DP-31561
    impact: Patch
