### PR TITLE
DP-31620: News headlines on org pages are the same heading level as the "News" header

### DIFF
--- a/changelogs/DP-31620.yml
+++ b/changelogs/DP-31620.yml
@@ -1,0 +1,59 @@
+# Every PR must have a changelog. To create a changelog:
+# 1. Make a copy of this file and name it with the ticket number.
+# 2. Keep the original format of one of the examples at the bottom, and override each element of it using ___TEMPLATE___ for reference
+# 3. Remove all comments from the copied file
+
+#___CHANGE TYPES___
+# - Added for new features.
+# - Changed for changes in existing functionality.
+# - Deprecated for soon-to-be removed features.
+# - Removed for now removed features.
+# - Fixed for any bug fixes.
+# - Security in case of vulnerabilities.
+# e.g. Added
+
+#___PROJECT___
+# - Patternlab
+# - React
+# - Docs
+# e.g. React
+# e.g. React, Patternlab
+
+#___COMPONENT___
+# Component name(s) in `PascalCase`
+# e.g. Header
+# e.g. Form, InputSlider, InputTextTypeAhead
+
+#___DESCRIPTION___
+# PR description and PR number (append PR number with # to create a link to the PR in Github)
+# If you need multiple lines, start the first line with the following "|-" characters.
+# For any breaking changes, add a comment in the PR describing the necessary changes on the consumer side and link that comment in the description.
+#e.g. Adds apples to apple trees for admin apple pickers (#PR)
+
+#___ISSUE___
+# A Jira ticket or a Github issue number (append Github issue number with # to create a link to the issue in Github)
+# e.g. DP-12345 or #123
+
+#___IMPACT___
+# - Major impact when you make incompatible API changes,
+# - Minor impact when you add functionality in a backwards compatible manner, and
+# - Patch impact when you make backwards compatible bug fixes.
+# e.g. Minor
+# See https://semver.org/ for more info.
+
+
+#___TEMPLATE___
+# ChangeType [enter a valid option, see __CHANGE TYPES___ e.g. Added]:
+#  - project: Enter one or multiple (comma separated) valid project prefix(es) - see ___PROJECT___ e.g. React, Patternlab
+#    component: Enter one or multiple (comma separated) valid component name(s) - see ___COMPONENT___ e.g. Color
+#    description: Describe the change and add the PR number. see ___DESCRIPTION___ e.g. Adds apples to apple trees for admin apple pickers (#PR)
+#    issue: Add a Jira ticket or issue number, e.g. DP-12345 or 124
+#    impact: Enter a valid impact, e.g. Minor
+
+#___EXAMPLE___
+Fixed:
+  - project: Patternlab
+    component: PressListing
+    description: Fix press listing heading levels. (#1867)
+    issue: DP-31620
+    impact: Patch

--- a/packages/patternlab/styleguide/source/_patterns/03-organisms/by-author/press-listing.twig
+++ b/packages/patternlab/styleguide/source/_patterns/03-organisms/by-author/press-listing.twig
@@ -16,7 +16,7 @@
       <div class="ma__press-listing__items">
         {% block featuredItems %}
           {% for pressTeaser in pressListing.items %}
-            {% set pressTeaser = pressTeaser|merge({"level":teaserHeading}) %}
+            {% set pressTeaser = pressTeaser|merge({"level":teaserHeading + 1}) %}
             {% include "@molecules/press-teaser.twig" %}
           {% endfor %}
         {% endblock %}
@@ -27,7 +27,7 @@
         {% block secondaryItems %}
           {% for pressTeaser in pressListing.secondaryItems %}
             <li class="ma__press-listing__secondary-item">
-              {% set pressTeaser = pressTeaser|merge({"level":teaserHeading}) %}
+              {% set pressTeaser = pressTeaser|merge({"level":teaserHeading + 1}) %}
               {% include "@molecules/press-teaser.twig" %}
             </li>
           {% endfor %}


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/develop/docs/for-developers/changelog-instructions.md)


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->

## Related Issue / Ticket

- [JIRA issue]()
- [Github issue]()

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1.

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

*

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
