### PR TITLE
[a11y] DP-31780 No space between visible text and visually hidden text

### DIFF
--- a/changelogs/DP-31780.yml
+++ b/changelogs/DP-31780.yml
@@ -1,0 +1,5 @@
+  - project: Patternlab
+    component: multiple components
+    description: Add space to screen reader only text containers where screen readers announce the text sequentially as a part of its parent contetiner's last word. (#1876)
+    issue: DP-31780
+    impact: Patch

--- a/packages/patternlab/styleguide/source/_patterns/01-atoms/04-headings/colored-heading-from-left.twig
+++ b/packages/patternlab/styleguide/source/_patterns/01-atoms/04-headings/colored-heading-from-left.twig
@@ -10,6 +10,6 @@
     {{ coloredHeadingFromLeft.title }}
   </h2>
   {% if coloredHeadingFromLeft.titleContext %}
-    <span class="visually-hidden"> {{ coloredHeadingFromLeft.titleContext }}</span>
+    <span class="ma__visually-hidden"> {{ coloredHeadingFromLeft.titleContext }}</span>
   {% endif %}
 </header>

--- a/packages/patternlab/styleguide/source/_patterns/01-atoms/04-headings/colored-heading-from-left.twig
+++ b/packages/patternlab/styleguide/source/_patterns/01-atoms/04-headings/colored-heading-from-left.twig
@@ -10,6 +10,6 @@
     {{ coloredHeadingFromLeft.title }}
   </h2>
   {% if coloredHeadingFromLeft.titleContext %}
-    <span class="visually-hidden">{{ coloredHeadingFromLeft.titleContext }}</span>
+    <span class="visually-hidden"> {{ coloredHeadingFromLeft.titleContext }}</span>
   {% endif %}
 </header>

--- a/packages/patternlab/styleguide/source/_patterns/01-atoms/04-headings/colored-heading.twig
+++ b/packages/patternlab/styleguide/source/_patterns/01-atoms/04-headings/colored-heading.twig
@@ -2,7 +2,7 @@
 
 {# use the level passed, the gloval level, or the default #}
 {% set headingLevel = coloredHeading.level ? : 2 %}
-  
+
 <h{{ headingLevel }} class="ma__colored-heading {{class}}">{{coloredHeading.text}}
-{% if coloredHeading.titleContext %}<span class="visually-hidden"> {{coloredHeading.titleContext}}</span>{% endif %}
+{% if coloredHeading.titleContext %}<span class="visually-hidden">&nbsp; {{coloredHeading.titleContext}}</span>{% endif %}
 </h{{ headingLevel }}>

--- a/packages/patternlab/styleguide/source/_patterns/01-atoms/04-headings/colored-heading.twig
+++ b/packages/patternlab/styleguide/source/_patterns/01-atoms/04-headings/colored-heading.twig
@@ -4,5 +4,5 @@
 {% set headingLevel = coloredHeading.level ? : 2 %}
 
 <h{{ headingLevel }} class="ma__colored-heading {{class}}">{{coloredHeading.text}}
-{% if coloredHeading.titleContext %}<span class="visually-hidden">&nbsp; {{coloredHeading.titleContext}}</span>{% endif %}
+{% if coloredHeading.titleContext %}<span class="ma__visually-hidden">&nbsp; {{coloredHeading.titleContext}}</span>{% endif %}
 </h{{ headingLevel }}>

--- a/packages/patternlab/styleguide/source/_patterns/01-atoms/04-headings/comp-heading.twig
+++ b/packages/patternlab/styleguide/source/_patterns/01-atoms/04-headings/comp-heading.twig
@@ -34,7 +34,7 @@
     id="{{compHeading.id}}"
   {% endif %}
   tabindex="-1">{{ compHeading.title }}
-  {% if compHeading.titleContext %}<span class="visually-hidden">&nbsp; {{ compHeading.titleContext }}</span>{% endif %}
+  {% if compHeading.titleContext %}<span class="ma__visually-hidden">&nbsp; {{ compHeading.titleContext }}</span>{% endif %}
 {% if compHeading.tag %}
 </{{ compHeading.tag }}>
 {% else %}

--- a/packages/patternlab/styleguide/source/_patterns/01-atoms/04-headings/comp-heading.twig
+++ b/packages/patternlab/styleguide/source/_patterns/01-atoms/04-headings/comp-heading.twig
@@ -34,7 +34,7 @@
     id="{{compHeading.id}}"
   {% endif %}
   tabindex="-1">{{ compHeading.title }}
-  {% if compHeading.titleContext %}<span class="visually-hidden"> {{ compHeading.titleContext }}</span>{% endif %}
+  {% if compHeading.titleContext %}<span class="visually-hidden">&nbsp; {{ compHeading.titleContext }}</span>{% endif %}
 {% if compHeading.tag %}
 </{{ compHeading.tag }}>
 {% else %}

--- a/packages/patternlab/styleguide/source/_patterns/01-atoms/04-headings/sidebar-heading.twig
+++ b/packages/patternlab/styleguide/source/_patterns/01-atoms/04-headings/sidebar-heading.twig
@@ -2,5 +2,5 @@
 {% set headingLevel = sidebarHeading.level ? : 2 %}
 
 <h{{ headingLevel }} class="ma__sidebar-heading">{{sidebarHeading.title}}{% if sidebarHeading.titleContext %}
-  <span class="visually-hidden">&nbsp; {{sidebarHeading.titleContext}}</span>{% endif %}
+  <span class="ma__visually-hidden">&nbsp; {{sidebarHeading.titleContext}}</span>{% endif %}
 </h{{ headingLevel }}>

--- a/packages/patternlab/styleguide/source/_patterns/01-atoms/04-headings/sidebar-heading.twig
+++ b/packages/patternlab/styleguide/source/_patterns/01-atoms/04-headings/sidebar-heading.twig
@@ -2,5 +2,5 @@
 {% set headingLevel = sidebarHeading.level ? : 2 %}
 
 <h{{ headingLevel }} class="ma__sidebar-heading">{{sidebarHeading.title}}{% if sidebarHeading.titleContext %}
-  <span class="visually-hidden"> {{sidebarHeading.titleContext}}</span>{% endif %}
+  <span class="visually-hidden">&nbsp; {{sidebarHeading.titleContext}}</span>{% endif %}
 </h{{ headingLevel }}>

--- a/packages/patternlab/styleguide/source/_patterns/01-atoms/09-media/figure.twig
+++ b/packages/patternlab/styleguide/source/_patterns/01-atoms/09-media/figure.twig
@@ -34,7 +34,7 @@
     {% if figure.skiplink.add %}
       <div class="ma__figure__skip-link_target js-skiplink-target">
         <a id="{{ skiplinkId }}" tabindex="-1">
-          You skipped the {{ skiplinkText }}<span class="ma__visually-hidden">, {{ figure.title.text }}</span>.
+          You skipped the {{ skiplinkText }}<span class="ma__visually-hidden">,&nbsp; {{ figure.title.text }}</span>.
         </a>
       </div>
     {% endif %}

--- a/packages/patternlab/styleguide/source/_patterns/01-atoms/10-table/table-responsive.twig
+++ b/packages/patternlab/styleguide/source/_patterns/01-atoms/10-table/table-responsive.twig
@@ -8,7 +8,7 @@
 
   <nav class="ma__table__horizontal-nav">
     <button class="ma__table__horizontal-nav__left" aria-controls="{{tableID}}">
-      <span class="visually-hidden">Scroll left</span>
+      <span class="ma__visually-hidden">Scroll left</span>
     </button>
 
     <div class="ma__scroll-indicator" aria-controls="{{tableID}}" role="scrollbar" aria-orientation="horizontal">
@@ -16,7 +16,7 @@
     </div>
 
     <button class="ma__table__horizontal-nav__right" aria-controls="{{tableID}}">
-      <span class="visually-hidden">Scroll right</span>
+      <span class="ma__visually-hidden">Scroll right</span>
     </button>
   </nav>
   <div class="ma__table--responsive__wrapper {{ mergedCells ? 'ma__table--merged-cells' : ''}}" id="{{tableID}}" tabindex="0" role="region" aria-orientation="horizontal" aria-label="{{table.description}}">

--- a/packages/patternlab/styleguide/source/_patterns/01-atoms/11-text/link.twig
+++ b/packages/patternlab/styleguide/source/_patterns/01-atoms/11-text/link.twig
@@ -18,5 +18,5 @@
   href="{{ link.href }}"
   {% if link.info %} title="{{ link.info }}"{% endif %}
   {% if link.ariaLabel %} aria-label="{{ link.ariaLabel }}"{% endif %}><span>{{ link.text }}</span>
-  {% if link.labelContext %}<span class="ma__visually-hidden"> {{ link.labelContext }}</span>{% endif %}
+  {% if link.labelContext %}<span class="ma__visually-hidden">&nbsp; {{ link.labelContext }}</span>{% endif %}
 </a>

--- a/packages/patternlab/styleguide/source/_patterns/01-atoms/decorative-link.twig
+++ b/packages/patternlab/styleguide/source/_patterns/01-atoms/decorative-link.twig
@@ -4,5 +4,5 @@
     class="js-clickable-link"
     {% if decorativeLink.info %}title="{{ decorativeLink.info }}"{% endif %}
     {% if decorativeLink.context %} aria-describedby="{{ decorativeLink.context }}"{% endif %}
-    {% if decorativeLink.ariaLabel %} aria-label="{{ decorativeLink.ariaLabel }}"{% endif %}>{{decorativeLink.text}}{% if decorativeLink.labelContext %}<span class="ma__visually-hidden"> {{decorativeLink.labelContext}}</span>{% endif %}&nbsp;{{ icon('arrow') }}</a>
+    {% if decorativeLink.ariaLabel %} aria-label="{{ decorativeLink.ariaLabel }}"{% endif %}>{{decorativeLink.text}}{% if decorativeLink.labelContext %}<span class="ma__visually-hidden">&nbsp; {{decorativeLink.labelContext}}</span>{% endif %}&nbsp;{{ icon('arrow') }}</a>
 </span>

--- a/packages/patternlab/styleguide/source/_patterns/02-molecules/callout-link.twig
+++ b/packages/patternlab/styleguide/source/_patterns/02-molecules/callout-link.twig
@@ -30,7 +30,7 @@ target="">
               </div>
           {% endif %}
           <span class="ma__download-link__file-link ma__callout-link__text">
-                  <span class="visually-hidden">Open {{ calloutLink.format }} file{% if calloutLink.size %}, {{ calloutLink.size }},{% endif %} for</span>
+                  <span class="ma__visually-hidden">Open {{ calloutLink.format }} file{% if calloutLink.size %}, {{ calloutLink.size }},{% endif %} for</span>
                   {{ calloutLink.text }}
               </span>
           {% if calloutLink.format or calloutLink.size %}

--- a/packages/patternlab/styleguide/source/_patterns/02-molecules/callout-stats.twig
+++ b/packages/patternlab/styleguide/source/_patterns/02-molecules/callout-stats.twig
@@ -4,6 +4,6 @@
 
 {% set modifierClass = statsCallout.pull ? "ma__callout-stats--" ~ statsCallout.pull : "" %}
 <div class="ma__callout-stats {{modifierClass}}">
-  <span class="ma__callout-stats__stat">{{statsCallout.stat}}</span>
-  <span class="ma__callout-stats__content">&nbsp; {{statsCallout.content}}</span>
+  <span class="ma__callout-stats__stat">{{statsCallout.stat}}</span>&nbsp;
+  <span class="ma__callout-stats__content">{{statsCallout.content}}</span>
 </div>

--- a/packages/patternlab/styleguide/source/_patterns/02-molecules/callout-stats.twig
+++ b/packages/patternlab/styleguide/source/_patterns/02-molecules/callout-stats.twig
@@ -5,5 +5,5 @@
 {% set modifierClass = statsCallout.pull ? "ma__callout-stats--" ~ statsCallout.pull : "" %}
 <div class="ma__callout-stats {{modifierClass}}">
   <span class="ma__callout-stats__stat">{{statsCallout.stat}}</span>
-  <span class="ma__callout-stats__content">{{statsCallout.content}}</span>
+  <span class="ma__callout-stats__content">&nbsp; {{statsCallout.content}}</span>
 </div>

--- a/packages/patternlab/styleguide/source/_patterns/02-molecules/contact-item.twig
+++ b/packages/patternlab/styleguide/source/_patterns/02-molecules/contact-item.twig
@@ -33,7 +33,7 @@
     <a
       href="tel:{{ link.href }}"
       class="ma__content-link">
-      {% if item.contactName %}<span class="visually-hidden">Call {{ item.contactName }}{% if item.label %}, {{item.label}}{% endif %} at </span>{% endif %}{{ link.text }}</a>
+      {% if item.contactName %}<span class="ma__visually-hidden">Call {{ item.contactName }}{% if item.label %}, {{item.label}}{% endif %} at </span>{% endif %}{{ link.text }}</a>
 
  {# Phone - add tel: to href #}
   {% elseif item.type == "fax" %}
@@ -43,13 +43,13 @@
   {% elseif item.type == "email" %}
     <a
       href="mailto:{{ link.href }}"
-      class="ma__content-link">{% if item.contactName %}<span class="visually-hidden">Email {{ item.contactName }} at </span>{% endif %}{{ link.text }}</a>
+      class="ma__content-link">{% if item.contactName %}<span class="ma__visually-hidden">Email {{ item.contactName }} at </span>{% endif %}{{ link.text }}</a>
 
    {% elseif item.type == "login" %}
     <a
       href="{{ link.href }}"
       class="ma__content-link">{{ link.text }}</a>
-      
+
     {# Address - RTE version of value and look for directions link #}
   {% elseif item.type == "address" %}
     <div class="ma__contact-group__address">

--- a/packages/patternlab/styleguide/source/_patterns/02-molecules/download-link-multilang.twig
+++ b/packages/patternlab/styleguide/source/_patterns/02-molecules/download-link-multilang.twig
@@ -14,7 +14,7 @@
       <a
         class="ma__download-link__file-link"
         href="{{ downloadLink.decorativeLink.href}}">
-        <span class="visually-hidden">Open {{ downloadLink.format }} file{% if downloadLink.size %}, {{ downloadLink.size }}{% endif %},&nbsp;</span>
+        <span class="ma__visually-hidden">Open {{ downloadLink.format }} file{% if downloadLink.size %}, {{ downloadLink.size }}{% endif %},&nbsp;</span>
           {{ downloadLink.decorativeLink.text }}
       </a>
       {% if downloadLink.format or downloadLink.size or downloadLink.language %}

--- a/packages/patternlab/styleguide/source/_patterns/02-molecules/download-link.twig
+++ b/packages/patternlab/styleguide/source/_patterns/02-molecules/download-link.twig
@@ -14,7 +14,7 @@
       <a
         class="ma__download-link__file-link"
         href="{{ downloadLink.decorativeLink.href}}">
-        <span class="visually-hidden">Open {{ downloadLink.format }} file{% if downloadLink.size %}, {{ downloadLink.size }}{% endif %},&nbsp;</span>
+        <span class="ma__visually-hidden">Open {{ downloadLink.format }} file{% if downloadLink.size %}, {{ downloadLink.size }}{% endif %},&nbsp;</span>
           {{ downloadLink.decorativeLink.text }}
       </a>
       {% if downloadLink.format or downloadLink.size %}

--- a/packages/patternlab/styleguide/source/_patterns/02-molecules/location-icons.twig
+++ b/packages/patternlab/styleguide/source/_patterns/02-molecules/location-icons.twig
@@ -1,6 +1,6 @@
 <section class="ma__location-icons">
   {% if locationIcons.title %}
-    <span class="visually-hidden">{{ locationIcons.title }}</span>
+    <span class="ma__visually-hidden">{{ locationIcons.title }}</span>
   {% endif %}
   <div class="ma__location-icons__items">
     {% for icon in locationIcons.icons %}

--- a/packages/patternlab/styleguide/source/_patterns/02-molecules/main-nav-hamburger.twig
+++ b/packages/patternlab/styleguide/source/_patterns/02-molecules/main-nav-hamburger.twig
@@ -6,7 +6,7 @@
       <li role="{{ nav.subNav ? 'menuitem' : 'none' }}"  class="ma__main__hamburger-nav__item {{ nav.active ? 'is-active' : '' }} {{ nav.subNav ? 'has-subnav js-main-nav-hamburger-toggle' : 'js-main-nav-hamburger-top-link' }}">
         {% if nav.subNav %}
           <button type="button" id="{{ buttonId }}" class="ma__main__hamburger-nav__top-link js-main-nav-hamburger__top-link" aria-expanded="false" aria-haspopup="true">
-          <span class="visually-hidden show-label">Show the sub topics of </span>
+          <span class="ma__visually-hidden show-label">Show the sub topics of </span>
               {{ nav.text }}
           <span class="toggle-indicator" aria-hidden="true"></span>
           </button>

--- a/packages/patternlab/styleguide/source/_patterns/02-molecules/main-nav.twig
+++ b/packages/patternlab/styleguide/source/_patterns/02-molecules/main-nav.twig
@@ -6,7 +6,7 @@
       <li role="{{ nav.subNav ? 'menuitem' : 'none' }}" class="ma__main-nav__item {{ nav.active ? 'is-active' : '' }} {{ nav.subNav ? 'has-subnav js-main-nav-toggle' : 'js-main-nav-top-link' }}" tabindex="-1">
         {% if nav.subNav %}
           <button type="button" id="{{ buttonId }}" class="ma__main-nav__top-link" aria-haspopup="true" aria-expanded="false" tabindex="0">
-              <span class="visually-hidden show-label">Show the sub topics of </span>
+              <span class="ma__visually-hidden show-label">Show the sub topics of </span>
               {{ nav.text }}
           </button>
           <div class="ma__main-nav__subitems js-main-nav-content is-closed">

--- a/packages/patternlab/styleguide/source/_patterns/02-molecules/map-leaflet.twig
+++ b/packages/patternlab/styleguide/source/_patterns/02-molecules/map-leaflet.twig
@@ -7,14 +7,14 @@
     <a href="{{ leafletMap.link.href }}">
       <div class="ma__leaflet-map__map js-leaflet-map"></div>
       <div class="ma__leaflet-map__directions-link">
-        <span>Get Directions<span class="ma__visually-hidden"> to {{ " " ~ leafletMap.link.info  ~ " "}}</span>&nbsp;{{ icon('arrow') }}</span>
+        <span>Get Directions<span class="ma__visually-hidden">&nbsp; to {{ " " ~ leafletMap.link.info  ~ " "}}</span>&nbsp;{{ icon('arrow') }}</span>
       </div>
     </a>
   {% else %}
     <div class="ma__leaflet-map__map js-leaflet-map"></div>
     {% if leafletMap.link.href %}
     <a class="ma__leaflet-map__directions-link" href="{{ leafletMap.link.href }}">
-      <span>Get Directions<span class="ma__visually-hidden"> to {{ " " ~ leafletMap.link.info ~ " "}}</span>&nbsp;{{ icon('arrow') }}</span>
+      <span>Get Directions<span class="ma__visually-hidden">&nbsp; to {{ " " ~ leafletMap.link.info ~ " "}}</span>&nbsp;{{ icon('arrow') }}</span>
     </a>
     {% endif %}
   {% endif %}

--- a/packages/patternlab/styleguide/source/_patterns/02-molecules/relationship-indicators.twig
+++ b/packages/patternlab/styleguide/source/_patterns/02-molecules/relationship-indicators.twig
@@ -3,7 +3,7 @@
     {% if relationshipIndicators.primary %}
       <div class="ma__relationship-indicators--section primary {{ relationshipIndicators.secondary ? '' : ' single' }}">
       <span class="ma__relationship-indicators--label" id="primary">
-        <span class="ma__visually-hidden">This page, {{ relationshipIndicators.pageTitle }}, is </span>
+        <span class="ma__visually-hidden">This page, {{ relationshipIndicators.pageTitle }}, is &nbsp;</span>
         {{ relationshipIndicators.primary.label }}
       </span>
         <ul class="ma__relationship-indicators--terms" aria-labelledby="primary">
@@ -32,7 +32,7 @@
               <span class="ma__relationship-indicators--icon">{{ icon(relationshipIndicators.secondary.icon) }}</span>
             {% endif %}
             <span class="ma__relationship-indicators--label" id="secondary">
-              <span class="ma__visually-hidden">This page, {{ relationshipIndicators.pageTitle }}, is </span>
+              <span class="ma__visually-hidden">This page, {{ relationshipIndicators.pageTitle }}, is &nbsp;</span>
               {{ relationshipIndicators.secondary.label }}
             </span>
           </li>

--- a/packages/patternlab/styleguide/source/_patterns/02-molecules/results-heading.twig
+++ b/packages/patternlab/styleguide/source/_patterns/02-molecules/results-heading.twig
@@ -1,7 +1,7 @@
 <div class="ma__results-heading js-results-heading">
   <div class="ma__results-heading__container">
     {% set headingLevel = resultsHeading.level ? resultsHeading.level : 2 %}
-    <h{{ headingLevel }} class="ma__results-heading__title">Showing {{ resultsHeading.numResults }} {% if resultsHeading.totalResults %} of {{ resultsHeading.totalResults }}{% endif %} results {% if resultsHeading.tags %}for:{% endif %}{% if resultsHeading.subject %}<span class="visually-hidden">for {{ resultsHeading.subject }}</span>{% endif %}</h{{ headingLevel }}>
+    <h{{ headingLevel }} class="ma__results-heading__title">Showing {{ resultsHeading.numResults }} {% if resultsHeading.totalResults %} of {{ resultsHeading.totalResults }}{% endif %} results {% if resultsHeading.tags %}for:{% endif %}{% if resultsHeading.subject %}<span class="visually-hidden">&nbsp; for {{ resultsHeading.subject }}</span>{% endif %}</h{{ headingLevel }}>
     {% if resultsHeading.tags %}
       <div class="ma__results-heading__tags">
         {% for tag in resultsHeading.tags %}

--- a/packages/patternlab/styleguide/source/_patterns/02-molecules/results-heading.twig
+++ b/packages/patternlab/styleguide/source/_patterns/02-molecules/results-heading.twig
@@ -1,7 +1,7 @@
 <div class="ma__results-heading js-results-heading">
   <div class="ma__results-heading__container">
     {% set headingLevel = resultsHeading.level ? resultsHeading.level : 2 %}
-    <h{{ headingLevel }} class="ma__results-heading__title">Showing {{ resultsHeading.numResults }} {% if resultsHeading.totalResults %} of {{ resultsHeading.totalResults }}{% endif %} results {% if resultsHeading.tags %}for:{% endif %}{% if resultsHeading.subject %}<span class="visually-hidden">&nbsp; for {{ resultsHeading.subject }}</span>{% endif %}</h{{ headingLevel }}>
+    <h{{ headingLevel }} class="ma__results-heading__title">Showing {{ resultsHeading.numResults }} {% if resultsHeading.totalResults %} of {{ resultsHeading.totalResults }}{% endif %} results {% if resultsHeading.tags %}for:{% endif %}{% if resultsHeading.subject %}<span class="ma__visually-hidden">&nbsp; for {{ resultsHeading.subject }}</span>{% endif %}</h{{ headingLevel }}>
     {% if resultsHeading.tags %}
       <div class="ma__results-heading__tags">
         {% for tag in resultsHeading.tags %}

--- a/packages/patternlab/styleguide/source/_patterns/02-molecules/social-links.twig
+++ b/packages/patternlab/styleguide/source/_patterns/02-molecules/social-links.twig
@@ -9,7 +9,7 @@
       {% for item in socialLinks.items %}
         <li class="ma__social-links__item">
           <a href="{{ item.href }}" class="ma__social-links__link js-social-share {{linkTheme}}" data-social-share="{{ item.linkType }}">
-            <span class="visually-hidden">{{ item.altText }}</span>
+            <span class="ma__visually-hidden">{{ item.altText }}</span>
             {{ icon(item.icon) }}
           </a>
         </li>

--- a/packages/patternlab/styleguide/source/_patterns/02-molecules/sticky-nav.twig
+++ b/packages/patternlab/styleguide/source/_patterns/02-molecules/sticky-nav.twig
@@ -1,7 +1,7 @@
 <nav
   class="ma__sticky-nav js-scroll-anchors"
   aria-label="Page Contents">
-  <h3 class="visually-hidden">the Contents{% if stickyNav.titleContext %} of the {{stickyNav.titleContext}} page{% endif %}</h3>
+  <h3 class="ma__visually-hidden">the Contents{% if stickyNav.titleContext %} of the {{stickyNav.titleContext}} page{% endif %}</h3>
   <button
     class="ma__sticky-nav__toggle-link js-scroll-anchors-toggle"
     aria-label="expand or collapse side nav">+</button>

--- a/packages/patternlab/styleguide/source/_patterns/03-organisms/by-author/action-details.twig
+++ b/packages/patternlab/styleguide/source/_patterns/03-organisms/by-author/action-details.twig
@@ -1,9 +1,9 @@
 <section class="ma__action-details">
-  <h2 class="ma__action-details__title">The Details{% if actionDetails.titleContext %}<span class="visually-hidden"> of {{actionDetails.titleContext}}</span>{% endif %}</h2>
+  <h2 class="ma__action-details__title">The Details{% if actionDetails.titleContext %}<span class="ma__visually-hidden"> of {{actionDetails.titleContext}}</span>{% endif %}</h2>
 
   <div class="ma__action-details__content">
     <nav class="ma__action-details__anchor-links js-scroll-anchors" aria-labelledby="page_contents">
-        <h3 class="visually-hidden" id="page_contents">Page Contents{% if actionDetails.titleContext %} of {{actionDetails.titleContext}}{% endif %}</h3>
+        <h3 class="ma__visually-hidden" id="page_contents">Page Contents{% if actionDetails.titleContext %} of {{actionDetails.titleContext}}{% endif %}</h3>
         <button class="ma__action-details__toggle-link js-scroll-anchors-toggle">+</button>
         {% for section in actionDetails.sections %}
           {% if section.id and section.title %}

--- a/packages/patternlab/styleguide/source/_patterns/03-organisms/by-author/action-finder.twig
+++ b/packages/patternlab/styleguide/source/_patterns/03-organisms/by-author/action-finder.twig
@@ -48,7 +48,7 @@
     {% endif %}
     {% if actionFinder.featuredLinks %}
       {% if actionFinder.featuredHeading %}
-        <h3 class="ma__action-finder__category">{{ actionFinder.featuredHeading }}{% if actionFinder.contextPositionTop == false and actionFinder.titleContext %}<span class="visually-hidden"> {{ actionFinder.titleContext }}</span>{% endif %}</h3>
+        <h3 class="ma__action-finder__category">{{ actionFinder.featuredHeading }}{% if actionFinder.contextPositionTop == false and actionFinder.titleContext %}<span class="visually-hidden">&nbsp; {{ actionFinder.titleContext }}</span>{% endif %}</h3>
       {% endif %}
       <div class="ma__action-finder__items">
         {% block featuredLinksList %}

--- a/packages/patternlab/styleguide/source/_patterns/03-organisms/by-author/action-finder.twig
+++ b/packages/patternlab/styleguide/source/_patterns/03-organisms/by-author/action-finder.twig
@@ -48,7 +48,7 @@
     {% endif %}
     {% if actionFinder.featuredLinks %}
       {% if actionFinder.featuredHeading %}
-        <h3 class="ma__action-finder__category">{{ actionFinder.featuredHeading }}{% if actionFinder.contextPositionTop == false and actionFinder.titleContext %}<span class="visually-hidden">&nbsp; {{ actionFinder.titleContext }}</span>{% endif %}</h3>
+        <h3 class="ma__action-finder__category">{{ actionFinder.featuredHeading }}{% if actionFinder.contextPositionTop == false and actionFinder.titleContext %}<span class="ma__visually-hidden">&nbsp; {{ actionFinder.titleContext }}</span>{% endif %}</h3>
       {% endif %}
       <div class="ma__action-finder__items">
         {% block featuredLinksList %}
@@ -66,7 +66,7 @@
     {% endif %}
     {% if actionFinder.links %}
       {% if actionFinder.generalHeading and actionFinder.featuredLinks %}
-        <h3 class="ma__action-finder__category">{{ actionFinder.generalHeading }}{% if actionFinder.contextPositionTop == false and actionFinder.titleContext %}<span class="visually-hidden"> {{ actionFinder.titleContext }}</span>{% endif %}</h3>
+        <h3 class="ma__action-finder__category">{{ actionFinder.generalHeading }}{% if actionFinder.contextPositionTop == false and actionFinder.titleContext %}<span class="ma__visually-hidden"> {{ actionFinder.titleContext }}</span>{% endif %}</h3>
       {% endif %}
       <div class="ma__action-finder__items ma__action-finder__items--all">
         {% block actionFinderLinksList %}

--- a/packages/patternlab/styleguide/source/_patterns/03-organisms/by-author/related-locations.twig
+++ b/packages/patternlab/styleguide/source/_patterns/03-organisms/by-author/related-locations.twig
@@ -5,13 +5,13 @@
   <div class="ma__related-locations__container">
   {% if relatedLocations.pages %}
     <h2 id="{{relatedLocations.customTitle ? 'nearby-locations' : 'related-locations'}}" class="ma__related-locations__title">{{relatedLocations.customTitle ? 'Nearby Locations' : 'Related Locations'}}
-    {% if relatedLocations.titleContext %}<span class="visually-hidden"> {{relatedLocations.titleContext}}</span>{% endif %}</h2>
+    {% if relatedLocations.titleContext %}<span class="visually-hidden">&nbsp; {{relatedLocations.titleContext}}</span>{% endif %}</h2>
   {% endif %}
     <div class="ma__related-locations__items">
       {% for page in relatedLocations.pages %}
         <div class="ma__related-locations__item">
-          <a class="ma__related-location" href="{{ page.link.href }}" 
-          title="{{ page.link.text }}" 
+          <a class="ma__related-location" href="{{ page.link.href }}"
+          title="{{ page.link.text }}"
           aria-describedby="Link to {{ page.link.text }}">
           {% set image = page.image.src ? page.image : { "alt": page.altTag, "src": page.image } %}
           {% include "@atoms/09-media/image.twig" %}
@@ -21,7 +21,7 @@
       {% endfor %}
     </div>
     <div class="ma__more-locations__items">
-      <h{{ headingLevel ? headingLevel : 3 }}>More Locations</h{{ headingLevel ? headingLevel : 3 }}> 
+      <h{{ headingLevel ? headingLevel : 3 }}>More Locations</h{{ headingLevel ? headingLevel : 3 }}>
       {% set linkList = relatedLocations.linkList %}
       {% include "@organisms/by-author/link-list.twig" %}
     </div>

--- a/packages/patternlab/styleguide/source/_patterns/03-organisms/by-author/related-locations.twig
+++ b/packages/patternlab/styleguide/source/_patterns/03-organisms/by-author/related-locations.twig
@@ -5,7 +5,7 @@
   <div class="ma__related-locations__container">
   {% if relatedLocations.pages %}
     <h2 id="{{relatedLocations.customTitle ? 'nearby-locations' : 'related-locations'}}" class="ma__related-locations__title">{{relatedLocations.customTitle ? 'Nearby Locations' : 'Related Locations'}}
-    {% if relatedLocations.titleContext %}<span class="visually-hidden">&nbsp; {{relatedLocations.titleContext}}</span>{% endif %}</h2>
+    {% if relatedLocations.titleContext %}<span class="ma__visually-hidden">&nbsp; {{relatedLocations.titleContext}}</span>{% endif %}</h2>
   {% endif %}
     <div class="ma__related-locations__items">
       {% for page in relatedLocations.pages %}

--- a/packages/patternlab/styleguide/source/_patterns/03-organisms/by-author/related-orgs-and-topics.twig
+++ b/packages/patternlab/styleguide/source/_patterns/03-organisms/by-author/related-orgs-and-topics.twig
@@ -9,7 +9,7 @@
 
       {% if column.linkList.links|length > 3 %}
         <button type="button" class="ma__related-orgs-and-topics--toggle js-ma__related-orgs-and-topics--toggle">
-          show <span class="more">more</span><span class="fewer">fewer</span><span class="ma__visually-hidden">{{ column.column_title }}</span>
+          show <span class="more">more</span><span class="fewer">fewer</span><span class="ma__visually-hidden">&nbsp; {{ column.column_title }}</span>
         </button>
       {% endif %}
     </div>

--- a/packages/patternlab/styleguide/source/_patterns/03-organisms/by-author/suggested-pages.twig
+++ b/packages/patternlab/styleguide/source/_patterns/03-organisms/by-author/suggested-pages.twig
@@ -6,7 +6,7 @@
 <section class="ma__suggested-pages {{ pageType }}">
   <div class="ma__suggested-pages__container">
     <div class="ma__suggested-pages__inner-container">
-      <h2 class="ma__suggested-pages__title">{{ suggestedPages.title }}{% if suggestedPages.titleContext %}<span class="visually-hidden"> {{suggestedPages.titleContext}}</span>{% endif %}</h2>
+      <h2 class="ma__suggested-pages__title">{{ suggestedPages.title }}{% if suggestedPages.titleContext %}<span class="visually-hidden">&nbsp; {{suggestedPages.titleContext}}</span>{% endif %}</h2>
       <ul class="ma__suggested-pages__items">
         {% if suggestedPages.view == "guide" %}
           {% for page in suggestedPages.pages %}

--- a/packages/patternlab/styleguide/source/_patterns/03-organisms/by-author/suggested-pages.twig
+++ b/packages/patternlab/styleguide/source/_patterns/03-organisms/by-author/suggested-pages.twig
@@ -6,7 +6,7 @@
 <section class="ma__suggested-pages {{ pageType }}">
   <div class="ma__suggested-pages__container">
     <div class="ma__suggested-pages__inner-container">
-      <h2 class="ma__suggested-pages__title">{{ suggestedPages.title }}{% if suggestedPages.titleContext %}<span class="visually-hidden">&nbsp; {{suggestedPages.titleContext}}</span>{% endif %}</h2>
+      <h2 class="ma__suggested-pages__title">{{ suggestedPages.title }}{% if suggestedPages.titleContext %}<span class="ma__visually-hidden">&nbsp; {{suggestedPages.titleContext}}</span>{% endif %}</h2>
       <ul class="ma__suggested-pages__items">
         {% if suggestedPages.view == "guide" %}
           {% for page in suggestedPages.pages %}

--- a/packages/patternlab/styleguide/source/_patterns/03-organisms/by-template/footer-with-columns.twig
+++ b/packages/patternlab/styleguide/source/_patterns/03-organisms/by-template/footer-with-columns.twig
@@ -30,7 +30,7 @@
     <button class="ma__footer__back2top js-back2top is-hidden">
       {{ icon('arrow') }}
       <span aria-hidden="true">Top</span>
-      <span class="visually-hidden">Go to the top of the page</span>
+      <span class="ma__visually-hidden">Go to the top of the page</span>
     </button>
   {% endif %}
 </footer>

--- a/packages/patternlab/styleguide/source/_patterns/03-organisms/by-template/sticky-toc.twig
+++ b/packages/patternlab/styleguide/source/_patterns/03-organisms/by-template/sticky-toc.twig
@@ -26,7 +26,7 @@
         </div>
       </nav>
       <div class="ma__sticky-toc__footer">
-        <button type="button" class="js-sticky-toc__toggle-items"  aria-haspopup="true" aria-expanded="false" aria-controls="sticky-toc">Show More<span class="ma__visually-hidden">Table of contents</span></span>
+        <button type="button" class="js-sticky-toc__toggle-items"  aria-haspopup="true" aria-expanded="false" aria-controls="sticky-toc">Show More<span class="ma__visually-hidden">&nbsp; Table of contents</span></span>
         </button>
       </div>
     </div>

--- a/packages/patternlab/styleguide/source/_patterns/03-organisms/by-template/table-of-contents-overlay.twig
+++ b/packages/patternlab/styleguide/source/_patterns/03-organisms/by-template/table-of-contents-overlay.twig
@@ -1,6 +1,6 @@
 <div class="ma__toc--overlay js-toc-container">
   <div class="ma__toc__toc__title js-inline-overlay-title" tab-index="-1">
-    <span class="ma__toc__subtitle">This is a part of{% if tableOfContentsOverlay.typeContext %}<span class="ma__visually-hidden">the {{ tableOfContentsOverlay.typeContext }}</span>{% endif %}:</span>
+    <span class="ma__toc__subtitle">This is a part of{% if tableOfContentsOverlay.typeContext %}<span class="ma__visually-hidden">&nbsp; the {{ tableOfContentsOverlay.typeContext }}</span>{% endif %}:</span>
     {% set decorativeLink = tableOfContentsOverlay.title %}
     {% include "@atoms/decorative-link.twig" %}
     <button type="button" class="ma__toc__toc__toggle js-inline-overlay-toggle" aria-expanded="false" aria-controls="{{tableOfContentsOverlay.id}}">
@@ -9,7 +9,7 @@
   </div>
   <div class="ma__toc--overlay__container js-inline-overlay" id="{{tableOfContentsOverlay.id}}">
     <div class="ma__toc__toc__title js-inline-overlay-title" tab-index="-1">
-      <span class="ma__toc__subtitle">This is a part of{% if tableOfContentsOverlay.typeContext %}<span class="ma__visually-hidden">the {{ tableOfContentsOverlay.typeContext }}</span>{% endif %}:</span>
+      <span class="ma__toc__subtitle">This is a part of{% if tableOfContentsOverlay.typeContext %}<span class="ma__visually-hidden">&nbsp; the {{ tableOfContentsOverlay.typeContext }}</span>{% endif %}:</span>
       {% set decorativeLink = tableOfContentsOverlay.title %}
       {% include "@atoms/decorative-link.twig" %}
       <button type="button" class="ma__toc__toc__toggle js-inline-overlay-toggle" aria-expanded="true" aria-controls="{{tableOfContentsOverlay.id}}">

--- a/packages/patternlab/styleguide/source/_patterns/03-organisms/feedback/mass-feedback.twig
+++ b/packages/patternlab/styleguide/source/_patterns/03-organisms/feedback/mass-feedback.twig
@@ -23,7 +23,7 @@
         </label>
 
         {% if helpTip %}
-        <div class="ma__help-tip-container" aria-hidden="true">
+        <div class="ma__help-tip-container">
           {% set helpTip = helpTip %}
           {% include "@organisms/by-author/help-tip.twig" %}
         </div>

--- a/packages/patternlab/styleguide/source/_patterns/03-organisms/feedback/mass-feedback.twig
+++ b/packages/patternlab/styleguide/source/_patterns/03-organisms/feedback/mass-feedback.twig
@@ -1,5 +1,5 @@
 <div data-nosnippet="true" class="ma__mass-feedback-form" id="feedback">
-  <h2 class="ma__mass-feedback-form__heading">{{ heading }}<span class="ma__visually-hidden"> with your feedback</span></h2>
+  <h2 class="ma__mass-feedback-form__heading">{{ heading }}<span class="ma__visually-hidden">&nbsp; with your feedback</span></h2>
   {# form screen #}
   <form class="ma__mass-feedback-form__form{{ submitted ? ' hidden': ''}}" method="post" novalidate action="{{ formAction }}" id="{{ formId }}">
     <fieldset class="ma_feedback-fieldset feedback-load" role="radiogroup">

--- a/packages/patternlab/styleguide/source/_patterns/03-organisms/page-header/page-header.twig
+++ b/packages/patternlab/styleguide/source/_patterns/03-organisms/page-header/page-header.twig
@@ -25,7 +25,7 @@
     {% if pageHeader.nested %}
         <h1 class="ma__page-header__title">
           {% if prefix %}
-            <span class="visually-hidden">{{ prefix }}&nbsp;</span>
+            <span class="ma__visually-hidden">{{ prefix }}&nbsp;</span>
           {% endif %}
           {{pageHeader.title}}
           {% if pageHeader.titleSubText %}
@@ -45,7 +45,7 @@
     {% else %}
       <h1 class="ma__page-header__title">
         {% if prefix %}
-          <span class="visually-hidden">{{ prefix }}&nbsp;</span>
+          <span class="ma__visually-hidden">{{ prefix }}&nbsp;</span>
         {% endif %}
         {{pageHeader.title}}
         {% if pageHeader.titleSubText %}
@@ -61,7 +61,7 @@
               <p class="ma__page-header__description">{{pageHeader.description}}</p>
             {% endif %}
           </div>
-      {% endif %}  
+      {% endif %}
       {% if pageHeader.links %}
         <div class="ma__page-header__links-wrapper">
             <ul class="ma__page-header__links">

--- a/packages/patternlab/styleguide/source/assets/js/modules/stickyTOC.js
+++ b/packages/patternlab/styleguide/source/assets/js/modules/stickyTOC.js
@@ -53,8 +53,8 @@ export default (function (window, document) {
       Array.from(tocSections.headings).forEach((section, index) => {
         let sectionId = section.id;
         // Remove span element before passing to the a tag.
-        if (section.querySelector('span.visually-hidden') !== null) {
-          section.querySelector('span.visually-hidden').remove();
+        if (section.querySelector('span.ma__visually-hidden') !== null) {
+          section.querySelector('span.ma__visually-hidden').remove();
         }
         const sectionTitle = section.innerText;
         const titleCheck = sectionTitle.trim();


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/develop/docs/for-developers/changelog-instructions.md)


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
Markup patterns with the issue:
```
<parent>Hi, I am a turip <span class="ma__visually-hidden"> that is blooming in a winter!</span></parent>
```
```
<parent><span class="ma__visually-hidden">pink </span> Easter bunny</parent>
```
JAWS or NVDA in Chrome or Edge in Windows don't recognize the space right after the opening span or before the closing span, and announce the two words, "turip" and "that" as one word "turipthat", "pink" and "easter" as one "pinkeaster" 

`&nbsp;` is added at the opening or closing tag of nested `.ma__visually-hidden` where its parent container's the closest word to`.ma__visually-hidden` to avoid this.

Edited components:

- 01-atoms/decorative-link.twig
- 01-atoms/04-headings/colored-heading.twig
- 01-atoms/04-headings/comp-heading.twig
- 01-atoms/04-headings/sidebar-heading.twig
- 01-atoms/09-media/figure.twig
- 01-atoms/11-text/link.twig
- 02-molecules/map-leaflet.twig
- 02-molecules/relationship-indicators.twig
- 02-molecules/results-heading.twig 
- 03-organisms/by-author/action-finder.twig
- 03-organisms/by-author/related-locations.twig
- 03-organisms/by-author/related-orgs-and-topics.twig
- 03-organisms/by-author/suggested-pages.twig
- 03-organisms/by-template/table-of-contents-overlay.twig
- 03-organisms/feedback/mass-feedback.twig

- 02-molecules/callout-stats.twig 
    - The stats and the following description in this component have the same issue described above, so it's also fixed with a similar approach.

## Related Issue / Ticket

- [JIRA issue](https://massgov.atlassian.net/browse/DP-31780)
- [Github issue]()

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->
Sample test pages:
- https://mayflower.digital.mass.gov/patternlab/b/patternlab/DP-31780_a11y-sr-text-space/?p=pages-event
- https://mayflower.digital.mass.gov/patternlab/b/patternlab/DP-31780_a11y-sr-text-space/?p=pages-information-details-dataviz (for figure - data viz container)
- https://mayflower.digital.mass.gov/patternlab/b/patternlab/DP-31780_a11y-sr-text-space/?p=pages-location-park-content
- https://mayflower.digital.mass.gov/patternlab/b/patternlab/DP-31780_a11y-sr-text-space/?p=pages-organization

Note:  When test with the components directly, they might not have `.ma__visually-hidden` content.

Method 1:  In the sample pages, open inspect and check the components to find they have `&nbsp;` at the opening or closing `.ma__visually-hidden` span based on how the parent container's text follows or is followed by the span.

Method 1:  Browse the sample pages with JAWS or NVDA in Chrome or Edge in Windows to find the first or last word in `.ma__visually-hidden` is NOT merged to the closest parent container's word as one word.

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

*

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
