### PR TITLE
DP-31955 Check for empty items for suggested pages

### DIFF
--- a/changelogs/DP-31955.yml
+++ b/changelogs/DP-31955.yml
@@ -1,0 +1,7 @@
+
+Changed:
+  - project: Patternlab
+    component: Suggested Pages
+    description: Add a condition to check suggested page items. (#1886)
+    issue: DP-31955
+    impact: Patch

--- a/packages/patternlab/styleguide/source/_patterns/03-organisms/by-author/suggested-pages.twig
+++ b/packages/patternlab/styleguide/source/_patterns/03-organisms/by-author/suggested-pages.twig
@@ -7,6 +7,7 @@
   <div class="ma__suggested-pages__container">
     <div class="ma__suggested-pages__inner-container">
       <h2 class="ma__suggested-pages__title">{{ suggestedPages.title }}{% if suggestedPages.titleContext %}<span class="ma__visually-hidden">&nbsp; {{suggestedPages.titleContext}}</span>{% endif %}</h2>
+      {% if suggestedPages.pages|length > 0 %}
       <ul class="ma__suggested-pages__items">
         {% if suggestedPages.view == "guide" %}
           {% for page in suggestedPages.pages %}
@@ -32,6 +33,7 @@
           {% endfor %}
         {% endif %}
       </ul>
+      {% endif %}
       {% if suggestedPages.moreLinks %}
         {% set linkList = suggestedPages.moreLinks %}
         {% include "@organisms/by-author/link-list.twig" %}


### PR DESCRIPTION
<!-- Please use TICKET Description of ticket as PR title (i.e. DP-1234 Add back-to link on Announcement template)  -->
Any PRs being created needs a changelog.txt file before being merged into dev. See: [Change Log Instructions](https://github.com/massgov/mayflower/blob/develop/docs/for-developers/changelog-instructions.md)


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.-->
Add a condition to check `li` items and set not to generate `ul` when no item.
No visual change.

## Related Issue / Ticket

- [JIRA issue](https://massgov.atlassian.net/browse/DP-31955)
- [Github issue]()

## Steps to Test
<!-- Outline the steps to test or reproduce the PR here.  Whenever possible deploy your branch to your fork Github Pages so UAT can be done without rebuilding. See: https://github.com/massgov/mayflower/blob/master/docs/deploy.md -->

1.  Test with guide page by removing  suggested page items to see if `ul` is generated in inspect.

## Screenshots
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.


## Additional Notes:

Anything else to add?

#### Impacted Areas in Application
<!-- List general components of the application that this PR will affect: -->

*

#### @TODO
<!-- List any known remaining work for this ticket / issue. -->

*

#### Today I learned...
<!-- Did you learn anything valuable in your work for this PR that you could share with the team?  You could list any relevant blogs, docs, or stack overflow posts that helped you with this work. -->
