### PR TITLE
patternlab/DP-34976-rich-text-heading-float-fix

### DIFF
--- a/changelogs/DP-34976.yml
+++ b/changelogs/DP-34976.yml
@@ -1,0 +1,6 @@
+Fixed:
+  - project: Patternlab
+    component: RichText
+    description: Rollback heading clear floats and fix the comp heading styles in floats  (#1934)
+    issue: DP-34424,DP-34976
+    impact: Patch

--- a/packages/assets/scss/03-organisms/_rich-text.scss
+++ b/packages/assets/scss/03-organisms/_rich-text.scss
@@ -81,7 +81,7 @@ $heading-indent: $gutter;
   h4 {
 
     @include ma-comp-heading;
-    display: flow-root;
+    display: flow-root;  // https://dev.to/baooab/what-is-display-flow-root-28ph
   }
 
   & h2,

--- a/packages/assets/scss/03-organisms/_rich-text.scss
+++ b/packages/assets/scss/03-organisms/_rich-text.scss
@@ -73,9 +73,9 @@ $heading-indent: $gutter;
     }
   }
 
-  // clear float for all headings after left floating elements
+  // clear float for all headings h1-h4 (with underline) after left floating elements
 
-  h1, h2, h3, h4, h5, h6 {
+  h1, h2, h3, h4 {
     clear: left;
   }
 

--- a/packages/assets/scss/03-organisms/_rich-text.scss
+++ b/packages/assets/scss/03-organisms/_rich-text.scss
@@ -73,23 +73,6 @@ $heading-indent: $gutter;
     }
   }
 
-  // clear float for all headings h1-h4 (with underline) after left floating elements
-
-  h1, h2, h3, h4 {
-    clear: left;
-  }
-
-  // rich text has an optional title
-
-  h2:not(.ma__comp-heading),
-  h3:not(.ma__comp-heading),
-  h3:not(.ma__sidebar-heading),
-  h4 {
-
-    @include ma-comp-heading;
-    display: block;
-  }
-
   & h2,
   &__container h2 {
     padding-top: .75em;

--- a/packages/assets/scss/03-organisms/_rich-text.scss
+++ b/packages/assets/scss/03-organisms/_rich-text.scss
@@ -73,6 +73,17 @@ $heading-indent: $gutter;
     }
   }
 
+  // rich text has an optional title
+
+  h2:not(.ma__comp-heading),
+  h3:not(.ma__comp-heading),
+  h3:not(.ma__sidebar-heading),
+  h4 {
+
+    @include ma-comp-heading;
+    display: flow-root;
+  }
+
   & h2,
   &__container h2 {
     padding-top: .75em;


### PR DESCRIPTION
Fixed:
  - project: Patternlab
    component: RichText
    description: Rollback heading clear floats and fix the comp heading styles in floats  (#1934)
    issue: DP-34424,DP-34976
    impact: Patch
