### PR TITLE
DP-38375 optimize images for image paragraph on info detail pages

### DIFF
--- a/changelogs/DP-38375.yml
+++ b/changelogs/DP-38375.yml
@@ -1,0 +1,6 @@
+Changed:
+  - project: Patternlab
+    component: Image, featuredItem
+    description: Allow externally rendered image in featuredItem and Image components.
+    issue: DP-38375
+    impact: Minor

--- a/packages/patternlab/styleguide/source/_patterns/01-atoms/09-media/image.twig
+++ b/packages/patternlab/styleguide/source/_patterns/01-atoms/09-media/image.twig
@@ -1,24 +1,29 @@
-<img
-  class="ma__image{% if image.shape %} {{ image.shape }}{% endif %}"
-  alt="{{ image.alt }}"
-  src="{{ image.src }}"
-  {% if image.versions %}
-    srcset="
+{# Allow to use render from CMS, for example responsive images #}
+{% if image_render is not empty %}
+  {{ image_render }}
+{% else %}
+  <img
+    class="ma__image{% if image.shape %} {{ image.shape }}{% endif %}"
+    alt="{{ image.alt }}"
+    src="{{ image.src }}"
+    {% if image.versions %}
+      srcset="
     {% for version in image.versions %}
       {% if version.url and version.width %}
         {{ version.url }} {{ version.width }}{% if not loop.last %},{% endif %}
       {% endif %}
     {% endfor %}
     "
-    {% if image.sizes %}
-      {# Only use sizes if certain breakpoints limit the width of the image to less than approximately full width #}
-      sizes="{{ image.sizes }}"
+      {% if image.sizes %}
+        {# Only use sizes if certain breakpoints limit the width of the image to less than approximately full width #}
+        sizes="{{ image.sizes }}"
+      {% endif %}
     {% endif %}
-  {% endif %}
-  {% if image.height %}
-    height="{{ image.height }}"
-  {% endif %}
-  {% if image.width %}
-    width="{{ image.width }}"
-  {% endif %}
-/>
+    {% if image.height %}
+      height="{{ image.height }}"
+    {% endif %}
+    {% if image.width %}
+      width="{{ image.width }}"
+    {% endif %}
+  />
+{% endif %}

--- a/packages/patternlab/styleguide/source/_patterns/02-molecules/featured-item.twig
+++ b/packages/patternlab/styleguide/source/_patterns/02-molecules/featured-item.twig
@@ -4,20 +4,33 @@
   {% set itemClass = itemClass ~ " ma__featured-item--" ~ featuredItem.variation %}
 {% endif %}
 
-<a class="{{itemClass}}" href="{{featuredItem.href}}" >
+<a class="{{ itemClass }}" href="{{ featuredItem.href }}">
+
   <div class="ma__featured-item__image">
-    {% set image = featuredItem.image %}
+    {% set image = null %}
+    {% if featuredItem.image %}
+      {% set image = featuredItem.image %}
+    {% elseif featuredItem.content %}
+      {% set image_render = featuredItem.content %}
+    {% endif %}
     {% include "@atoms/09-media/image.twig" %}
   </div>
+
   {% if featuredItem.featuredImage %}
-    <div class="ma__featured-item__image--large">
+    <div class="ma__featured-item__image--large dima-test">
       {% set image = featuredItem.featuredImage %}
       {% include "@atoms/09-media/image.twig" %}
     </div>
+  {% elseif featuredItem.featuredContent %}
+    <div class="ma__featured-item__image--large dima-test3">
+      {% set image_render = featuredItem.featuredContent %}
+      {% include "@atoms/09-media/image.twig" %}
+    </div>
   {% endif %}
+
   <div class="ma__featured-item__title-container">
     <div class="ma__featured-item__title">
-      <span>{{featuredItem.text}}</span>&nbsp;{{ icon('arrow') }}
+      <span>{{ featuredItem.text }}</span>&nbsp;{{ icon('arrow') }}
     </div>
   </div>
 </a>

--- a/packages/patternlab/styleguide/source/_patterns/02-molecules/featured-item.twig
+++ b/packages/patternlab/styleguide/source/_patterns/02-molecules/featured-item.twig
@@ -17,12 +17,12 @@
   </div>
 
   {% if featuredItem.featuredImage %}
-    <div class="ma__featured-item__image--large dima-test">
+    <div class="ma__featured-item__image--large">
       {% set image = featuredItem.featuredImage %}
       {% include "@atoms/09-media/image.twig" %}
     </div>
   {% elseif featuredItem.featuredContent %}
-    <div class="ma__featured-item__image--large dima-test3">
+    <div class="ma__featured-item__image--large">
       {% set image_render = featuredItem.featuredContent %}
       {% include "@atoms/09-media/image.twig" %}
     </div>


### PR DESCRIPTION
This PR add a posibility to use `image_render` variable for `Image` component. If that key is provided - it will be used instead of image attributes. 
`image_render` variable will be directly rendered in the Image.twig template as is. 


## Description
This was made to allow use direct render img tag for mainly to use Drupal managed responsive images.

## Related Issue / Ticket

- [JIRA issue](https://massgov.atlassian.net/browse/DP-38375)
- [Github issue](https://github.com/massgov/openmass/pull/2916)

## Steps to Test
This can be tested on pages like https://www.mass.gov/orgs/veteran-education-employment-trainin. Another place to test https://mass.local/qag-service3
It apply to feature-item component. 
![image](https://github.com/user-attachments/assets/59616482-0c5d-40dc-8f4d-f47c61d55e77)

