### PR TITLE
DP-39184: Fix glossary term matching

### DIFF
--- a/changelogs/DP-39184.yml
+++ b/changelogs/DP-39184.yml
@@ -1,0 +1,59 @@
+# Every PR must have a changelog. To create a changelog:
+# 1. Make a copy of this file and name it with the ticket number.
+# 2. Keep the original format of one of the examples at the bottom, and override each element of it using ___TEMPLATE___ for reference
+# 3. Remove all comments from the copied file
+
+#___CHANGE TYPES___
+# - Added for new features.
+# - Changed for changes in existing functionality.
+# - Deprecated for soon-to-be removed features.
+# - Removed for now removed features.
+# - Fixed for any bug fixes.
+# - Security in case of vulnerabilities.
+# e.g. Added
+
+#___PROJECT___
+# - Patternlab
+# - React
+# - Docs
+# e.g. React
+# e.g. React, Patternlab
+
+#___COMPONENT___
+# Component name(s) in `PascalCase`
+# e.g. Header
+# e.g. Form, InputSlider, InputTextTypeAhead
+
+#___DESCRIPTION___
+# PR description and PR number (append PR number with # to create a link to the PR in Github)
+# If you need multiple lines, start the first line with the following "|-" characters.
+# For any breaking changes, add a comment in the PR describing the necessary changes on the consumer side and link that comment in the description.
+#e.g. Adds apples to apple trees for admin apple pickers (#PR)
+
+#___ISSUE___
+# A Jira ticket or a Github issue number (append Github issue number with # to create a link to the issue in Github)
+# e.g. DP-12345 or #123
+
+#___IMPACT___
+# - Major impact when you make incompatible API changes,
+# - Minor impact when you add functionality in a backwards compatible manner, and
+# - Patch impact when you make backwards compatible bug fixes.
+# e.g. Minor
+# See https://semver.org/ for more info.
+
+
+#___TEMPLATE___
+# ChangeType [enter a valid option, see __CHANGE TYPES___ e.g. Added]:
+#  - project: Enter one or multiple (comma separated) valid project prefix(es) - see ___PROJECT___ e.g. React, Patternlab
+#    component: Enter one or multiple (comma separated) valid component name(s) - see ___COMPONENT___ e.g. Color
+#    description: Describe the change and add the PR number. see ___DESCRIPTION___ e.g. Adds apples to apple trees for admin apple pickers (#PR)
+#    issue: Add a Jira ticket or issue number, e.g. DP-12345 or 124
+#    impact: Enter a valid impact, e.g. Minor
+
+#___EXAMPLE___
+Changed:
+  - project: Patternlab
+    component: Popover
+    description: Change template to remove whitespace from markup (#1980)
+    issue: DP-39184
+    impact: Minor

--- a/packages/patternlab/styleguide/source/_patterns/02-molecules/popover.twig
+++ b/packages/patternlab/styleguide/source/_patterns/02-molecules/popover.twig
@@ -9,16 +9,18 @@
  #
  # Additionally, we add tabindex="-1" to the dialog element to catch focus if
  # users interact with the popover content, preventing it from closing on 'focusout'
+ #
+ # To prevent extra spaces from appearing around the popover, also need to collapse all whitespace, hence the set-blocks.
  #}
-<span class="popover">
-  <button type="button" class="popover__trigger js-popover-trigger">{{tooltip.openText}}</button>
-  <span role="dialog" id="popover-{{ tooltip.controlId }}" aria-labelledby="popover-{{ tooltip.controlId }}-label" aria-modal="true" class="popover__dialog js-popover-dialog" tabindex="-1">
-    <button type="button" class="popover__close js-popover-close" aria-label="{{ tooltip.closeText }}">{{icon('close')}}</button>
-    {% if tooltip.title %}
-      {% set headingLevel = tooltip.level ? : 2 %}
-      <span role="heading" aria-level="{{ headingLevel }}" class="popover__title" id="popover-{{ tooltip.controlId }}-label">{{ tooltip.title }}</span>
-    {% endif %}
-    <span class="popover__body">{{ tooltip.message }}</span>
-  </span>
-  <span class="popover__caret"></span>
-</span>
+
+{% set trigger %}<button type="button" class="popover__trigger js-popover-trigger">{{tooltip.openText}}</button>{% endset %}
+
+{% set dialog_opentag %}<span role="dialog" id="popover-{{ tooltip.controlId }}" aria-labelledby="popover-{{ tooltip.controlId }}-label" aria-modal="true" class="popover__dialog js-popover-dialog" tabindex="-1">{% endset %}
+{% set dialog_close %}<button type="button" class="popover__close js-popover-close" aria-label="{{ tooltip.closeText }}">{{icon('close')}}</button>{% endset %}
+{% set dialog_title %}<span role="heading" aria-level="{{ headingLevel ?: 2 }}" class="popover__title" id="popover-{{ tooltip.controlId }}-label">{{ tooltip.title }}</span>{% endset %}
+{% set dialog_body %}<span class="popover__body">{{ tooltip.message }}</span>{% endset %}
+{% set dialog_closetag %}</span>{% endset %}
+{% set dialog_carat %}<span class="popover__caret"></span>{% endset %}
+
+{% set dialog %}{{ dialog_opentag }}{{ dialog_close }}{{ dialog_title }}{{ dialog_body }}{{ dialog_closetag }}{{ dialog_carat }}{% endset %}
+<span class="popover">{{trigger}}{{dialog}}</span>


### PR DESCRIPTION
## Description
Refactors the poppover component's markup to eliminate whitespace

## Related Issue / Ticket

- [JIRA issue](https://massgov.atlassian.net/browse/DP-39184)

#### Today I learned...
`{% spaceless %}` has been removed from twig and the `|spaceless` filter is also deprecated.