### PR TITLE
DP-43205-Change-hidden-H3-to-H2-with-video-in-header

### DIFF
--- a/changelogs/DP-43205.yml
+++ b/changelogs/DP-43205.yml
@@ -1,0 +1,7 @@
+Changed:
+  - project: Patternlab
+    component: Video
+    description: Change default video title heading level from h3 to h2 for improved accessibility.
+    issue: DP-43205
+    impact: Patch
+

--- a/packages/patternlab/styleguide/source/_patterns/01-atoms/09-media/video.json
+++ b/packages/patternlab/styleguide/source/_patterns/01-atoms/09-media/video.json
@@ -12,6 +12,6 @@
       "property": ""
     },
     "position": "",
-    "headingLevel": "3"
+    "headingLevel": "2"
   }
 }

--- a/packages/patternlab/styleguide/source/_patterns/01-atoms/09-media/video.twig
+++ b/packages/patternlab/styleguide/source/_patterns/01-atoms/09-media/video.twig
@@ -1,5 +1,5 @@
 {% set posClass = video.position ? "ma__video--" ~ video.position : '' %}
-{% set headingLevel = video.headingLevel? : 3 %}
+{% set headingLevel = video.headingLevel? : 2 %}
 {% set skiplinkId = "video-" ~ random(9999) %}
 
 

--- a/packages/patternlab/styleguide/source/_patterns/01-atoms/09-media/video~as-floated-right.json
+++ b/packages/patternlab/styleguide/source/_patterns/01-atoms/09-media/video~as-floated-right.json
@@ -11,6 +11,6 @@
       "property": ""
     },
     "position": "right",
-    "headingLevel": "3"
+    "headingLevel": "2"
   }
 }


### PR DESCRIPTION
## Description
Change default video title heading level from h3 to h2 for improved accessibility.

## Related Issue / Ticket

- [JIRA issue](https://massgov.atlassian.net/browse/DP-43205)
