### PR TITLE
DP-46503-Print-styles-batch-3-follow-up-fix

### DIFF
--- a/changelogs/DP-46503.yml
+++ b/changelogs/DP-46503.yml
@@ -1,0 +1,7 @@
+Changed:
+  - project: Assets
+    component: PrintStyles
+    description: Hide virtual assistant widget and floating action button in print styles.
+    issue: DP-46503
+    impact: Patch
+

--- a/packages/assets/scss/08-print/_print.scss
+++ b/packages/assets/scss/08-print/_print.scss
@@ -18,6 +18,7 @@
   }
 
   /* Print typography - spacing and weight (no font-size changes) */
+
   h1,
   .ma__page-header__title,
   .ma__comp-heading--h1 {
@@ -96,6 +97,7 @@
   }
 
   /* Colored header from left - no indent, dark text in print */
+
   .ma__colored-header-from-left,
   .ma__colored-header-from-left__title {
     margin-left: 0 !important;
@@ -158,13 +160,14 @@
   .ma__fixed-feedback-button,
   #gtm-loginto, // contextual login buttons
   #specto-widget-root, // chatbot region
-  massgov-virtual-assistant-widget,
+  #massgov-virtual-assistant-widget,
   #massgov-virtual-assistant-floating-action-button,
   .ma__sticky-toc__stuck {
     display: none !important;
   }
 
   /* Show table of contents overlay for print (law library/binder pages) */
+
   .ma__toc--overlay {
     display: block !important;
     position: static !important;
@@ -182,6 +185,7 @@
   }
 
   /* Hide icons/SVG in print - avoid empty space (not [class*="icon"] - too broad, hides social links etc.) */
+
   svg,
   .icon,
   .ma__icon,
@@ -190,6 +194,7 @@
   }
 
   /* Remove icon spacing so no gap where icon was */
+
   .ma__icon + span,
   span + .ma__icon,
   .icon + span,
@@ -463,7 +468,9 @@
   }
 
   /* Callout links three-up: collapse card padding/gaps in print */
+
   .ma__callout-links-three-up__heading {
+
     h3 {
       margin-top: 0 !important;
       margin-bottom: 0 !important;
@@ -480,6 +487,7 @@
   }
 
   .ma__callout-links-three-up {
+
     .ma__callout-link__container {
       padding-right: 0 !important;
     }
@@ -734,6 +742,7 @@
 
   /* Best practice: hide embedded iframes in print.
      Cross-origin iframe content is rendered inconsistently by browsers (blank gaps/cut-off). */
+
   .ma__form-requirements + .ma__iframe {
     display: none !important;
   }


### PR DESCRIPTION
Fixed SCSS lint issues in scss/08-print/_print.scss:
added missing empty lines before rules to satisfy rule-empty-line-before
addressed unknown selector warning for massgov-virtual-assistant-widget