### PR TITLE
DP-46555-Pagination-on-Past-Events-Org-Page-returns-to-first-page-instead-of-advancing

### DIFF
--- a/changelogs/DP-46555.yml
+++ b/changelogs/DP-46555.yml
@@ -1,0 +1,6 @@
+Changed:
+  - project: Patternlab
+    component: EventListingInteractive
+    description: Fix results heading initialization so past-events pagination works without JavaScript errors.
+    issue: DP-46555
+    impact: Patch

--- a/packages/patternlab/styleguide/source/assets/js/helpers/listing.js
+++ b/packages/patternlab/styleguide/source/assets/js/helpers/listing.js
@@ -66,7 +66,8 @@ export default (function(window, document, undefined, $, moment){
    */
   function transformPaginationData(args) {
     let data = args.data;
-    let targetPage = args.targetPage ? args.targetPage : 1; // default to first page if none passed
+    let rawTargetPage = Number(args.targetPage);
+    let targetPage = Number.isFinite(rawTargetPage) ? rawTargetPage : 1; // default to first page if none passed
     let totalPages = data.totalPages;
     let pages = [];
 
@@ -110,9 +111,13 @@ export default (function(window, document, undefined, $, moment){
   function transformResultsHeading(args) {
     let pageTotal = 0,
         totalActive = 0,
-        page = args.page ? args.page : 1,
+        page = Number.isFinite(Number(args.page)) ? Number(args.page) : 1,
         data = args.data,
-        resultsHeading = data.resultsHeading; // preserve active resultsHeading.tags
+        resultsHeading = data.resultsHeading ? data.resultsHeading : {}; // preserve active resultsHeading.tags
+
+    if (!Array.isArray(resultsHeading.tags)) {
+      resultsHeading.tags = [];
+    }
 
     // Tally the total active and page length.
     data.items.map(function(item){

--- a/packages/patternlab/styleguide/source/assets/js/modules/eventListingInteractive.js
+++ b/packages/patternlab/styleguide/source/assets/js/modules/eventListingInteractive.js
@@ -60,6 +60,9 @@ export default (function (window,document,$,undefined) {
     function handlePagination (e, target) {
       "use strict";
       let nextPage = parseInt(target, 10);
+      if (!Number.isFinite(nextPage)) {
+        nextPage = 1;
+      }
 
       masterData.pagination = listings.transformPaginationData({ data: masterData, targetPage: nextPage });
       masterData.resultsHeading = listings.transformResultsHeading({ data: masterData, page: nextPage });
@@ -74,9 +77,11 @@ export default (function (window,document,$,undefined) {
     if (history.state) {
       defaultPage = history.state.page;
     }
-    if (params) {
-      defaultPage = params.get("page");
+    else if (params.has("_page")) {
+      // Drupal query pager is 0-based, component pages are 1-based.
+      defaultPage = parseInt(params.get("_page"), 10) + 1;
     }
+    defaultPage = Number.isFinite(Number(defaultPage)) ? Number(defaultPage) : 1;
     handlePagination(null, defaultPage);
 
 
@@ -139,7 +144,10 @@ export default (function (window,document,$,undefined) {
       masterData.maxItems = listing.maxItems ? listing.maxItems : masterListing.length;
 
       // The initial results heading data structure
-      masterData.resultsHeading = masterListingMarkup.resultsHeading;
+      masterData.resultsHeading = listing.resultsHeading ? listing.resultsHeading : {};
+      if (!Array.isArray(masterData.resultsHeading.tags)) {
+        masterData.resultsHeading.tags = [];
+      }
 
       // Create items with listing and markup.
       masterData.items = getMasterListingWithMarkup(masterListing, masterListingMarkup, masterData.maxItems);

--- a/packages/patternlab/styleguide/source/assets/js/modules/pagination.js
+++ b/packages/patternlab/styleguide/source/assets/js/modules/pagination.js
@@ -17,24 +17,36 @@ export default (function (window, document, $, undefined) {
     if (history.state && history.state.page) {
       targetPageNumber = history.state.page;
     } else if (params.has('_page')) {
-      targetPageNumber = params.get('_page');
+      // Drupal query pager is 0-based, component pages are 1-based.
+      targetPageNumber = parseInt(params.get('_page'), 10) + 1;
     }
+    targetPageNumber = Number.isFinite(Number(targetPageNumber)) ? Number(targetPageNumber) : 1;
 
     // Listen for previous page button click and trigger pagination event.
-    $el.on('click', prevButton, function () {
+    $el.on('click', prevButton, function (e) {
+      e.preventDefault();
+      if ($(e.currentTarget).hasClass('disabled')) {
+        return;
+      }
       targetPageNumber = parseInt(targetPageNumber) - 1;
       pushPaginationState(targetPageNumber);
       $el.trigger('ma:Pagination:Pagination', [history.state.page]);
     });
     // Listen for next button click and trigger pagination event.
-    $el.on('click', nextButton, function () {
+    $el.on('click', nextButton, function (e) {
+      e.preventDefault();
+      if ($(e.currentTarget).hasClass('disabled')) {
+        return;
+      }
       targetPageNumber = parseInt(targetPageNumber) + 1;
       pushPaginationState(targetPageNumber);
       $el.trigger('ma:Pagination:Pagination', [history.state.page]);
     });
     // Listen for page number button click and trigger pagination event;
     $el.on('click', pageButton, function (e) {
-      targetPageNumber = $(e.target).data('page');
+      e.preventDefault();
+      targetPageNumber = $(e.target).closest(pageButton).data('page');
+      targetPageNumber = Number.isFinite(Number(targetPageNumber)) ? Number(targetPageNumber) : 1;
       pushPaginationState(targetPageNumber);
       $el.trigger('ma:Pagination:Pagination', [history.state.page]);
     });
@@ -147,19 +159,20 @@ export default (function (window, document, $, undefined) {
   }
 
   function pushPaginationState(pageNum, replace = false) {
+    let targetPage = Number.isFinite(Number(pageNum)) ? Number(pageNum) : 1;
     let params = new URLSearchParams(window.location.search);
-    params.set('_page', pageNum);
+    params.set('_page', targetPage - 1);
 
     if (replace) {
       history.replaceState(
-        { page: pageNum },
-        `${document.title} | page ${pageNum}`, `${window.location.origin}${window.location.pathname}?${params.toString()}`
+        { page: targetPage },
+        `${document.title} | page ${targetPage}`, `${window.location.origin}${window.location.pathname}?${params.toString()}`
       );
     }
     else {
       history.pushState(
-        { page: pageNum },
-        `${document.title} | page ${pageNum}`, `${window.location.origin}${window.location.pathname}?${params.toString()}`
+        { page: targetPage },
+        `${document.title} | page ${targetPage}`, `${window.location.origin}${window.location.pathname}?${params.toString()}`
       );
     }
   }


### PR DESCRIPTION
Fix results heading initialization so past events pagination works without JavaScript errors.