### PR TITLE
DP-46555-Pagination-on-Past-Events-Org-Page-returns-to-first-page-instead-of-advancing

### DIFF
--- a/changelogs/DP-46555.yml
+++ b/changelogs/DP-46555.yml
@@ -1,0 +1,6 @@
+Fixed:
+  - project: Patternlab
+    component: EventListingInteractive
+    description: Restore initial resultsHeading from listing data; transformListing output does not include resultsHeading (potentially regression from DP-39285).
+    issue: DP-46555
+    impact: Patch

--- a/changelogs/DP-46555.yml
+++ b/changelogs/DP-46555.yml
@@ -1,6 +1,6 @@
 Fixed:
   - project: Patternlab
     component: EventListingInteractive
-    description: Restore initial resultsHeading from listing data; transformListing output does not include resultsHeading (potentially regression from DP-39285).
+    description: Moved pagination/results heading updates to JS and reverted the DP-39285 regression.
     issue: DP-46555
     impact: Patch

--- a/packages/patternlab/styleguide/source/assets/js/modules/eventListingInteractive.js
+++ b/packages/patternlab/styleguide/source/assets/js/modules/eventListingInteractive.js
@@ -60,9 +60,6 @@ export default (function (window,document,$,undefined) {
     function handlePagination (e, target) {
       "use strict";
       let nextPage = parseInt(target, 10);
-      if (!Number.isFinite(nextPage) || nextPage < 1) {
-        nextPage = 1;
-      }
 
       masterData.pagination = listings.transformPaginationData({ data: masterData, targetPage: nextPage });
       masterData.resultsHeading = listings.transformResultsHeading({ data: masterData, page: nextPage });
@@ -74,11 +71,11 @@ export default (function (window,document,$,undefined) {
     $pagination.on('ma:Pagination:Pagination', handlePagination);
     let defaultPage = 1;
     let params = new URLSearchParams(window.location.search);
-    if (history.state && history.state.page) {
+    if (history.state) {
       defaultPage = history.state.page;
     }
-    if (params.has("_page")) {
-      defaultPage = params.get("_page");
+    if (params) {
+      defaultPage = params.get("page");
     }
     handlePagination(null, defaultPage);
 

--- a/packages/patternlab/styleguide/source/assets/js/modules/eventListingInteractive.js
+++ b/packages/patternlab/styleguide/source/assets/js/modules/eventListingInteractive.js
@@ -60,6 +60,9 @@ export default (function (window,document,$,undefined) {
     function handlePagination (e, target) {
       "use strict";
       let nextPage = parseInt(target, 10);
+      if (!Number.isFinite(nextPage) || nextPage < 1) {
+        nextPage = 1;
+      }
 
       masterData.pagination = listings.transformPaginationData({ data: masterData, targetPage: nextPage });
       masterData.resultsHeading = listings.transformResultsHeading({ data: masterData, page: nextPage });
@@ -71,11 +74,11 @@ export default (function (window,document,$,undefined) {
     $pagination.on('ma:Pagination:Pagination', handlePagination);
     let defaultPage = 1;
     let params = new URLSearchParams(window.location.search);
-    if (history.state) {
+    if (history.state && history.state.page) {
       defaultPage = history.state.page;
     }
-    if (params) {
-      defaultPage = params.get("page");
+    if (params.has("_page")) {
+      defaultPage = params.get("_page");
     }
     handlePagination(null, defaultPage);
 

--- a/packages/patternlab/styleguide/source/assets/js/modules/eventListingInteractive.js
+++ b/packages/patternlab/styleguide/source/assets/js/modules/eventListingInteractive.js
@@ -60,6 +60,9 @@ export default (function (window,document,$,undefined) {
     function handlePagination (e, target) {
       "use strict";
       let nextPage = parseInt(target, 10);
+      if (!Number.isFinite(nextPage) || nextPage < 1) {
+        nextPage = 1;
+      }
 
       masterData.pagination = listings.transformPaginationData({ data: masterData, targetPage: nextPage });
       masterData.resultsHeading = listings.transformResultsHeading({ data: masterData, page: nextPage });
@@ -74,8 +77,8 @@ export default (function (window,document,$,undefined) {
     if (history.state) {
       defaultPage = history.state.page;
     }
-    if (params) {
-      defaultPage = params.get("page");
+    if (params && params.has("_page")) {
+      defaultPage = params.get("_page");
     }
     handlePagination(null, defaultPage);
 

--- a/packages/patternlab/styleguide/source/assets/js/modules/eventListingInteractive.js
+++ b/packages/patternlab/styleguide/source/assets/js/modules/eventListingInteractive.js
@@ -133,13 +133,13 @@ export default (function (window,document,$,undefined) {
       let masterListing = listing.eventListing.events,
 
       // Pass in listing and template name.
-      masterListingMarkup = listings.transformListing(masterListing, 'eventListingRow', {bustCache: 'icon-update-2025'});
+      masterListingMarkup = listings.transformListing(masterListing, 'eventListingRow');
 
       // The max number of items per page, if designated in eventListing data structure, else all
       masterData.maxItems = listing.maxItems ? listing.maxItems : masterListing.length;
 
       // The initial results heading data structure
-      masterData.resultsHeading = masterListingMarkup.resultsHeading;
+      masterData.resultsHeading = listing.resultsHeading;
 
       // Create items with listing and markup.
       masterData.items = getMasterListingWithMarkup(masterListing, masterListingMarkup, masterData.maxItems);

--- a/packages/patternlab/styleguide/source/assets/js/modules/pagination.js
+++ b/packages/patternlab/styleguide/source/assets/js/modules/pagination.js
@@ -17,22 +17,23 @@ export default (function (window, document, $, undefined) {
     } else if (params.has('_page')) {
       targetPageNumber = params.get('_page');
     }
+    targetPageNumber = normalizePageNumber(targetPageNumber);
 
     // Listen for previous page button click and trigger pagination event.
     $el.on('click', prevButton, function () {
-      targetPageNumber = parseInt(targetPageNumber) - 1;
+      targetPageNumber = normalizePageNumber(targetPageNumber) - 1;
       pushPaginationState(targetPageNumber);
       $el.trigger('ma:Pagination:Pagination', [history.state.page]);
     });
     // Listen for next button click and trigger pagination event.
     $el.on('click', nextButton, function () {
-      targetPageNumber = parseInt(targetPageNumber) + 1;
+      targetPageNumber = normalizePageNumber(targetPageNumber) + 1;
       pushPaginationState(targetPageNumber);
       $el.trigger('ma:Pagination:Pagination', [history.state.page]);
     });
     // Listen for page number button click and trigger pagination event;
     $el.on('click', pageButton, function (e) {
-      targetPageNumber = $(e.target).data('page');
+      targetPageNumber = normalizePageNumber($(e.target).data('page'));
       pushPaginationState(targetPageNumber);
       $el.trigger('ma:Pagination:Pagination', [history.state.page]);
     });
@@ -40,7 +41,7 @@ export default (function (window, document, $, undefined) {
     window.onpopstate = function (e) {
       if (e.state) {
         if (e.state.page) {
-          $el.trigger("ma:Pagination:Pagination", [e.state.page]);
+          $el.trigger("ma:Pagination:Pagination", [normalizePageNumber(e.state.page)]);
         }
       }
     };
@@ -183,6 +184,7 @@ export default (function (window, document, $, undefined) {
   }
 
   function pushPaginationState(pageNum, replace = false) {
+    pageNum = normalizePageNumber(pageNum);
     let params = new URLSearchParams(window.location.search);
     params.set('_page', pageNum);
 
@@ -198,6 +200,11 @@ export default (function (window, document, $, undefined) {
         `${document.title} | page ${pageNum}`, `${window.location.origin}${window.location.pathname}?${params.toString()}`
       );
     }
+  }
+
+  function normalizePageNumber(pageNum) {
+    let parsed = parseInt(pageNum, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 1;
   }
 
 })(window, document, jQuery);

--- a/packages/patternlab/styleguide/source/assets/js/modules/pagination.js
+++ b/packages/patternlab/styleguide/source/assets/js/modules/pagination.js
@@ -1,5 +1,3 @@
-import twiggy from '../helpers/twiggy';
-
 export default (function (window, document, $, undefined) {
   if ($('.js-pagination').length === 0) {
     return;
@@ -70,23 +68,53 @@ export default (function (window, document, $, undefined) {
       return;
     }
 
-    // Render async with Twig.
-    return twiggy('@molecules/pagination.twig')
-      .then(template => {
-        // Truncate the pagination with ellipsis to prevent it from showing
-        // all page numbers if there are a lot.
-        let pagination = truncatePaginationDisplay(args.data);
-        // Render the pagination Twig async.
-        return template.renderAsync({ pagination: pagination });
-      })
-      .then(markup => {
-        // twiggy is appending the entire pagiantion.twig template
-        // to itself, causing a double .ma__pagination wrapper
-        // unwrappedMarkup is the markup unwrapped and still contains the 
-        // original handlers 
-        const unwrapperMarkup = $($.parseHTML(markup)).html();
-        args.$el.html(unwrapperMarkup);
-      });
+    // Truncate the pagination with ellipsis to prevent it from showing
+    // all page numbers if there are a lot.
+    let pagination = truncatePaginationDisplay(args.data);
+    const $container = $('<nav class="ma__pagination__container" aria-label="Pagination Navigation"></nav>');
+    const $prev = $('<a class="ma__pagination__prev js-pagination-prev" role="button" href="#"></a>')
+      .text(String(pagination.prev.text));
+    if (pagination.prev.disabled) {
+      $prev.addClass('disabled').attr('aria-disabled', 'true');
+    }
+    else {
+      $prev.attr('aria-label', `Go to ${String(pagination.prev.text)} page`);
+    }
+    $container.append($prev);
+
+    pagination.pages.forEach(function(page) {
+      if (page.text === "spacer") {
+        $container.append('<span class="ma__pagination__spacer">&hellip;</span>');
+        return;
+      }
+
+      const pageText = String(page.text);
+      const $page = $('<a class="ma__pagination__page js-pagination-page" href="#" role="button"></a>')
+        .text(pageText)
+        .attr('data-page', pageText);
+
+      if (page.active) {
+        $page
+          .addClass('is-active')
+          .attr('aria-label', `Currently on Page ${pageText}`);
+      }
+      else {
+        $page.attr('aria-label', `Go to Page ${pageText}`);
+      }
+      $container.append($page);
+    });
+
+    const $next = $('<a class="ma__pagination__next js-pagination-next" role="button" href="#"></a>')
+      .text(String(pagination.next.text));
+    if (pagination.next.disabled) {
+      $next.addClass('disabled').attr('aria-disabled', 'true');
+    }
+    else {
+      $next.attr('aria-label', `Go to ${String(pagination.next.text)} page`);
+    }
+    $container.append($next);
+
+    args.$el.empty().append($container);
   }
 
   /**

--- a/packages/patternlab/styleguide/source/assets/js/modules/pagination.js
+++ b/packages/patternlab/styleguide/source/assets/js/modules/pagination.js
@@ -72,15 +72,12 @@ export default (function (window, document, $, undefined) {
     // all page numbers if there are a lot.
     let pagination = truncatePaginationDisplay(args.data);
     const $container = $('<nav class="ma__pagination__container" aria-label="Pagination Navigation"></nav>');
-    const $prev = $('<a class="ma__pagination__prev js-pagination-prev" role="button" href="#"></a>')
-      .text(String(pagination.prev.text));
-    if (pagination.prev.disabled) {
-      $prev.addClass('disabled').attr('aria-disabled', 'true');
-    }
-    else {
-      $prev.attr('aria-label', `Go to ${String(pagination.prev.text)} page`);
-    }
-    $container.append($prev);
+    $container.append(buildPaginationLink({
+      className: 'ma__pagination__prev js-pagination-prev',
+      text: pagination.prev.text,
+      disabled: pagination.prev.disabled,
+      ariaLabel: `Go to ${String(pagination.prev.text)} page`
+    }));
 
     pagination.pages.forEach(function(page) {
       if (page.text === "spacer") {
@@ -89,32 +86,43 @@ export default (function (window, document, $, undefined) {
       }
 
       const pageText = String(page.text);
-      const $page = $('<a class="ma__pagination__page js-pagination-page" href="#" role="button"></a>')
-        .text(pageText)
-        .attr('data-page', pageText);
-
-      if (page.active) {
-        $page
-          .addClass('is-active')
-          .attr('aria-label', `Currently on Page ${pageText}`);
-      }
-      else {
-        $page.attr('aria-label', `Go to Page ${pageText}`);
-      }
-      $container.append($page);
+      $container.append(buildPaginationLink({
+        className: 'ma__pagination__page js-pagination-page',
+        text: pageText,
+        isActive: page.active,
+        dataPage: pageText,
+        ariaLabel: page.active ? `Currently on Page ${pageText}` : `Go to Page ${pageText}`
+      }));
     });
 
-    const $next = $('<a class="ma__pagination__next js-pagination-next" role="button" href="#"></a>')
-      .text(String(pagination.next.text));
-    if (pagination.next.disabled) {
-      $next.addClass('disabled').attr('aria-disabled', 'true');
-    }
-    else {
-      $next.attr('aria-label', `Go to ${String(pagination.next.text)} page`);
-    }
-    $container.append($next);
+    $container.append(buildPaginationLink({
+      className: 'ma__pagination__next js-pagination-next',
+      text: pagination.next.text,
+      disabled: pagination.next.disabled,
+      ariaLabel: `Go to ${String(pagination.next.text)} page`
+    }));
 
     args.$el.empty().append($container);
+  }
+
+  function buildPaginationLink(args) {
+    const $link = $('<a role="button" href="#"></a>')
+      .addClass(args.className)
+      .text(String(args.text));
+
+    if (args.dataPage) {
+      $link.attr('data-page', args.dataPage);
+    }
+    if (args.isActive) {
+      $link.addClass('is-active');
+    }
+    if (args.disabled) {
+      $link.attr('aria-disabled', 'true').addClass('disabled');
+    }
+    else {
+      $link.attr('aria-label', args.ariaLabel);
+    }
+    return $link;
   }
 
   /**

--- a/packages/patternlab/styleguide/source/assets/js/modules/resultsHeading.js
+++ b/packages/patternlab/styleguide/source/assets/js/modules/resultsHeading.js
@@ -1,5 +1,3 @@
-import twiggy from '../helpers/twiggy';
-
 export default (function (window,document,$,undefined) {
   // Set up global component config
   let  clearAllButton = '.js-results-heading-clear', // events triggered on parent
@@ -43,10 +41,55 @@ export default (function (window,document,$,undefined) {
     if (!args.data) {
       return;
     }
-    // Asynchronously render via TwigJS.
-    twiggy('@molecules/results-heading.twig')
-        .then(t => t.renderAsync({resultsHeading: args.data}))
-        .then(markup => args.$el.html($(markup).children()))
+    const heading = args.data;
+    const hasTags = Array.isArray(heading.tags) && heading.tags.length > 0;
+    const $container = $('<div class="ma__results-heading__container"></div>');
+    const $title = $('<div class="ma__results-heading__title" role="status"></div>');
+
+    let titleText = `Showing ${String(heading.numResults || "0 - 0")}`;
+    if (heading.totalResults) {
+      titleText += ` of ${String(heading.totalResults)}`;
+    }
+    titleText += " results";
+    if (hasTags) {
+      titleText += "for:";
+    }
+    $title.text(titleText);
+
+    if (heading.subject) {
+      $title.append($('<span class="ma__visually-hidden"></span>').text(` for ${String(heading.subject)}`));
+    }
+    $container.append($title);
+
+    if (hasTags) {
+      const $tags = $('<fieldset class="ma__results-heading__tags"></fieldset>');
+      $tags.append('<legend class="ma__visually-hidden">Clear the active filters with the following buttons.</legend>');
+
+      heading.tags.forEach(function(tag) {
+        const $button = $('<button type="button" class="ma__results-heading__tag js-results-heading-tag"></button>')
+          .text(String(tag.text || ""));
+        if (tag.type) {
+          $button.attr('data-ma-filter-type', String(tag.type));
+        }
+        if (tag.value) {
+          $button.attr('data-ma-filter-value', String(tag.value));
+        }
+        $tags.append($button);
+      });
+
+      $tags.append('<button type="button" class="ma__results-heading__clear js-results-heading-clear">Clear all</button>');
+      $container.append($tags);
+    }
+
+    if (heading.sortResults) {
+      // Preserve the existing sort results subtree if this listing includes it.
+      const $existingSort = args.$el.find(".ma__results-heading__sort").first();
+      if ($existingSort.length) {
+        $container.append($('<div class="ma__results-heading__sort"></div>').html($existingSort.html()));
+      }
+    }
+
+    args.$el.empty().append($container);
   }
 
 })(window,document,jQuery);

--- a/packages/patternlab/styleguide/source/assets/js/modules/resultsHeading.js
+++ b/packages/patternlab/styleguide/source/assets/js/modules/resultsHeading.js
@@ -44,41 +44,10 @@ export default (function (window,document,$,undefined) {
     const heading = args.data;
     const hasTags = Array.isArray(heading.tags) && heading.tags.length > 0;
     const $container = $('<div class="ma__results-heading__container"></div>');
-    const $title = $('<div class="ma__results-heading__title" role="status"></div>');
-
-    let titleText = `Showing ${String(heading.numResults || "0 - 0")}`;
-    if (heading.totalResults) {
-      titleText += ` of ${String(heading.totalResults)}`;
-    }
-    titleText += " results";
-    if (hasTags) {
-      titleText += "for:";
-    }
-    $title.text(titleText);
-
-    if (heading.subject) {
-      $title.append($('<span class="ma__visually-hidden"></span>').text(` for ${String(heading.subject)}`));
-    }
-    $container.append($title);
+    $container.append(buildTitle(heading, hasTags));
 
     if (hasTags) {
-      const $tags = $('<fieldset class="ma__results-heading__tags"></fieldset>');
-      $tags.append('<legend class="ma__visually-hidden">Clear the active filters with the following buttons.</legend>');
-
-      heading.tags.forEach(function(tag) {
-        const $button = $('<button type="button" class="ma__results-heading__tag js-results-heading-tag"></button>')
-          .text(String(tag.text || ""));
-        if (tag.type) {
-          $button.attr('data-ma-filter-type', String(tag.type));
-        }
-        if (tag.value) {
-          $button.attr('data-ma-filter-value', String(tag.value));
-        }
-        $tags.append($button);
-      });
-
-      $tags.append('<button type="button" class="ma__results-heading__clear js-results-heading-clear">Clear all</button>');
-      $container.append($tags);
+      $container.append(buildTags(heading.tags));
     }
 
     if (heading.sortResults) {
@@ -90,6 +59,40 @@ export default (function (window,document,$,undefined) {
     }
 
     args.$el.empty().append($container);
+  }
+
+  function buildTitle(heading, hasTags) {
+    let titleText = `Showing ${String(heading.numResults || "0 - 0")}`;
+    if (heading.totalResults) {
+      titleText += ` of ${String(heading.totalResults)}`;
+    }
+    titleText += hasTags ? " results for:" : " results";
+
+    const $title = $('<div class="ma__results-heading__title" role="status"></div>')
+      .text(titleText);
+    if (heading.subject) {
+      $title.append($('<span class="ma__visually-hidden"></span>').text(` for ${String(heading.subject)}`));
+    }
+    return $title;
+  }
+
+  function buildTags(tags) {
+    const $tags = $('<fieldset class="ma__results-heading__tags"></fieldset>')
+      .append('<legend class="ma__visually-hidden">Clear the active filters with the following buttons.</legend>');
+
+    tags.forEach(function(tag) {
+      const $button = $('<button type="button" class="ma__results-heading__tag js-results-heading-tag"></button>')
+        .text(String(tag.text || ""));
+      if (tag.type) {
+        $button.attr('data-ma-filter-type', String(tag.type));
+      }
+      if (tag.value) {
+        $button.attr('data-ma-filter-value', String(tag.value));
+      }
+      $tags.append($button);
+    });
+
+    return $tags.append('<button type="button" class="ma__results-heading__clear js-results-heading-clear">Clear all</button>');
   }
 
 })(window,document,jQuery);


### PR DESCRIPTION
- Reverted the pagination regression in interactive event listings so page navigation advances correctly.
- Updated event listing pagination/results-heading JS so first load and pagination-click states stay in sync.
- Replaced runtime Twig fetch usage in the affected event listing interactions with direct DOM updates to avoid 403 failures from protected .twig paths.
- Normalized pagination page handling (_page) to keep state predictable across direct loads and navigation.

Openmass PR: https://github.com/massgov/openmass/pull/3355