### PR TITLE
DP-46593-Blue-focus-borders-on-blue-site-banner-on-safari

### DIFF
--- a/changelogs/DP-46593.yml
+++ b/changelogs/DP-46593.yml
@@ -1,0 +1,6 @@
+Fixed:
+  - project: Assets
+    component: BrandBanner
+    description: Set a white focus outline on site banner to improve focus visibility in Safari.
+    issue: DP-46593
+    impact: Patch

--- a/changelogs/DP-46593.yml
+++ b/changelogs/DP-46593.yml
@@ -1,6 +1,6 @@
 Fixed:
   - project: Assets
-    component: BrandBanner
-    description: Set a white focus outline on site banner to improve focus visibility in Safari.
+    component: BrandBanner, Header, UtilityNav
+    description: Use MDS focus token on dark header surfaces with :focus-visible for keyboard focus.
     issue: DP-46593
     impact: Patch

--- a/packages/assets/scss/00-base/_design-tokens.scss
+++ b/packages/assets/scss/00-base/_design-tokens.scss
@@ -2,5 +2,7 @@
 
 // Load tracked CSS token sources into the Sass build so components can
 // reference the variables at runtime via var(--mds-*).
+
 @include meta.load-css("../tokens/primitives.css");
+
 @include meta.load-css("../tokens/index.css");

--- a/packages/assets/scss/02-molecules/_brand-banner.scss
+++ b/packages/assets/scss/02-molecules/_brand-banner.scss
@@ -44,6 +44,20 @@
         }
     }
 
+    // Safari can render a default blue focus ring on dark banner themes.
+    &[class*="-bg-dark"] &-container {
+        .mac-safari & {
+            &:focus,
+            &:focus-visible {
+                outline-style: solid !important;
+                outline-width: 2px !important;
+                outline-color: var(--mf-c-white) !important;
+                outline-offset: 0;
+                box-shadow: none !important;
+            }
+        }
+    }
+
     &-logo {
         height: 20px;
         width: 20px;

--- a/packages/assets/scss/02-molecules/_brand-banner.scss
+++ b/packages/assets/scss/02-molecules/_brand-banner.scss
@@ -44,17 +44,13 @@
         }
     }
 
-    // Safari can render a default blue focus ring on dark banner themes.
     &[class*="-bg-dark"] &-container {
-        .mac-safari & {
-            &:focus,
-            &:focus-visible {
-                outline-style: solid !important;
-                outline-width: 2px !important;
-                outline-color: var(--mf-c-white) !important;
-                outline-offset: 0;
-                box-shadow: none !important;
-            }
+        &:focus-visible {
+            outline-style: solid !important;
+            outline-width: 2px !important;
+            outline-color: var(--mds-border-focus-on-dark) !important;
+            outline-offset: 0;
+            box-shadow: none !important;
         }
     }
 

--- a/packages/assets/scss/02-molecules/_brand-banner.scss
+++ b/packages/assets/scss/02-molecules/_brand-banner.scss
@@ -45,6 +45,7 @@
     }
 
     &[class*="-bg-dark"] &-container {
+
         &:focus-visible {
             outline-style: solid !important;
             outline-width: 2px !important;

--- a/packages/assets/scss/02-molecules/_google-translate.scss
+++ b/packages/assets/scss/02-molecules/_google-translate.scss
@@ -10,6 +10,7 @@ $translate-control-padding-right: 40px;
 
 .translated-ltr,
 .translated-rtl {
+
   body {
     top: 0 !important;
   }
@@ -25,12 +26,14 @@ $translate-control-padding-right: 40px;
 
    NOTE: This is placed at the top of the stylesheet so component-specific
    padding (like buttons) can override it with higher specificity. */
+
 .notranslate {
   padding-left: 0;
   padding-right: 0;
 }
 
 /* Hide default Google Translate widget */
+
 .ma__goog-te-wrapper {
   position: absolute;
   left: -9999px;
@@ -40,6 +43,7 @@ $translate-control-padding-right: 40px;
 }
 
 /* Hide Google Translate elements */
+
 .goog-te-banner-frame.skiptranslate {
   display: none !important;
 }
@@ -57,6 +61,7 @@ body > .skiptranslate {
 }
 
 .ma__translate {
+
   &-container {
     display: flex;
     flex-direction: column;
@@ -151,6 +156,7 @@ body > .skiptranslate {
 }
 
 #ma__translate-help {
+
   p {
     font: var(--mds-text-caption);
     text-align: center;

--- a/packages/assets/scss/03-organisms/_header-hamburger.scss
+++ b/packages/assets/scss/03-organisms/_header-hamburger.scss
@@ -13,6 +13,7 @@ body.show-menu {
 }
 
 body.ma-disable-menu-transition {
+
   .ma__header__hamburger__nav-container,
   .menu-overlay,
   .alert-overlay {

--- a/packages/assets/scss/03-organisms/_header-hamburger.scss
+++ b/packages/assets/scss/03-organisms/_header-hamburger.scss
@@ -295,6 +295,17 @@ body.ma-disable-menu-transition {
 
       padding-left: 20px;
     }
+
+    .mac-safari & {
+      &:focus,
+      &:focus-visible {
+        outline-style: solid !important;
+        outline-width: 2px !important;
+        outline-color: var(--mf-c-white) !important;
+        outline-offset: 0;
+        box-shadow: none !important;
+      }
+    }
   }
 
   &__menu-home-link {
@@ -421,6 +432,17 @@ body.ma-disable-menu-transition {
       width: 20px;
       display: inline-block;
       vertical-align: middle;
+    }
+
+    .mac-safari & {
+      &:focus,
+      &:focus-visible {
+        outline-style: solid !important;
+        outline-width: 2px !important;
+        outline-color: var(--mf-c-white) !important;
+        outline-offset: 0;
+        box-shadow: none !important;
+      }
     }
   }
 

--- a/packages/assets/scss/03-organisms/_header-hamburger.scss
+++ b/packages/assets/scss/03-organisms/_header-hamburger.scss
@@ -296,15 +296,12 @@ body.ma-disable-menu-transition {
       padding-left: 20px;
     }
 
-    .mac-safari & {
-      &:focus,
-      &:focus-visible {
-        outline-style: solid !important;
-        outline-width: 2px !important;
-        outline-color: var(--mf-c-white) !important;
-        outline-offset: 0;
-        box-shadow: none !important;
-      }
+    &:focus-visible {
+      outline-style: solid !important;
+      outline-width: 2px !important;
+      outline-color: var(--mds-border-focus-on-dark) !important;
+      outline-offset: 0;
+      box-shadow: none !important;
     }
   }
 
@@ -434,15 +431,12 @@ body.ma-disable-menu-transition {
       vertical-align: middle;
     }
 
-    .mac-safari & {
-      &:focus,
-      &:focus-visible {
-        outline-style: solid !important;
-        outline-width: 2px !important;
-        outline-color: var(--mf-c-white) !important;
-        outline-offset: 0;
-        box-shadow: none !important;
-      }
+    &:focus-visible {
+      outline-style: solid !important;
+      outline-width: 2px !important;
+      outline-color: var(--mds-border-focus-on-dark) !important;
+      outline-offset: 0;
+      box-shadow: none !important;
     }
   }
 

--- a/packages/assets/scss/03-organisms/_modal.scss
+++ b/packages/assets/scss/03-organisms/_modal.scss
@@ -20,6 +20,7 @@
 }
 
 .ma__modal {
+
   &-overlay {
     position: fixed;
     inset: 0;
@@ -165,6 +166,7 @@ body.ma__modal-open {
 }
 
 @keyframes ma__modal-fade-in {
+
   from {
     opacity: 0;
     transform: scale(0.95);
@@ -177,13 +179,16 @@ body.ma__modal-open {
 }
 
 @media (max-width: 768px), (min-resolution: 150dpi) {
+
   .ma__modal-overlay {
     padding: var(--mds-space-md);
   }
 }
 
 @media (max-width: 600px), (min-resolution: 200dpi) {
+
   .ma__modal {
+
     &-dialog {
       padding: var(--mds-space-lg) var(--mds-space-md);
       overflow-y: auto;

--- a/packages/assets/scss/03-organisms/_utility-nav.scss
+++ b/packages/assets/scss/03-organisms/_utility-nav.scss
@@ -91,6 +91,17 @@ $utility-nav-height: 43px;
       &:hover {
         opacity: .7;
       }
+
+      .mac-safari & {
+        &:focus,
+        &:focus-visible {
+          outline-style: solid !important;
+          outline-width: 2px !important;
+          outline-color: var(--mf-c-white) !important;
+          outline-offset: 0;
+          box-shadow: none !important;
+        }
+      }
     }
 
     &:after {

--- a/packages/assets/scss/03-organisms/_utility-nav.scss
+++ b/packages/assets/scss/03-organisms/_utility-nav.scss
@@ -92,15 +92,12 @@ $utility-nav-height: 43px;
         opacity: .7;
       }
 
-      .mac-safari & {
-        &:focus,
-        &:focus-visible {
-          outline-style: solid !important;
-          outline-width: 2px !important;
-          outline-color: var(--mf-c-white) !important;
-          outline-offset: 0;
-          box-shadow: none !important;
-        }
+      &:focus-visible {
+        outline-style: solid !important;
+        outline-width: 2px !important;
+        outline-color: var(--mds-border-focus-on-dark) !important;
+        outline-offset: 0;
+        box-shadow: none !important;
       }
     }
 

--- a/packages/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
+++ b/packages/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
@@ -17,6 +17,7 @@ function initializeMainNavHamburger() {
   const HEADER_TOGGLE_BREAKPOINT = 940;
   const DISABLE_MENU_TRANSITION_CLASS = "ma-disable-menu-transition";
   const osInfo = navigator.appVersion;
+  const userAgent = navigator.userAgent;
   const body = document.querySelector("body");
   let width = body.clientWidth;
   let alertlOffsetPosition;
@@ -54,6 +55,15 @@ function initializeMainNavHamburger() {
 
   function isHeaderDesktop() {
     return body.clientWidth > HEADER_TOGGLE_BREAKPOINT;
+  }
+
+  const isMacSafari =
+    /Macintosh/.test(userAgent) &&
+    /Safari/.test(userAgent) &&
+    !/Chrome|CriOS|Chromium|Edg|OPR|Firefox|FxiOS/.test(userAgent);
+
+  if (isMacSafari) {
+    body.classList.add("mac-safari");
   }
 
   if (!isMixedHeader && translateModalElements.length > 1) {

--- a/packages/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
+++ b/packages/patternlab/styleguide/source/assets/js/modules/mainNavHamburger.js
@@ -17,7 +17,6 @@ function initializeMainNavHamburger() {
   const HEADER_TOGGLE_BREAKPOINT = 940;
   const DISABLE_MENU_TRANSITION_CLASS = "ma-disable-menu-transition";
   const osInfo = navigator.appVersion;
-  const userAgent = navigator.userAgent;
   const body = document.querySelector("body");
   let width = body.clientWidth;
   let alertlOffsetPosition;
@@ -55,15 +54,6 @@ function initializeMainNavHamburger() {
 
   function isHeaderDesktop() {
     return body.clientWidth > HEADER_TOGGLE_BREAKPOINT;
-  }
-
-  const isMacSafari =
-    /Macintosh/.test(userAgent) &&
-    /Safari/.test(userAgent) &&
-    !/Chrome|CriOS|Chromium|Edg|OPR|Firefox|FxiOS/.test(userAgent);
-
-  if (isMacSafari) {
-    body.classList.add("mac-safari");
   }
 
   if (!isMixedHeader && translateModalElements.length > 1) {


### PR DESCRIPTION
Set a white focus outline on site banner to improve focus visibility in Safari.