### PR TITLE
DP-46594-Fix-global-menu-overlap-on-translate-module-on-Android

### DIFF
--- a/changelogs/DP-46594.yml
+++ b/changelogs/DP-46594.yml
@@ -1,0 +1,6 @@
+Fixed:
+  - project: Patternlab
+    component: Modal
+    description: Move the translate modal overlay to document.body when opened so it is not clipped by the hamburger nav drawer on Android.
+    issue: DP-46594
+    impact: Patch

--- a/changelogs/DP-46594.yml
+++ b/changelogs/DP-46594.yml
@@ -1,6 +1,6 @@
 Fixed:
   - project: Patternlab
     component: Modal
-    description: Move the translate modal overlay to document.body when opened so it is not clipped by the hamburger nav drawer on Android.
+    description: Portal the translate modal to documentElement when opened and hide the hamburger drawer while the modal is open so the nav edge does not show through on Android.
     issue: DP-46594
     impact: Patch

--- a/changelogs/DP-46594.yml
+++ b/changelogs/DP-46594.yml
@@ -1,6 +1,6 @@
 Fixed:
   - project: Patternlab
     component: Modal
-    description: Portal the translate modal to documentElement when opened and hide the hamburger drawer while the modal is open so the nav edge does not show through on Android.
+    description: Portal the translate modal to documentElement when opened and hide the hamburger drawer while it is open so the nav edge does not show through on Android.
     issue: DP-46594
     impact: Patch

--- a/packages/assets/scss/03-organisms/_modal.scss
+++ b/packages/assets/scss/03-organisms/_modal.scss
@@ -19,8 +19,8 @@
   }
 }
 
-// Portaled to documentElement (see modal.js) — full viewport above the hamburger nav.
-html > .ma__modal-overlay.ma__active {
+// Portaled translate modal (see modal.js) — full viewport above the hamburger nav.
+html > .ma__modal-overlay.ma__modal--translate.ma__active {
   position: fixed;
   inset: 0;
   width: 100%;
@@ -29,9 +29,8 @@ html > .ma__modal-overlay.ma__active {
   z-index: $z-skyline;
 }
 
-// Hide the open drawer and its dim overlay while a modal is open on mobile.
-// The modal supplies its own backdrop; prevents the nav edge from showing through.
-body.ma__modal-open {
+// Hide the open drawer and its dim overlay while the translate modal is open on mobile.
+body.ma__translate-modal-open {
   @media ($bp-header-toggle-max) {
     .ma__header__hamburger__nav-container,
     .menu-overlay.overlay-open {

--- a/packages/assets/scss/03-organisms/_modal.scss
+++ b/packages/assets/scss/03-organisms/_modal.scss
@@ -19,9 +19,25 @@
   }
 }
 
-// When portaled to body (see modal.js), sit above the hamburger nav stacking context.
-body > .ma__modal-overlay.ma__active {
+// Portaled to documentElement (see modal.js) — full viewport above the hamburger nav.
+html > .ma__modal-overlay.ma__active {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  min-height: 100vh;
+  min-height: 100dvh;
   z-index: $z-skyline;
+}
+
+// Hide the open drawer and its dim overlay while a modal is open on mobile.
+// The modal supplies its own backdrop; prevents the nav edge from showing through.
+body.ma__modal-open {
+  @media ($bp-header-toggle-max) {
+    .ma__header__hamburger__nav-container,
+    .menu-overlay.overlay-open {
+      visibility: hidden;
+    }
+  }
 }
 
 .ma__modal {

--- a/packages/assets/scss/03-organisms/_modal.scss
+++ b/packages/assets/scss/03-organisms/_modal.scss
@@ -19,11 +19,16 @@
   }
 }
 
+// When portaled to body (see modal.js), sit above the hamburger nav stacking context.
+body > .ma__modal-overlay.ma__active {
+  z-index: $z-skyline;
+}
+
 .ma__modal {
   &-overlay {
     position: fixed;
     inset: 0;
-    z-index: 1000;
+    z-index: $z-modal;
     display: none;
     align-items: center;
     justify-content: center;

--- a/packages/patternlab/styleguide/source/_patterns/03-organisms/modal/modal.twig
+++ b/packages/patternlab/styleguide/source/_patterns/03-organisms/modal/modal.twig
@@ -11,7 +11,7 @@
         {{ icon(modal.icon, "20", "20") }}
         <span>{{ modal.buttonText }}</span>
     </button>
-    <div id="{{ modalId }}" class="ma__modal-overlay ma__modal" role="dialog" aria-modal="true" aria-labelledby="{{ modalTitleId }}">
+    <div id="{{ modalId }}" class="ma__modal-overlay ma__modal{% if googleLanguages %} ma__modal--translate{% endif %}" role="dialog" aria-modal="true" aria-labelledby="{{ modalTitleId }}">
         <div class="ma__modal-dialog">
             <div class="ma__modal-header">
                 <button type="button" class="ma__modal-close" aria-label="Close dialog">

--- a/packages/patternlab/styleguide/source/assets/js/modules/googleTranslateSelect.js
+++ b/packages/patternlab/styleguide/source/assets/js/modules/googleTranslateSelect.js
@@ -111,6 +111,7 @@
     modalElement.classList.remove('ma__active');
     modalElement.classList.remove('ma__shim-active');
     document.body.classList.remove('ma__modal-open');
+    document.body.classList.remove('ma__translate-modal-open');
     trigger.focus();
   }
 

--- a/packages/patternlab/styleguide/source/assets/js/modules/modal.js
+++ b/packages/patternlab/styleguide/source/assets/js/modules/modal.js
@@ -32,6 +32,10 @@ class AccessibleModal {
         this.onOkCallback = options.onOk || null;
         this.portalParent = null;
         this.portalPlaceholder = null;
+        this.isTranslateModalInstance = Boolean(
+            this.modal.classList.contains('ma__modal--translate') ||
+            this.modal.closest('[data-utility-nav-modal="translate"]')
+        );
 
         // For focus management
         this.focusableElements = null;
@@ -110,18 +114,22 @@ class AccessibleModal {
     }
 
     /**
-     * Root node for portaled modals. Use documentElement instead of body because
-     * the hamburger menu sets body { position: fixed }, which breaks viewport-fixed
-     * overlays on mobile (notably Android).
+     * Root node for the portaled translate modal. Use documentElement instead of body
+     * because the hamburger menu sets body { position: fixed }, which breaks
+     * viewport-fixed overlays on mobile (notably Android).
      */
     getPortalRoot() {
         return document.documentElement;
     }
 
     /**
-     * Move the modal overlay out of the hamburger nav drawer so it is not clipped.
+     * Move the translate modal overlay out of the header nav so it is not clipped.
      */
-    portalModalToBody() {
+    portalTranslateModal() {
+        if (!this.isTranslateModalInstance) {
+            return;
+        }
+
         const portalRoot = this.getPortalRoot();
 
         if (this.modal.parentElement === portalRoot) {
@@ -137,8 +145,8 @@ class AccessibleModal {
     /**
      * Restore the modal overlay to its original DOM position after close.
      */
-    restoreModalFromBody() {
-        if (!this.portalParent || !this.portalPlaceholder) {
+    restoreTranslateModal() {
+        if (!this.isTranslateModalInstance || !this.portalParent || !this.portalPlaceholder) {
             return;
         }
 
@@ -161,7 +169,7 @@ class AccessibleModal {
         // If null, we'll use the fallback element when closing
         this.triggerElement = triggerElement;
 
-        this.portalModalToBody();
+        this.portalTranslateModal();
 
         // Add active class to overlay to make it visible
         this.modal.classList.add('ma__active');
@@ -171,6 +179,10 @@ class AccessibleModal {
 
         // Prevent body scroll - improves usability and prevents confusion
         document.body.classList.add('ma__modal-open');
+
+        if (this.isTranslateModalInstance) {
+            document.body.classList.add('ma__translate-modal-open');
+        }
 
         // Update list of focusable elements within dialog
         this.updateFocusableElements();
@@ -192,8 +204,9 @@ class AccessibleModal {
 
         // Restore body scroll
         document.body.classList.remove('ma__modal-open');
+        document.body.classList.remove('ma__translate-modal-open');
 
-        this.restoreModalFromBody();
+        this.restoreTranslateModal();
 
         // Return focus to trigger element if it exists
         // Otherwise, return focus to first focusable element on page (skip link)

--- a/packages/patternlab/styleguide/source/assets/js/modules/modal.js
+++ b/packages/patternlab/styleguide/source/assets/js/modules/modal.js
@@ -110,18 +110,28 @@ class AccessibleModal {
     }
 
     /**
-     * Move the modal overlay to document.body so it is not clipped by ancestors
-     * (e.g. the hamburger nav drawer on Android).
+     * Root node for portaled modals. Use documentElement instead of body because
+     * the hamburger menu sets body { position: fixed }, which breaks viewport-fixed
+     * overlays on mobile (notably Android).
+     */
+    getPortalRoot() {
+        return document.documentElement;
+    }
+
+    /**
+     * Move the modal overlay out of the hamburger nav drawer so it is not clipped.
      */
     portalModalToBody() {
-        if (this.modal.parentElement === document.body) {
+        const portalRoot = this.getPortalRoot();
+
+        if (this.modal.parentElement === portalRoot) {
             return;
         }
 
         this.portalParent = this.modal.parentElement;
         this.portalPlaceholder = document.createComment('ma-modal-placeholder');
         this.portalParent.insertBefore(this.portalPlaceholder, this.modal);
-        document.body.appendChild(this.modal);
+        portalRoot.appendChild(this.modal);
     }
 
     /**

--- a/packages/patternlab/styleguide/source/assets/js/modules/modal.js
+++ b/packages/patternlab/styleguide/source/assets/js/modules/modal.js
@@ -30,6 +30,8 @@ class AccessibleModal {
         this.translateBtn = this.modal.querySelector('.ma__modal-btn-translate');
         this.triggerElement = null;
         this.onOkCallback = options.onOk || null;
+        this.portalParent = null;
+        this.portalPlaceholder = null;
 
         // For focus management
         this.focusableElements = null;
@@ -108,6 +110,38 @@ class AccessibleModal {
     }
 
     /**
+     * Move the modal overlay to document.body so it is not clipped by ancestors
+     * (e.g. the hamburger nav drawer on Android).
+     */
+    portalModalToBody() {
+        if (this.modal.parentElement === document.body) {
+            return;
+        }
+
+        this.portalParent = this.modal.parentElement;
+        this.portalPlaceholder = document.createComment('ma-modal-placeholder');
+        this.portalParent.insertBefore(this.portalPlaceholder, this.modal);
+        document.body.appendChild(this.modal);
+    }
+
+    /**
+     * Restore the modal overlay to its original DOM position after close.
+     */
+    restoreModalFromBody() {
+        if (!this.portalParent || !this.portalPlaceholder) {
+            return;
+        }
+
+        if (this.portalPlaceholder.parentElement) {
+            this.portalParent.insertBefore(this.modal, this.portalPlaceholder);
+            this.portalPlaceholder.remove();
+        }
+
+        this.portalParent = null;
+        this.portalPlaceholder = null;
+    }
+
+    /**
      * Open the modal
      * @param {HTMLElement|null} triggerElement - Optional element that triggered the modal
      * If null or not provided, focus will return to first focusable page element on close
@@ -116,6 +150,8 @@ class AccessibleModal {
         // Store reference to element that opened the dialog
         // If null, we'll use the fallback element when closing
         this.triggerElement = triggerElement;
+
+        this.portalModalToBody();
 
         // Add active class to overlay to make it visible
         this.modal.classList.add('ma__active');
@@ -146,6 +182,8 @@ class AccessibleModal {
 
         // Restore body scroll
         document.body.classList.remove('ma__modal-open');
+
+        this.restoreModalFromBody();
 
         // Return focus to trigger element if it exists
         // Otherwise, return focus to first focusable element on page (skip link)


### PR DESCRIPTION
Fix translate modal overlap with global menu on Android.

[Openmass PR](https://github.com/massgov/openmass/pull/3377/)
[Jira Ticket](https://massgov.atlassian.net/browse/DP-46594)