### PR TITLE
DP-45281-Buttons-look-narrow-and-tall

### DIFF
--- a/changelogs/DP-45281.yml
+++ b/changelogs/DP-45281.yml
@@ -1,0 +1,6 @@
+Fixed:
+  - project: Patternlab
+    component: ActionFinder
+    description: Use 5-of-12 width for a single callout link in rich-text action-finder so the button is not sized for a three-up grid.
+    issue: DP-45281
+    impact: Minor

--- a/packages/assets/scss/03-organisms/_action-finder.scss
+++ b/packages/assets/scss/03-organisms/_action-finder.scss
@@ -171,6 +171,17 @@ $action-finder-bp: 900px;
   }
 }
 
+// Single callout links in rich text should not use the 3-up action-finder width.
+.ma__rich-text .ma__action-finder .ma__callout-link:only-child {
+
+  @media ($bp-large-min) {
+    float: none;
+    margin-right: 0;
+    clear: none;
+    width: 100% * 5 / 12;
+  }
+}
+
 //theme
 $action-finder-bg-color: mix($c-bg, $c-primary,89%);
 $action-finder-border-color: mix($c-white, $c-primary,50%);


### PR DESCRIPTION
adjust width for a single callout link in rich-text action-finder so the button is not sized for a three-up grid.

[JIRA](https://massgov.atlassian.net/browse/DP-45281)
[Openmass](https://github.com/massgov/openmass/pull/3408)