### PR TITLE
DP-48741-Update-Document-Links-So-Screen-Readers-Announce-the-Document-Title-Before-File-Information

### DIFF
--- a/changelogs/DP-48741.yml
+++ b/changelogs/DP-48741.yml
@@ -1,0 +1,6 @@
+Fixed:
+  - project: Patternlab
+    component: DownloadLink, DownloadLinkMultilang, CalloutLink
+    description: Announce the document title before file type and size so screen readers hear the link name first.
+    issue: DP-48741
+    impact: Patch

--- a/packages/patternlab/styleguide/source/_patterns/02-molecules/callout-link.twig
+++ b/packages/patternlab/styleguide/source/_patterns/02-molecules/callout-link.twig
@@ -30,8 +30,7 @@ target="">
               </div>
           {% endif %}
           <span class="ma__download-link__file-link ma__callout-link__text">
-                  <span class="ma__visually-hidden">Open {{ calloutLink.format }} file{% if calloutLink.size %}, {{ calloutLink.size }},{% endif %} for</span>
-                  {{ calloutLink.text }}
+                  {{ calloutLink.text }}<span class="ma__visually-hidden">, Open {{ calloutLink.format }} file{% if calloutLink.size %}, {{ calloutLink.size }}{% endif %}</span>
               </span>
           {% if calloutLink.format or calloutLink.size %}
               <span class="ma__download-link__file-spec">({{ calloutLink.format }} {{ calloutLink.size }})</span>

--- a/packages/patternlab/styleguide/source/_patterns/02-molecules/download-link-multilang.twig
+++ b/packages/patternlab/styleguide/source/_patterns/02-molecules/download-link-multilang.twig
@@ -15,8 +15,7 @@
       <a
               class="ma__download-link__file-link"
               href="{{ downloadLink.decorativeLink.href}}">
-        <span class="ma__visually-hidden">Open {{ downloadLink.format }} file{% if downloadLink.size %}, {{ downloadLink.size }}{% endif %},&nbsp;</span>
-        <span {% if downloadLink.inlineLinks.document_id %}id="{{ downloadLink.inlineLinks.document_id }}"{% endif %}>{{ downloadLink.decorativeLink.text }}</span>
+        <span {% if downloadLink.inlineLinks.document_id %}id="{{ downloadLink.inlineLinks.document_id }}"{% endif %}>{{ downloadLink.decorativeLink.text }}</span><span class="ma__visually-hidden">, Open {{ downloadLink.format }} file{% if downloadLink.size %}, {{ downloadLink.size }}{% endif %}</span>
       </a>
       {% if downloadLink.format or downloadLink.size or downloadLink.language %}
         <span class="ma__download-link__file-spec">({% if downloadLink.language %}{{ downloadLink.language ~ ',' }} {% endif %}{{ downloadLink.format }} {{ downloadLink.size }})</span>

--- a/packages/patternlab/styleguide/source/_patterns/02-molecules/download-link.twig
+++ b/packages/patternlab/styleguide/source/_patterns/02-molecules/download-link.twig
@@ -15,8 +15,7 @@
       <a
         class="ma__download-link__file-link"
         href="{{ downloadLink.decorativeLink.href}}">
-        <span class="ma__visually-hidden">Open {{ downloadLink.format }} file{% if downloadLink.size %}, {{ downloadLink.size }}{% endif %},&nbsp;</span>
-          {{ downloadLink.decorativeLink.text }}
+          {{ downloadLink.decorativeLink.text }}<span class="ma__visually-hidden">, Open {{ downloadLink.format }} file{% if downloadLink.size %}, {{ downloadLink.size }}{% endif %}</span>
       </a>
       {% if downloadLink.format or downloadLink.size or downloadLink.language %}
         <span class="ma__download-link__file-spec">


### PR DESCRIPTION
Announce the document title before file type and size so screen readers hear the link name first

- [JIRA issue](https://massgov.atlassian.net/browse/DP-48741)
- [Openmass PR]()